### PR TITLE
feat(contract): implement tip record storage with temporary TTL

### DIFF
--- a/contracts/tipz/src/lib.rs
+++ b/contracts/tipz/src/lib.rs
@@ -29,7 +29,7 @@ mod test;
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 use crate::errors::ContractError;
-use crate::types::{ContractStats, LeaderboardEntry, Profile};
+use crate::types::{ContractStats, LeaderboardEntry, Profile, Tip};
 
 #[contract]
 pub struct TipzContract;
@@ -127,6 +127,22 @@ impl TipzContract {
     pub fn withdraw_tips(_env: Env, _caller: Address, _amount: i128) -> Result<(), ContractError> {
         // TODO: Implement in issue #10 - Withdraw Tips
         Err(ContractError::NotInitialized)
+    }
+
+    /// Get a single tip record by its ID.
+    ///
+    /// Returns [`ContractError::NotFound`] when the tip does not exist or its
+    /// temporary-storage TTL has expired (~7 days after the tip was sent).
+    pub fn get_tip(env: Env, tip_id: u32) -> Result<Tip, ContractError> {
+        tips::get_tip(&env, tip_id).ok_or(ContractError::NotFound)
+    }
+
+    /// Return up to `count` recent tips received by `creator`, newest first.
+    ///
+    /// Tips that have expired are silently omitted, so the returned vector may
+    /// contain fewer than `count` entries.
+    pub fn get_recent_tips(env: Env, creator: Address, count: u32) -> Vec<Tip> {
+        tips::get_recent_tips(&env, &creator, count)
     }
 
     // ──────────────────────────────────────────────

--- a/contracts/tipz/src/test/test_tips.rs
+++ b/contracts/tipz/src/test/test_tips.rs
@@ -1,14 +1,347 @@
-//! Tests for send_tip functionality.
+//! Tests for tip record storage with temporary TTL (issue #10).
 //!
-//! TODO: Implement in issues #26-27
+//! All storage calls must run inside `env.as_contract()` because the Soroban
+//! SDK enforces contract-context isolation in tests.
 //!
-//! Test cases to cover:
-//! - Successful tip (balance updates, tip record created)
-//! - Tip to unregistered creator → NotRegistered
-//! - Tip amount = 0 → InvalidAmount
-//! - Tip to self → CannotTipSelf
-//! - Message length validation
-//! - Multiple tips accumulate correctly
-//! - Global stats update after tip
+//! Test cases:
+//! - Sequential tip ID assignment
+//! - Correct field values on stored tips
+//! - `get_tip` returns `None` for missing / expired entries
+//! - `get_recent_tips` returns only the target creator's tips
+//! - `get_recent_tips` returns entries newest-first
+//! - `get_recent_tips` respects the `count` limit
+//! - `get_recent_tips` returns an empty list when there are no tips
+//! - TTL expiry: entries are evicted after `TIP_TTL_LEDGERS` ledgers
+//! - `get_recent_tips` silently skips expired entries
 
 #![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{
+    tips::{get_recent_tips, get_tip, store_tip, TIP_TTL_LEDGERS},
+    TipzContract,
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn make_string(env: &Env, s: &str) -> String {
+    String::from_str(env, s)
+}
+
+/// Register a fresh contract instance and return its ID.
+fn register(env: &Env) -> soroban_sdk::Address {
+    env.register_contract(None, TipzContract)
+}
+
+/// Advance the ledger sequence and timestamp without changing other fields.
+fn advance_ledger(env: &Env, delta: u32) {
+    use soroban_sdk::testutils::Ledger as _;
+    env.ledger().with_mut(|info| {
+        info.sequence_number += delta;
+        info.timestamp += delta as u64 * 5; // 5 s per ledger
+    });
+}
+
+// ── store_tip / get_tip ───────────────────────────────────────────────────────
+
+#[test]
+fn store_tip_assigns_sequential_ids() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let msg = make_string(&env, "great content!");
+
+    let (id0, id1, id2) = env.as_contract(&contract_id, || {
+        let i0 = store_tip(&env, &tipper, &creator, 1_000_000, msg.clone());
+        let i1 = store_tip(&env, &tipper, &creator, 2_000_000, msg.clone());
+        let i2 = store_tip(&env, &tipper, &creator, 3_000_000, msg.clone());
+        (i0, i1, i2)
+    });
+
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn get_tip_returns_correct_fields() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let amount = 5_000_000_i128;
+    let msg = make_string(&env, "love your work");
+
+    env.as_contract(&contract_id, || {
+        let tip_id = store_tip(&env, &tipper, &creator, amount, msg.clone());
+        let tip = get_tip(&env, tip_id).expect("tip should be present");
+
+        assert_eq!(tip.id, tip_id);
+        assert_eq!(tip.tipper, tipper);
+        assert_eq!(tip.creator, creator);
+        assert_eq!(tip.amount, amount);
+        assert_eq!(tip.message, msg);
+    });
+}
+
+#[test]
+fn get_tip_returns_none_for_nonexistent_id() {
+    let env = Env::default();
+    let contract_id = register(&env);
+
+    env.as_contract(&contract_id, || {
+        assert!(get_tip(&env, 0).is_none());
+        assert!(get_tip(&env, 9999).is_none());
+    });
+}
+
+// ── TTL expiry ────────────────────────────────────────────────────────────────
+
+#[test]
+fn get_tip_returns_none_after_ttl_expires() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    let tip_id = env.as_contract(&contract_id, || {
+        store_tip(
+            &env,
+            &tipper,
+            &creator,
+            1_000_000,
+            make_string(&env, "hello"),
+        )
+    });
+
+    // Entry should still be present before expiry.
+    env.as_contract(&contract_id, || {
+        assert!(get_tip(&env, tip_id).is_some());
+
+        // Extend the contract instance TTL so the instance survives the
+        // ledger advance below (instance TTL is independent of temp TTL).
+        env.storage()
+            .instance()
+            .extend_ttl(TIP_TTL_LEDGERS + 10, TIP_TTL_LEDGERS + 10);
+    });
+
+    // Advance past the TTL.
+    advance_ledger(&env, TIP_TTL_LEDGERS + 1);
+
+    env.as_contract(&contract_id, || {
+        assert!(
+            get_tip(&env, tip_id).is_none(),
+            "tip should be evicted after TTL expires"
+        );
+    });
+}
+
+// ── get_recent_tips ───────────────────────────────────────────────────────────
+
+#[test]
+fn get_recent_tips_returns_empty_when_no_tips_exist() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let creator = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        let tips = get_recent_tips(&env, &creator, 10);
+        assert_eq!(tips.len(), 0);
+    });
+}
+
+#[test]
+fn get_recent_tips_returns_only_target_creator_tips() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator_a = Address::generate(&env);
+    let creator_b = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        store_tip(
+            &env,
+            &tipper,
+            &creator_a,
+            1_000_000,
+            make_string(&env, "a1"),
+        );
+        store_tip(
+            &env,
+            &tipper,
+            &creator_b,
+            2_000_000,
+            make_string(&env, "b1"),
+        );
+        store_tip(
+            &env,
+            &tipper,
+            &creator_a,
+            3_000_000,
+            make_string(&env, "a2"),
+        );
+        store_tip(
+            &env,
+            &tipper,
+            &creator_b,
+            4_000_000,
+            make_string(&env, "b2"),
+        );
+
+        let tips_a = get_recent_tips(&env, &creator_a, 10);
+        assert_eq!(tips_a.len(), 2);
+        for tip in tips_a.iter() {
+            assert_eq!(tip.creator, creator_a);
+        }
+
+        let tips_b = get_recent_tips(&env, &creator_b, 10);
+        assert_eq!(tips_b.len(), 2);
+        for tip in tips_b.iter() {
+            assert_eq!(tip.creator, creator_b);
+        }
+    });
+}
+
+#[test]
+fn get_recent_tips_returns_newest_first() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        let id0 = store_tip(
+            &env,
+            &tipper,
+            &creator,
+            1_000_000,
+            make_string(&env, "first"),
+        );
+        let id1 = store_tip(
+            &env,
+            &tipper,
+            &creator,
+            2_000_000,
+            make_string(&env, "second"),
+        );
+        let id2 = store_tip(
+            &env,
+            &tipper,
+            &creator,
+            3_000_000,
+            make_string(&env, "third"),
+        );
+
+        let tips = get_recent_tips(&env, &creator, 3);
+        assert_eq!(tips.len(), 3);
+
+        // Scan is backwards so highest ID comes first.
+        assert_eq!(tips.get(0).unwrap().id, id2);
+        assert_eq!(tips.get(1).unwrap().id, id1);
+        assert_eq!(tips.get(2).unwrap().id, id0);
+    });
+}
+
+#[test]
+fn get_recent_tips_respects_count_limit() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        for i in 0_u32..5 {
+            store_tip(
+                &env,
+                &tipper,
+                &creator,
+                (i as i128 + 1) * 1_000_000,
+                make_string(&env, "msg"),
+            );
+        }
+
+        let tips = get_recent_tips(&env, &creator, 3);
+        assert_eq!(tips.len(), 3);
+    });
+}
+
+#[test]
+fn get_recent_tips_skips_expired_entries() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    // Store two tips that will expire.
+    env.as_contract(&contract_id, || {
+        store_tip(
+            &env,
+            &tipper,
+            &creator,
+            1_000_000,
+            make_string(&env, "old1"),
+        );
+        store_tip(
+            &env,
+            &tipper,
+            &creator,
+            2_000_000,
+            make_string(&env, "old2"),
+        );
+
+        // Extend the contract instance TTL so the instance survives the
+        // ledger advance below (instance TTL is independent of temp TTL).
+        env.storage()
+            .instance()
+            .extend_ttl(TIP_TTL_LEDGERS + 10, TIP_TTL_LEDGERS + 10);
+    });
+
+    // Advance past TTL to evict the old tips.
+    advance_ledger(&env, TIP_TTL_LEDGERS + 1);
+
+    // Store two fresh tips after the expiry window.
+    let (fresh_id0, fresh_id1) = env.as_contract(&contract_id, || {
+        let i0 = store_tip(
+            &env,
+            &tipper,
+            &creator,
+            3_000_000,
+            make_string(&env, "new1"),
+        );
+        let i1 = store_tip(
+            &env,
+            &tipper,
+            &creator,
+            4_000_000,
+            make_string(&env, "new2"),
+        );
+        (i0, i1)
+    });
+
+    // Requesting 10 should return only the 2 fresh tips; the 2 expired ones
+    // are silently skipped.
+    env.as_contract(&contract_id, || {
+        let tips = get_recent_tips(&env, &creator, 10);
+        assert_eq!(tips.len(), 2);
+        assert_eq!(tips.get(0).unwrap().id, fresh_id1);
+        assert_eq!(tips.get(1).unwrap().id, fresh_id0);
+    });
+}
+
+#[test]
+fn get_recent_tips_returns_empty_for_unknown_creator() {
+    let env = Env::default();
+    let contract_id = register(&env);
+    let tipper = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        store_tip(&env, &tipper, &creator, 1_000_000, make_string(&env, "hi"));
+
+        let tips = get_recent_tips(&env, &other, 10);
+        assert_eq!(tips.len(), 0);
+    });
+}

--- a/contracts/tipz/src/tips.rs
+++ b/contracts/tipz/src/tips.rs
@@ -1,8 +1,120 @@
-//! Tipping logic for the Tipz contract.
+//! Tip record storage for the Tipz contract.
 //!
-//! Handles:
-//! - send_tip: Transfer XLM from tipper → contract, credit creator balance
-//! - withdraw_tips: Transfer from contract → creator, deduct fee
+//! Tips are stored in **temporary** storage so they are automatically evicted
+//! after [`TIP_TTL_LEDGERS`] ledgers (~7 days), preventing unbounded state
+//! growth. Callers that read expired entries receive `None` / an empty list
+//! rather than an error.
+//!
+//! # Storage layout
+//! | Key                    | Storage   | Value  |
+//! |------------------------|-----------|--------|
+//! | `DataKey::Tip(id)`     | temporary | `Tip`  |
+//! | `DataKey::TipCount`    | instance  | `u32`  |
+//!
+//! `TipCount` is the next available tip ID (i.e. the total number of tips ever
+//! created). It lives in instance storage so it persists for the lifetime of
+//! the contract.
 
-// TODO: Implement send_tip in issue #7
-// TODO: Implement withdraw_tips in issue #10
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::storage::DataKey;
+use crate::types::Tip;
+
+/// Approximate TTL for tip records in ledgers.
+///
+/// 7 days × 86 400 s/day ÷ 5 s/ledger = 120 960 ledgers.
+pub const TIP_TTL_LEDGERS: u32 = 120_960;
+
+/// Create a new [`Tip`] record and store it in temporary storage.
+///
+/// The global tip counter (`DataKey::TipCount`) is incremented atomically so
+/// each tip gets a unique, monotonically increasing ID.  The entry TTL is
+/// extended to [`TIP_TTL_LEDGERS`] immediately after insertion.
+///
+/// Returns the ID assigned to the new tip.
+///
+/// # Note
+/// This function will be called by `send_tip` once issue #7 is implemented.
+#[allow(dead_code)]
+pub fn store_tip(
+    env: &Env,
+    tipper: &Address,
+    creator: &Address,
+    amount: i128,
+    message: String,
+) -> u32 {
+    let tip_id: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TipCount)
+        .unwrap_or(0);
+
+    // Increment the global counter before storing so future reads see the
+    // correct total even if the entry itself has expired.
+    env.storage()
+        .instance()
+        .set(&DataKey::TipCount, &tip_id.saturating_add(1));
+
+    let tip = Tip {
+        id: tip_id,
+        tipper: tipper.clone(),
+        creator: creator.clone(),
+        amount,
+        message,
+        timestamp: env.ledger().timestamp(),
+    };
+
+    env.storage().temporary().set(&DataKey::Tip(tip_id), &tip);
+
+    // Extend TTL to TIP_TTL_LEDGERS from the current ledger.
+    // threshold == extend_to means "always extend when below the target".
+    env.storage()
+        .temporary()
+        .extend_ttl(&DataKey::Tip(tip_id), TIP_TTL_LEDGERS, TIP_TTL_LEDGERS);
+
+    tip_id
+}
+
+/// Retrieve a single tip by its ID.
+///
+/// Returns `None` if the tip does not exist or its TTL has expired.
+pub fn get_tip(env: &Env, tip_id: u32) -> Option<Tip> {
+    env.storage().temporary().get(&DataKey::Tip(tip_id))
+}
+
+/// Return up to `count` recent tips sent to `creator`.
+///
+/// Tips are scanned backwards from the most recent global tip ID so that the
+/// newest entries appear first in the returned vector.  Entries that have
+/// already expired are silently skipped, meaning the returned vector may
+/// contain fewer than `count` items even when the creator has received more
+/// tips in total.
+pub fn get_recent_tips(env: &Env, creator: &Address, count: u32) -> Vec<Tip> {
+    let tip_count: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TipCount)
+        .unwrap_or(0);
+
+    let mut result: Vec<Tip> = Vec::new(env);
+    let mut found: u32 = 0;
+    let mut i: u32 = tip_count;
+
+    while i > 0 && found < count {
+        i -= 1;
+
+        // Expired entries are simply absent from temporary storage — skip them.
+        if let Some(tip) = env
+            .storage()
+            .temporary()
+            .get::<DataKey, Tip>(&DataKey::Tip(i))
+        {
+            if tip.creator == *creator {
+                result.push_back(tip);
+                found += 1;
+            }
+        }
+    }
+
+    result
+}

--- a/contracts/tipz/src/types.rs
+++ b/contracts/tipz/src/types.rs
@@ -38,19 +38,21 @@ pub struct Profile {
     pub updated_at: u64,
 }
 
-/// Individual tip record.
+/// Individual tip record stored in temporary storage with a TTL of ~7 days.
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct Tip {
-    /// Tipper's address
-    pub from: Address,
-    /// Creator's address
-    pub to: Address,
+    /// Unique tip ID (monotonically increasing global counter)
+    pub id: u32,
+    /// Address that sent the tip
+    pub tipper: Address,
+    /// Address of the creator who received the tip
+    pub creator: Address,
     /// Tip amount in stroops
     pub amount: i128,
     /// Optional message (0-280 chars)
     pub message: String,
-    /// Ledger timestamp
+    /// Ledger timestamp at the time the tip was sent
     pub timestamp: u64,
 }
 


### PR DESCRIPTION
## Description
Adds tip record storage to the Tipz contract using Soroban's temporary storage, so recent tips can be queried while stale entries are automatically evicted after ~7 days.

Closes #10

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)

## Changes Made
- Add `id: u32` field to Tip struct; rename `from`/`to` to `tipper`/`creator`
- Implement `store_tip`: stores Tip in temporary storage with 120,960-ledger TTL (~7 days at 5s/ledger)
- Implement `get_tip`: retrieves tip by ID, returns None if expired or missing
- Implement `get_recent_tips`: scans backwards from latest tip ID, filters by creator, silently skips expired entries
- Expose `get_tip` and `get_recent_tips` on the public contract interface
- Add 10 tests covering ID sequencing, field correctness, TTL expiry, creator filtering, newest-first ordering, count limits, and expired-entry skipping

## Checklist

### Contract Changes
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all tests)
- [ ] New tests written for new functionality
- [ ] No hardcoded values that should be configurable

### Frontend Changes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] Tested in browser with Freighter wallet
- [ ] Responsive design verified

### General
- [x] Code follows project conventions
- [x] Self-reviewed my own code
- [x] No `console.log` or debug code left in
- [x] Branch is up to date with `main`

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
