### PR TITLE
feat(contract): implement leaderboard and write unit tests

### DIFF
--- a/contracts/tipz/src/leaderboard.rs
+++ b/contracts/tipz/src/leaderboard.rs
@@ -1,9 +1,136 @@
 //! Leaderboard tracking for the Tipz contract.
 //!
-//! Maintains a sorted list of top creators by total tips received.
-//! The leaderboard is updated after each tip.
+//! Maintains a sorted list (descending by `total_tips_received`) of up to
+//! [`MAX_LEADERBOARD_SIZE`] creators.  The list is refreshed after every tip
+//! via [`update_leaderboard`].
+//!
+//! ## Storage
+//! The board is persisted as a single `Vec<LeaderboardEntry>` under
+//! `DataKey::Leaderboard` in instance storage.
+//!
+//! ## Complexity
+//! Sorting uses selection sort — O(n²) — which is acceptable for n ≤ 50.
 
-// TODO: Implement leaderboard logic in issue #17
-//
-// pub fn update_leaderboard(env: &Env, profile: &Profile) { ... }
-// pub fn get_leaderboard(env: &Env, limit: u32) -> Vec<LeaderboardEntry> { ... }
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::storage::DataKey;
+use crate::types::{LeaderboardEntry, Profile};
+
+/// Maximum number of entries retained on the leaderboard.
+pub const MAX_LEADERBOARD_SIZE: u32 = 50;
+
+// ── internal helpers ──────────────────────────────────────────────────────────
+
+fn load(env: &Env) -> Vec<LeaderboardEntry> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Leaderboard)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn save(env: &Env, board: &Vec<LeaderboardEntry>) {
+    env.storage().instance().set(&DataKey::Leaderboard, board);
+}
+
+/// Sort `board` in-place, descending by `total_tips_received`.
+///
+/// Uses selection sort — O(n²) — which is fine for n ≤ [`MAX_LEADERBOARD_SIZE`].
+fn sort_descending(board: &mut Vec<LeaderboardEntry>) {
+    let len = board.len();
+    let mut i: u32 = 0;
+    while i < len {
+        let mut max_idx = i;
+        let mut j = i + 1;
+        while j < len {
+            if board.get(j).unwrap().total_tips_received
+                > board.get(max_idx).unwrap().total_tips_received
+            {
+                max_idx = j;
+            }
+            j += 1;
+        }
+        if max_idx != i {
+            let a = board.get(i).unwrap();
+            let b = board.get(max_idx).unwrap();
+            board.set(i, b);
+            board.set(max_idx, a);
+        }
+        i += 1;
+    }
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/// Refresh the leaderboard after `profile` has received a tip.
+///
+/// If the creator already has an entry it is updated in-place; otherwise a new
+/// entry is appended.  The list is then sorted descending by
+/// `total_tips_received` and trimmed to [`MAX_LEADERBOARD_SIZE`].
+pub fn update_leaderboard(env: &Env, profile: &Profile) {
+    let mut board = load(env);
+    let len = board.len();
+
+    // Locate an existing entry for this creator.
+    let mut existing_idx: Option<u32> = None;
+    let mut i: u32 = 0;
+    while i < len {
+        if board.get(i).unwrap().address == profile.owner {
+            existing_idx = Some(i);
+            break;
+        }
+        i += 1;
+    }
+
+    let entry = LeaderboardEntry {
+        address: profile.owner.clone(),
+        username: profile.username.clone(),
+        total_tips_received: profile.total_tips_received,
+        credit_score: profile.credit_score,
+    };
+
+    match existing_idx {
+        Some(idx) => board.set(idx, entry),
+        None => board.push_back(entry),
+    }
+
+    sort_descending(&mut board);
+
+    // Trim to the maximum allowed size (drop the tail — lowest earners).
+    while board.len() > MAX_LEADERBOARD_SIZE {
+        board.pop_back();
+    }
+
+    save(env, &board);
+}
+
+/// Return up to `limit` leaderboard entries sorted descending by total tips.
+///
+/// Passing `limit = 0` returns the full list.
+pub fn get_leaderboard(env: &Env, limit: u32) -> Vec<LeaderboardEntry> {
+    let board = load(env);
+    if limit == 0 || limit >= board.len() {
+        return board;
+    }
+    let mut result = Vec::new(env);
+    let mut i: u32 = 0;
+    while i < limit {
+        result.push_back(board.get(i).unwrap());
+        i += 1;
+    }
+    result
+}
+
+/// Return the 1-based rank of `address` on the leaderboard, or `None` when
+/// the address is not present.
+pub fn get_leaderboard_rank(env: &Env, address: &Address) -> Option<u32> {
+    let board = load(env);
+    let len = board.len();
+    let mut i: u32 = 0;
+    while i < len {
+        if board.get(i).unwrap().address == *address {
+            return Some(i + 1);
+        }
+        i += 1;
+    }
+    None
+}

--- a/contracts/tipz/src/lib.rs
+++ b/contracts/tipz/src/lib.rs
@@ -203,10 +203,18 @@ impl TipzContract {
     // Leaderboard
     // ──────────────────────────────────────────────
 
-    /// Get the top creators by total tips received.
-    pub fn get_leaderboard(_env: Env, _limit: u32) -> Result<Vec<LeaderboardEntry>, ContractError> {
-        // TODO: Implement in issue #17 - Leaderboard
-        Err(ContractError::NotInitialized)
+    /// Get the top creators by total tips received, sorted descending.
+    ///
+    /// Returns at most `limit` entries.  Passing `limit = 0` returns all
+    /// stored entries (up to 50).
+    pub fn get_leaderboard(env: Env, limit: u32) -> Result<Vec<LeaderboardEntry>, ContractError> {
+        Ok(leaderboard::get_leaderboard(&env, limit))
+    }
+
+    /// Return the 1-based rank of `address` on the leaderboard, or `None`
+    /// when the address has not yet appeared in the top 50.
+    pub fn get_leaderboard_rank(env: Env, address: Address) -> Option<u32> {
+        leaderboard::get_leaderboard_rank(&env, &address)
     }
 
     // ──────────────────────────────────────────────

--- a/contracts/tipz/src/test/test_leaderboard.rs
+++ b/contracts/tipz/src/test/test_leaderboard.rs
@@ -1,13 +1,313 @@
-//! Tests for leaderboard functionality.
+//! Tests for leaderboard functionality (issue #28).
 //!
-//! TODO: Implement in issue #29
+//! ## Coverage
+//! - [`test_leaderboard_initial_empty`]   — no tips → empty board
+//! - [`test_leaderboard_single_creator`]  — one tipped creator appears
+//! - [`test_leaderboard_ordering`]        — multiple creators sorted descending
+//! - [`test_leaderboard_max_size`]        — 51 creators → only top 50 retained
+//! - [`test_leaderboard_rank_update`]     — creator moves up after more tips
+//! - [`test_leaderboard_rank_lookup`]     — `get_leaderboard_rank` returns correct 1-based position
 //!
-//! Test cases to cover:
-//! - Empty leaderboard returns empty vec
-//! - Single creator appears on leaderboard after tip
-//! - Multiple creators sorted by total tips received
-//! - Limit parameter respected
-//! - Leaderboard updates after new tip changes ranking
-//! - Leaderboard entries contain correct data
+//! Tests that require XLM transfers use the full SAC setup (same pattern as
+//! `test_tips.rs`).  The `test_leaderboard_max_size` test bypasses `send_tip`
+//! and calls `leaderboard::update_leaderboard` directly inside the contract
+//! context to avoid the overhead of 51 token transfers.
 
 #![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
+
+use crate::leaderboard::MAX_LEADERBOARD_SIZE;
+use crate::storage::DataKey;
+use crate::types::Profile;
+use crate::TipzContract;
+use crate::TipzContractClient;
+
+// ── shared usernames for the max-size test (3-32 chars, [a-z0-9_]) ───────────
+
+const CREATOR_NAMES: [&str; 51] = [
+    "n001", "n002", "n003", "n004", "n005", "n006", "n007", "n008", "n009", "n010", "n011", "n012",
+    "n013", "n014", "n015", "n016", "n017", "n018", "n019", "n020", "n021", "n022", "n023", "n024",
+    "n025", "n026", "n027", "n028", "n029", "n030", "n031", "n032", "n033", "n034", "n035", "n036",
+    "n037", "n038", "n039", "n040", "n041", "n042", "n043", "n044", "n045", "n046", "n047", "n048",
+    "n049", "n050", "n051",
+];
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Full environment with an initialised contract, a funded tipper, and an SAC.
+fn setup() -> (
+    Env,
+    TipzContractClient<'static>,
+    Address, // contract_id
+    Address, // tipper
+    Address, // token_address
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipzContract);
+    let client = TipzContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
+
+    let admin = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+    // Zero fee so the full tip amount is credited (simpler assertions).
+    client.initialize(&admin, &fee_collector, &0, &token_address);
+
+    let tipper = Address::generate(&env);
+    token_admin_client.mint(&tipper, &1_000_000_000_000_i128); // 100 000 XLM
+
+    (env, client, contract_id, tipper, token_address)
+}
+
+/// Insert a profile directly into persistent storage (bypasses validation so
+/// tests stay fast and focused on leaderboard behaviour).
+fn insert_profile(env: &Env, contract_id: &Address, address: &Address, username: &str) {
+    let now = env.ledger().timestamp();
+    let profile = Profile {
+        owner: address.clone(),
+        username: String::from_str(env, username),
+        display_name: String::from_str(env, username),
+        bio: String::from_str(env, ""),
+        image_url: String::from_str(env, ""),
+        x_handle: String::from_str(env, ""),
+        x_followers: 0,
+        x_engagement_avg: 0,
+        credit_score: 40,
+        total_tips_received: 0,
+        total_tips_count: 0,
+        balance: 0,
+        registered_at: now,
+        updated_at: now,
+    };
+    env.as_contract(contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Profile(address.clone()), &profile);
+    });
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// Before any tips are sent the leaderboard must be empty.
+#[test]
+fn test_leaderboard_initial_empty() {
+    let (_, client, _, _, _) = setup();
+    let board = client.get_leaderboard(&50);
+    assert_eq!(
+        board.len(),
+        0,
+        "leaderboard should be empty before any tips"
+    );
+}
+
+/// A single creator who has received a tip must appear on the leaderboard with
+/// the correct total.
+#[test]
+fn test_leaderboard_single_creator() {
+    let (env, client, contract_id, tipper, _) = setup();
+
+    let creator = Address::generate(&env);
+    insert_profile(&env, &contract_id, &creator, "alice");
+
+    let amount: i128 = 10_000_000; // 1 XLM
+    client.send_tip(&tipper, &creator, &amount, &String::from_str(&env, ""));
+
+    let board = client.get_leaderboard(&50);
+    assert_eq!(board.len(), 1);
+    assert_eq!(board.get(0).unwrap().address, creator);
+    assert_eq!(board.get(0).unwrap().total_tips_received, amount);
+    assert_eq!(
+        board.get(0).unwrap().username,
+        String::from_str(&env, "alice")
+    );
+}
+
+/// With three creators the leaderboard must be ordered descending by
+/// `total_tips_received`.
+#[test]
+fn test_leaderboard_ordering() {
+    let (env, client, contract_id, tipper, _) = setup();
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    insert_profile(&env, &contract_id, &alice, "alice");
+    insert_profile(&env, &contract_id, &bob, "bob");
+    insert_profile(&env, &contract_id, &carol, "carol");
+
+    let msg = String::from_str(&env, "");
+    // alice: 3 XLM, carol: 5 XLM, bob: 1 XLM  →  expected order: carol, alice, bob
+    client.send_tip(&tipper, &alice, &30_000_000, &msg);
+    client.send_tip(&tipper, &carol, &50_000_000, &msg);
+    client.send_tip(&tipper, &bob, &10_000_000, &msg);
+
+    let board = client.get_leaderboard(&50);
+    assert_eq!(board.len(), 3);
+    assert_eq!(
+        board.get(0).unwrap().address,
+        carol,
+        "carol should be rank 1"
+    );
+    assert_eq!(
+        board.get(1).unwrap().address,
+        alice,
+        "alice should be rank 2"
+    );
+    assert_eq!(board.get(2).unwrap().address, bob, "bob should be rank 3");
+
+    // Verify the descending order invariant holds across the full list.
+    assert!(board.get(0).unwrap().total_tips_received >= board.get(1).unwrap().total_tips_received);
+    assert!(board.get(1).unwrap().total_tips_received >= board.get(2).unwrap().total_tips_received);
+}
+
+/// When 51 creators have received tips only the top 50 must be retained; the
+/// lowest-earning creator must be pruned.
+///
+/// This test calls `leaderboard::update_leaderboard` directly inside the
+/// contract context to avoid the cost of 51 token-transfer transactions.
+#[test]
+fn test_leaderboard_max_size() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, TipzContract);
+    let client = TipzContractClient::new(&env, &contract_id);
+    let now = env.ledger().timestamp();
+
+    // Generate 51 addresses outside the contract context so they can be
+    // referenced both inside the closure and in the assertions below.
+    let mut addresses: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    let mut i: u32 = 0;
+    while i < 51 {
+        addresses.push_back(Address::generate(&env));
+        i += 1;
+    }
+
+    // Populate the leaderboard directly via the internal function.
+    // Creator 0 receives the most tips (51 × 10 M stroops); creator 50
+    // receives the least (1 × 10 M stroops) and should be pruned.
+    env.as_contract(&contract_id, || {
+        let mut i: u32 = 0;
+        while i < 51 {
+            let addr = addresses.get(i).unwrap();
+            let tips = (51 - i) as i128 * 10_000_000;
+            let profile = Profile {
+                owner: addr.clone(),
+                username: String::from_str(&env, CREATOR_NAMES[i as usize]),
+                display_name: String::from_str(&env, CREATOR_NAMES[i as usize]),
+                bio: String::from_str(&env, ""),
+                image_url: String::from_str(&env, ""),
+                x_handle: String::from_str(&env, ""),
+                x_followers: 0,
+                x_engagement_avg: 0,
+                credit_score: 40,
+                total_tips_received: tips,
+                total_tips_count: 1,
+                balance: tips,
+                registered_at: now,
+                updated_at: now,
+            };
+            crate::leaderboard::update_leaderboard(&env, &profile);
+            i += 1;
+        }
+    });
+
+    let board = client.get_leaderboard(&50);
+    assert_eq!(
+        board.len(),
+        MAX_LEADERBOARD_SIZE,
+        "leaderboard must retain at most {MAX_LEADERBOARD_SIZE} entries"
+    );
+
+    // The creator at index 50 (1 × 10 M stroops) must have been pruned.
+    let lowest = addresses.get(50).unwrap();
+    let mut found = false;
+    let mut j: u32 = 0;
+    while j < board.len() {
+        if board.get(j).unwrap().address == lowest {
+            found = true;
+            break;
+        }
+        j += 1;
+    }
+    assert!(
+        !found,
+        "lowest-tipped creator must be pruned from the top-50"
+    );
+}
+
+/// A creator who overtakes another must appear at a higher rank after the
+/// additional tip.
+#[test]
+fn test_leaderboard_rank_update() {
+    let (env, client, contract_id, tipper, _) = setup();
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    insert_profile(&env, &contract_id, &alice, "alice");
+    insert_profile(&env, &contract_id, &bob, "bob");
+
+    let msg = String::from_str(&env, "");
+
+    // Bob starts in the lead.
+    client.send_tip(&tipper, &bob, &50_000_000, &msg);
+    client.send_tip(&tipper, &alice, &10_000_000, &msg);
+
+    let board_before = client.get_leaderboard(&50);
+    assert_eq!(
+        board_before.get(0).unwrap().address,
+        bob,
+        "bob should lead initially"
+    );
+
+    // Alice receives a larger tip and overtakes bob.
+    client.send_tip(&tipper, &alice, &100_000_000, &msg);
+
+    let board_after = client.get_leaderboard(&50);
+    assert_eq!(
+        board_after.get(0).unwrap().address,
+        alice,
+        "alice should lead after receiving more tips"
+    );
+    assert_eq!(
+        board_after.get(1).unwrap().address,
+        bob,
+        "bob should drop to rank 2"
+    );
+}
+
+/// `get_leaderboard_rank` must return the correct 1-based position for every
+/// ranked creator and `None` for an address not on the leaderboard.
+#[test]
+fn test_leaderboard_rank_lookup() {
+    let (env, client, contract_id, tipper, _) = setup();
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    insert_profile(&env, &contract_id, &alice, "alice");
+    insert_profile(&env, &contract_id, &bob, "bob");
+    insert_profile(&env, &contract_id, &carol, "carol");
+
+    let msg = String::from_str(&env, "");
+    // carol: 5 XLM → rank 1, alice: 3 XLM → rank 2, bob: 1 XLM → rank 3
+    client.send_tip(&tipper, &carol, &50_000_000, &msg);
+    client.send_tip(&tipper, &alice, &30_000_000, &msg);
+    client.send_tip(&tipper, &bob, &10_000_000, &msg);
+
+    assert_eq!(client.get_leaderboard_rank(&carol), Some(1));
+    assert_eq!(client.get_leaderboard_rank(&alice), Some(2));
+    assert_eq!(client.get_leaderboard_rank(&bob), Some(3));
+
+    // An address that has never received a tip must not be ranked.
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.get_leaderboard_rank(&stranger),
+        None,
+        "unranked address should return None"
+    );
+}

--- a/contracts/tipz/src/tips.rs
+++ b/contracts/tipz/src/tips.rs
@@ -8,6 +8,7 @@ use soroban_sdk::{Address, Env, String, Vec};
 
 use crate::errors::ContractError;
 use crate::events::emit_tip_sent;
+use crate::leaderboard;
 use crate::storage::{self, DataKey};
 use crate::token;
 use crate::types::Tip;
@@ -106,6 +107,7 @@ pub fn send_tip(
     profile.total_tips_received += amount;
     profile.total_tips_count += 1;
     storage::set_profile(env, &profile);
+    leaderboard::update_leaderboard(env, &profile);
 
     store_tip(env, tipper, creator, amount, message.clone());
 


### PR DESCRIPTION
- Implement leaderboard.rs: update_leaderboard (upsert + selection sort + trim to 50), get_leaderboard (paginated), get_leaderboard_rank (1-based)
- Call update_leaderboard in send_tip after every tip so the board stays live
- Expose get_leaderboard and get_leaderboard_rank on the public contract interface
- Add 6 tests covering: initial empty state, single creator, descending sort, 50-entry size cap with pruning, rank update after overtake, and rank lookup (including None for unranked addresses)

Closes #28