### PR TITLE
[FRONTEND] Create shared TypeScript type definitions

### DIFF
--- a/frontend-scaffold/src/types/index.ts
+++ b/frontend-scaffold/src/types/index.ts
@@ -1,0 +1,12 @@
+export type {
+  Profile,
+  Tip,
+  LeaderboardEntry,
+  ContractStats,
+  CreditTier,
+} from "./contract";
+export { getCreditTier } from "./contract";
+
+export type { ProfileFormData } from "./profile";
+
+export type { WalletState } from "./wallet";

--- a/frontend-scaffold/src/types/profile.ts
+++ b/frontend-scaffold/src/types/profile.ts
@@ -1,0 +1,10 @@
+export type { Profile } from "./contract";
+
+/** Form data for creating or updating a profile. */
+export interface ProfileFormData {
+  username: string;
+  displayName: string;
+  bio: string;
+  imageUrl: string;
+  xHandle: string;
+}

--- a/frontend-scaffold/src/types/wallet.ts
+++ b/frontend-scaffold/src/types/wallet.ts
@@ -1,0 +1,6 @@
+/** State of the connected Stellar wallet. */
+export interface WalletState {
+  publicKey: string | null;
+  connected: boolean;
+  network: "TESTNET" | "PUBLIC";
+}


### PR DESCRIPTION
## Description

Add shared type files for profile forms and wallet state, plus barrel export.

## Changes

- Create `src/types/profile.ts` -- re-exports Profile from contract.ts, adds ProfileFormData interface
- Create `src/types/wallet.ts` -- WalletState interface with publicKey, connected, network
- Create `src/types/index.ts` -- barrel export for all types
- `npm run typecheck` passes with no errors

## How to test

- `cd frontend-scaffold && npx tsc --noEmit`

Closes #61