### PR TITLE
[FRONTEND] Optimize Vite config for production builds

### DIFF
--- a/frontend-scaffold/vite.config.ts
+++ b/frontend-scaffold/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
+import path from "path";
 
 export default defineConfig({
   plugins: [
@@ -12,12 +13,18 @@ export default defineConfig({
       globals: { Buffer: true },
     }),
   ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
   server: {
     port: 3000,
     open: true,
   },
   build: {
     outDir: "build",
+    sourcemap: true,
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
## Description

Add production optimizations to Vite configuration.

## Changes

- Enable source maps (`build.sourcemap: true`) for production debugging
- Add `resolve.alias` for `@` -> `src/` as backup for tsconfig paths
- `server.port` (3000) and `server.open` (true) already configured
- `build.outDir` already set to `build`

## How to test

- `cd frontend-scaffold && npm run build` -- verify build output includes .map files

Closes #63