### PR TITLE
Create useWallet hook for wallet connection

### DIFF
--- a/frontend-scaffold/src/hooks/useWallet.ts
+++ b/frontend-scaffold/src/hooks/useWallet.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import {
+  StellarWalletsKit,
+  WalletNetwork,
+  FREIGHTER_ID,
+  FreighterModule,
+  AlbedoModule,
+  xBullModule,
+} from '@creit.tech/stellar-wallets-kit';
+import { useWalletStore } from '../store/walletStore';
+
+const kit = new StellarWalletsKit({
+  network: WalletNetwork.TESTNET,
+  selectedWalletId: FREIGHTER_ID,
+  modules: [new FreighterModule(), new AlbedoModule(), new xBullModule()],
+});
+
+export const useWallet = () => {
+  const { publicKey, connected, network, connect, disconnect } = useWalletStore();
+
+  const actions = useMemo(() => ({
+    connect: () => {
+      kit.openModal({
+        onWalletSelected: async (option) => {
+          kit.setWallet(option.id);
+          const { address } = await kit.getAddress();
+          connect(address);
+        },
+      });
+    },
+
+    disconnect: () => {
+      disconnect();
+    },
+
+    signTransaction: async (xdr: string): Promise<string> => {
+      const { signedTxXdr } = await kit.signTransaction(xdr, {
+        address: publicKey ?? undefined,
+      });
+      return signedTxXdr;
+    },
+  }), [publicKey, connect, disconnect]);
+
+  return { publicKey, connected, network, ...actions };
+};

--- a/frontend-scaffold/src/store/walletStore.ts
+++ b/frontend-scaffold/src/store/walletStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+type Network = 'TESTNET' | 'PUBLIC';
+
+interface WalletState {
+  publicKey: string | null;
+  connected: boolean;
+  network: Network;
+}
+
+interface WalletActions {
+  connect: (publicKey: string) => void;
+  disconnect: () => void;
+  setNetwork: (network: Network) => void;
+}
+
+type WalletStore = WalletState & WalletActions;
+
+export const useWalletStore = create<WalletStore>((set) => ({
+  publicKey: null,
+  connected: false,
+  network: 'TESTNET',
+
+  connect: (publicKey) => set({ publicKey, connected: true }),
+
+  disconnect: () => set({ publicKey: null, connected: false }),
+
+  setNetwork: (network) => set({ network }),
+}));


### PR DESCRIPTION
closed #70


Description:

 implements the useWallet hook as the primary interface for wallet 
interactions across the app.

What was added

- src/hooks/useWallet.ts — custom React hook wrapping StellarWalletsKit and the 
Zustand wallet store
- src/store/walletStore.ts — Zustand store managing publicKey, connected, and 
network state (dependency from #64)

How it works

- StellarWalletsKit is initialized once at module level (singleton) with 
FreighterModule, AlbedoModule, and xBullModule on WalletNetwork.TESTNET
- connect() opens the wallet selection modal, sets the chosen wallet via 
option.id, fetches the address with kit.getAddress(), and updates the store
- disconnect() clears the store state
- signTransaction(xdr) delegates to kit.signTransaction() with the current 
public key and returns the signed XDR string
- publicKey, connected, network are read directly from the Zustand store

Checklist
- [x] Follows @creit.tech/stellar-wallets-kit v1.9.5 API
- [x] TypeScript strict mode — zero type errors
- [x] No unnecessary re-renders (actions memoized with useMemo)
- [x] Matches architecture defined in docs/FRONTEND_GUIDE.md
