### PR TITLE
feat: #65 [FRONTEND] Create Zustand store for user profile state

### DIFF
--- a/frontend-scaffold/src/store/profileStore.ts
+++ b/frontend-scaffold/src/store/profileStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+import { Profile } from '@/types/contract';
+
+interface ProfileState {
+  profile: Profile | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface ProfileActions {
+  setProfile: (profile: Profile) => void;
+  clearProfile: () => void;
+  setLoading: (loading: boolean) => void;
+  setError: (error: string | null) => void;
+}
+
+type ProfileStore = ProfileState & ProfileActions;
+
+export const useProfileStore = create<ProfileStore>((set) => ({
+  profile: null,
+  loading: false,
+  error: null,
+
+  setProfile: (profile) => set({ profile }),
+
+  clearProfile: () => set({ profile: null }),
+
+  setLoading: (loading) => set({ loading }),
+
+  setError: (error) => set({ error }),
+}));


### PR DESCRIPTION
## Summary

- Creates `frontend-scaffold/src/store/profileStore.ts` with a Zustand store for the connected user's profile data
- State: `profile: Profile | null`, `loading: boolean`, `error: string | null`
- Actions: `setProfile`, `clearProfile`, `setLoading`, `setError`
- Imports `Profile` type from `@/types/contract`
- Exports `useProfileStore` hook using Zustand `create` (v5 pattern, no deprecated middleware)
- Follows the same store pattern established by `walletStore.ts` (#64)

## Dependency

Depends on wallet store (#64) — profile state is a separate slice and does not couple directly to wallet internals.

Closes #65