### PR TITLE
feat(ui): add design system components (CopyButton, Divider, Tooltip,…

### DIFF
--- a/frontend-scaffold/src/components/ui/CopyButton.tsx
+++ b/frontend-scaffold/src/components/ui/CopyButton.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { Copy, Check } from 'lucide-react';
+import Button from './Button';
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  className?: string;
+}
+
+const CopyButton: React.FC<CopyButtonProps> = ({ text, label, className = '' }) => {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout;
+    if (copied) {
+      timeout = setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    }
+    return () => clearTimeout(timeout);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={`flex items-center gap-2 ${className}`}
+      onClick={handleCopy}
+      type="button"
+      title={label || "Copy to clipboard"}
+    >
+      {copied ? <Check size={16} /> : <Copy size={16} />}
+      {label && <span>{copied ? 'Copied!' : label}</span>}
+      {!label && copied && <span className="sr-only">Copied!</span>}
+    </Button>
+  );
+};
+
+export default CopyButton;

--- a/frontend-scaffold/src/components/ui/Divider.tsx
+++ b/frontend-scaffold/src/components/ui/Divider.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface DividerProps {
+  orientation?: 'horizontal' | 'vertical';
+  className?: string;
+}
+
+const Divider: React.FC<DividerProps> = ({ orientation = 'horizontal', className = '' }) => {
+  if (orientation === 'vertical') {
+    return <div className={`border-l-2 border-black h-full ${className}`} role="separator" aria-orientation="vertical" />;
+  }
+
+  return <div className={`border-t-2 border-black w-full ${className}`} role="separator" aria-orientation="horizontal" />;
+};
+
+export default Divider;

--- a/frontend-scaffold/src/components/ui/Skeleton.tsx
+++ b/frontend-scaffold/src/components/ui/Skeleton.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface SkeletonProps {
+  width?: string;
+  height?: string;
+  variant?: 'text' | 'rect' | 'circle';
+  lines?: number;
+}
+
+const Skeleton: React.FC<SkeletonProps> = ({
+  width,
+  height,
+  variant = 'text',
+  lines = 1,
+}) => {
+  const baseClasses = 'animate-pulse border-2 border-black';
+  const bgClasses = 'bg-gray-200'; // Pulsing will be mostly handled by Tailwind's animate-pulse, we can add a custom pulse in CSS if we specifically need grey-100 to grey-200, but standard is fine. Actually, let's inject a style or use standard animate-pulse with a gray background.
+  
+  // Custom keyframes could be added but Tailwind's default animate-pulse changes opacity which looks close enough if combined with a base background. For brutalism, using a straight gray background is preferred.
+  
+  if (variant === 'text') {
+    return (
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: lines }).map((_, i) => (
+          <div
+            key={i}
+            className={`${baseClasses} ${bgClasses} rounded-full`}
+            style={{
+              width: width || (lines > 1 && i === lines - 1 ? '70%' : '100%'),
+              height: height || '1rem',
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${baseClasses} ${bgClasses} ${
+        variant === 'circle' ? 'rounded-full' : 'rounded-none'
+      }`}
+      style={{
+        width: width || (variant === 'circle' ? '3rem' : '100%'),
+        height: height || (variant === 'circle' ? '3rem' : '10rem'),
+      }}
+    />
+  );
+};
+
+export default Skeleton;

--- a/frontend-scaffold/src/components/ui/Tooltip.tsx
+++ b/frontend-scaffold/src/components/ui/Tooltip.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface TooltipProps {
+  content: string;
+  children: React.ReactNode;
+  position?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ content, children, position = 'top' }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseEnter = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, 200);
+  };
+
+  const handleMouseLeave = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClasses = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+    left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+  };
+
+  const arrowClasses = {
+    top: 'top-full left-1/2 -translate-x-1/2 border-t-black border-l-transparent border-r-transparent border-b-transparent',
+    bottom: 'bottom-full left-1/2 -translate-x-1/2 border-b-black border-l-transparent border-r-transparent border-t-transparent',
+    left: 'left-full top-1/2 -translate-y-1/2 border-l-black border-t-transparent border-b-transparent border-r-transparent',
+    right: 'right-full top-1/2 -translate-y-1/2 border-r-black border-t-transparent border-b-transparent border-l-transparent',
+  };
+
+  return (
+    <div
+      className="relative inline-block"
+      ref={triggerRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onFocus={handleMouseEnter}
+      onBlur={handleMouseLeave}
+    >
+      {children}
+      {isVisible && (
+        <div
+          className={`absolute z-50 px-3 py-1.5 text-sm whitespace-nowrap bg-black text-white border-2 border-black ${positionClasses[position]}`}
+          style={{ boxShadow: '4px 4px 0px 0px rgba(0,0,0,1)' }}
+          role="tooltip"
+        >
+          {content}
+          <div
+            className={`absolute border-solid border-[6px] ${arrowClasses[position]}`}
+            style={{ width: 0, height: 0 }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
## Description

This PR implements Phase 3 Design System Enhancements for the frontend as specified in Issues #85, #84, #83, and #81. The following reusable components matching the project's brutalist aesthetic have been created:

- **CopyButton**: A ghost-variant button that copies provided text to the clipboard and gives user feedback (icon changes from Copy to Check for 2 seconds).
- **Divider**: A simple horizontal/vertical divider with brutalist bold borders (`border-black`).
- **Tooltip**: A hover tooltip featuring a 200ms delay, brutalist shadow, black background, and directional positioning (top, bottom, left, right) with an arrow indicator.
- **Skeleton**: A loading placeholder component that supports `text`, `rect`, and `circle` variants, complete with a pulsing animation and matching bold borders.

## Changes:
- Added `src/components/ui/CopyButton.tsx`
- Added `src/components/ui/Divider.tsx`
- Added `src/components/ui/Tooltip.tsx`
- Added `src/components/ui/Skeleton.tsx`

## Related Issues:
Closes #85, Closes #84, Closes #83 , Closes #81 
