### PR TITLE
feat: add mobile nav and shared tip UI

### DIFF
--- a/frontend-scaffold/src/components/layout/Header.tsx
+++ b/frontend-scaffold/src/components/layout/Header.tsx
@@ -1,22 +1,76 @@
-import React from 'react';
-import { Github } from 'lucide-react';
+import React, { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Github, Menu, X } from "lucide-react";
+import { Link } from "react-router-dom";
+import Button from "../ui/Button";
+import { useWallet } from "../../hooks/useWallet";
 
 const Header: React.FC = () => {
+  const { connected, publicKey, connect, disconnect } = useWallet();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const headerRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      if (
+        mobileMenuOpen &&
+        headerRef.current &&
+        !headerRef.current.contains(event.target as Node)
+      ) {
+        setMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    };
+  }, [mobileMenuOpen]);
+
+  const closeMobileMenu = () => setMobileMenuOpen(false);
+
+  const handleWalletAction = () => {
+    if (connected) {
+      disconnect();
+    } else {
+      connect();
+    }
+    closeMobileMenu();
+  };
+
+  const walletLabel =
+    connected && publicKey
+      ? `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`
+      : "Connect Wallet";
+
   return (
-    <header className="border-b-3 border-black bg-white">
-      <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
-        <a href="/" className="flex items-center gap-2">
+    <header
+      ref={headerRef}
+      className="border-b-3 border-black bg-white relative z-30"
+    >
+      <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between gap-4">
+        <Link
+          to="/"
+          className="flex items-center gap-2"
+          onClick={closeMobileMenu}
+        >
           <span className="text-2xl font-black tracking-tight">TIPZ</span>
           <span className="text-xl">💫</span>
-        </a>
+        </Link>
 
         <nav className="hidden md:flex items-center gap-6">
-          <a href="/leaderboard" className="font-bold uppercase text-sm tracking-wide hover:underline">
+          <Link
+            to="/leaderboard"
+            className="font-bold uppercase text-sm tracking-wide hover:underline"
+          >
             Leaderboard
-          </a>
-          <a href="/dashboard" className="font-bold uppercase text-sm tracking-wide hover:underline">
+          </Link>
+          <Link
+            to="/dashboard"
+            className="font-bold uppercase text-sm tracking-wide hover:underline"
+          >
             Dashboard
-          </a>
+          </Link>
         </nav>
 
         <div className="flex items-center gap-4">
@@ -29,9 +83,74 @@ const Header: React.FC = () => {
           >
             <Github size={20} />
           </a>
-          {/* Wallet connect button will be added here */}
+          <Button
+            size="sm"
+            className="hidden md:inline-flex"
+            onClick={connected ? disconnect : connect}
+          >
+            {walletLabel}
+          </Button>
+          <button
+            type="button"
+            className="md:hidden inline-flex items-center justify-center border-2 border-black bg-white p-2"
+            style={{ boxShadow: "4px 4px 0px 0px rgba(0,0,0,1)" }}
+            aria-label={
+              mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"
+            }
+            aria-expanded={mobileMenuOpen}
+            onClick={() => setMobileMenuOpen((open) => !open)}
+          >
+            {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
         </div>
       </div>
+
+      <AnimatePresence>
+        {mobileMenuOpen && (
+          <motion.div
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -16 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            className="md:hidden absolute left-0 right-0 top-full border-b-3 border-black bg-white"
+          >
+            <div className="max-w-6xl mx-auto px-4 py-4 flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-black uppercase tracking-[0.2em]">
+                  Navigation
+                </span>
+                <button
+                  type="button"
+                  onClick={closeMobileMenu}
+                  className="inline-flex items-center justify-center border-2 border-black bg-white p-2"
+                  aria-label="Close mobile menu"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+
+              <Link
+                to="/leaderboard"
+                onClick={closeMobileMenu}
+                className="border-2 border-black bg-yellow-100 px-4 py-3 font-bold uppercase tracking-wide"
+              >
+                Leaderboard
+              </Link>
+              <Link
+                to="/dashboard"
+                onClick={closeMobileMenu}
+                className="border-2 border-black bg-white px-4 py-3 font-bold uppercase tracking-wide"
+              >
+                Dashboard
+              </Link>
+
+              <Button className="w-full" onClick={handleWalletAction}>
+                {connected ? `Disconnect ${walletLabel}` : "Connect Wallet"}
+              </Button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </header>
   );
 };

--- a/frontend-scaffold/src/components/shared/AmountDisplay.tsx
+++ b/frontend-scaffold/src/components/shared/AmountDisplay.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { stroopToXlm } from "../../helpers/format";
+
+interface AmountDisplayProps {
+  amount: string;
+  className?: string;
+}
+
+const AmountDisplay: React.FC<AmountDisplayProps> = ({
+  amount,
+  className = "",
+}) => {
+  const xlmAmount = stroopToXlm(new BigNumber(amount)).toFormat();
+
+  return (
+    <span className={`font-black tabular-nums ${className}`}>
+      {xlmAmount} XLM
+    </span>
+  );
+};
+
+export default AmountDisplay;

--- a/frontend-scaffold/src/components/shared/CreditBadge.tsx
+++ b/frontend-scaffold/src/components/shared/CreditBadge.tsx
@@ -1,19 +1,45 @@
-import React from 'react';
-import Badge, { getTierFromScore } from '../ui/Badge';
+import React from "react";
+import { Link } from "react-router-dom";
+import Badge, { getTierFromScore } from "../ui/Badge";
+import Tooltip from "../ui/Tooltip";
 
 interface CreditBadgeProps {
   score: number;
   showScore?: boolean;
   className?: string;
+  clickable?: boolean;
 }
 
 const CreditBadge: React.FC<CreditBadgeProps> = ({
   score,
   showScore = true,
   className,
+  clickable = false,
 }) => {
   const tier = getTierFromScore(score);
-  return <Badge tier={tier} score={showScore ? score : undefined} className={className} />;
+  const badge = (
+    <Badge
+      tier={tier}
+      score={showScore ? score : undefined}
+      className={`${clickable ? "cursor-pointer" : ""} ${className ?? ""}`}
+    />
+  );
+
+  return (
+    <Tooltip content={`Credit Score: ${score}/1000 • Tier: ${tier}`}>
+      {clickable ? (
+        <Link
+          to="/docs/credit-score"
+          className="inline-flex"
+          aria-label="Learn about credit scores"
+        >
+          {badge}
+        </Link>
+      ) : (
+        badge
+      )}
+    </Tooltip>
+  );
 };
 
 export default CreditBadge;

--- a/frontend-scaffold/src/components/shared/TipCard.tsx
+++ b/frontend-scaffold/src/components/shared/TipCard.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import Avatar from "../ui/Avatar";
+import Card from "../ui/Card";
+import AmountDisplay from "./AmountDisplay";
+import type { Tip } from "../../types";
+import { truncateString } from "../../helpers/format";
+
+interface TipCardProps {
+  tip: Tip;
+  showSender?: boolean;
+  showReceiver?: boolean;
+}
+
+const formatRelativeTimestamp = (timestamp: number): string => {
+  const normalizedTimestamp =
+    timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp;
+  const diffSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - normalizedTimestamp) / 1000),
+  );
+
+  if (diffSeconds < 60) return "just now";
+  if (diffSeconds < 3600) {
+    const minutes = Math.floor(diffSeconds / 60);
+    return `${minutes} min${minutes === 1 ? "" : "s"} ago`;
+  }
+  if (diffSeconds < 86400) {
+    const hours = Math.floor(diffSeconds / 3600);
+    return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  }
+  const days = Math.floor(diffSeconds / 86400);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+};
+
+const TipCard: React.FC<TipCardProps> = ({
+  tip,
+  showSender = true,
+  showReceiver = true,
+}) => {
+  const primaryAddress = showSender ? tip.from : tip.to;
+  const primaryLabel = showSender ? "From" : "To";
+  const secondaryAddress =
+    showSender && showReceiver ? tip.to : showReceiver ? tip.from : null;
+  const secondaryLabel =
+    showSender && showReceiver ? "To" : showReceiver ? "From" : null;
+
+  return (
+    <button
+      type="button"
+      className="block w-full text-left"
+      aria-label={`Open tip card for ${truncateString(primaryAddress)}`}
+    >
+      <Card hover className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <Avatar
+              address={primaryAddress}
+              alt={`${primaryLabel} ${primaryAddress}`}
+              size="md"
+            />
+            <div className="min-w-0">
+              <p className="text-[11px] font-black uppercase tracking-[0.2em] text-gray-500">
+                {primaryLabel}
+              </p>
+              <p className="truncate text-sm font-black">
+                {truncateString(primaryAddress)}
+              </p>
+              {secondaryAddress && secondaryLabel && (
+                <p className="mt-1 truncate text-xs font-bold text-gray-600">
+                  {secondaryLabel}: {truncateString(secondaryAddress)}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex-shrink-0 border-2 border-black bg-yellow-100 px-3 py-2">
+            <AmountDisplay amount={tip.amount} />
+          </div>
+        </div>
+
+        <p
+          className="overflow-hidden text-sm font-medium leading-6 text-gray-700"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {tip.message || "No message attached."}
+        </p>
+
+        <div className="flex items-center justify-between border-t-2 border-dashed border-black pt-3">
+          <span className="text-[11px] font-black uppercase tracking-[0.2em] text-gray-500">
+            Tip activity
+          </span>
+          <span className="text-xs font-bold">
+            {formatRelativeTimestamp(tip.timestamp)}
+          </span>
+        </div>
+      </Card>
+    </button>
+  );
+};
+
+export default TipCard;

--- a/frontend-scaffold/src/components/shared/TransactionStatus.tsx
+++ b/frontend-scaffold/src/components/shared/TransactionStatus.tsx
@@ -1,56 +1,82 @@
-import React from 'react';
-import Loader from '../ui/Loader';
+import React from "react";
+import Button from "../ui/Button";
+import CopyButton from "../ui/CopyButton";
+import Loader from "../ui/Loader";
+import { useWallet } from "../../hooks/useWallet";
 
 interface TransactionStatusProps {
-  status: 'idle' | 'signing' | 'submitting' | 'confirming' | 'success' | 'error';
+  status:
+    | "idle"
+    | "signing"
+    | "submitting"
+    | "confirming"
+    | "success"
+    | "error";
   txHash?: string;
   errorMessage?: string;
+  onRetry?: () => void;
 }
 
 const statusMessages: Record<string, string> = {
-  idle: '',
-  signing: 'Waiting for wallet signature...',
-  submitting: 'Submitting transaction...',
-  confirming: 'Confirming on network...',
-  success: 'Transaction confirmed!',
-  error: 'Transaction failed',
+  idle: "",
+  signing: "Waiting for wallet signature...",
+  submitting: "Submitting transaction...",
+  confirming: "Confirming on network...",
+  success: "Transaction confirmed!",
+  error: "Transaction failed",
 };
 
 const TransactionStatus: React.FC<TransactionStatusProps> = ({
   status,
   txHash,
   errorMessage,
+  onRetry,
 }) => {
-  if (status === 'idle') return null;
+  const { network } = useWallet();
+  if (status === "idle") return null;
 
-  const isLoading = ['signing', 'submitting', 'confirming'].includes(status);
+  const isLoading = ["signing", "submitting", "confirming"].includes(status);
+  const explorerBase =
+    network === "PUBLIC"
+      ? "https://stellar.expert/explorer/public/tx/"
+      : "https://stellar.expert/explorer/testnet/tx/";
 
   return (
     <div className="border-2 border-black p-4 text-center">
       {isLoading && <Loader text={statusMessages[status]} />}
 
-      {status === 'success' && (
+      {status === "success" && (
         <div>
           <p className="text-lg font-black text-green-800 mb-2">
             {statusMessages.success}
           </p>
           {txHash && (
-            <a
-              href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm underline font-bold"
-            >
-              View on Stellar Expert →
-            </a>
+            <div className="flex flex-col items-center gap-3">
+              <a
+                href={`${explorerBase}${txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm underline font-bold"
+              >
+                View on Stellar Expert →
+              </a>
+              <CopyButton text={txHash} label="Copy TX Hash" />
+            </div>
           )}
         </div>
       )}
 
-      {status === 'error' && (
-        <p className="text-lg font-black text-red-800">
-          {errorMessage || statusMessages.error}
-        </p>
+      {status === "error" && (
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-lg font-black text-red-800">
+            {errorMessage || statusMessages.error}
+          </p>
+          {onRetry && (
+            <Button variant="outline" size="sm" onClick={onRetry}>
+              Try Again
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend-scaffold/src/components/ui/CopyButton.tsx
+++ b/frontend-scaffold/src/components/ui/CopyButton.tsx
@@ -12,7 +12,7 @@ const CopyButton: React.FC<CopyButtonProps> = ({ text, label, className = '' }) 
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
-    let timeout: NodeJS.Timeout;
+    let timeout: ReturnType<typeof setTimeout>;
     if (copied) {
       timeout = setTimeout(() => {
         setCopied(false);

--- a/frontend-scaffold/src/components/ui/Tooltip.tsx
+++ b/frontend-scaffold/src/components/ui/Tooltip.tsx
@@ -9,7 +9,7 @@ interface TooltipProps {
 const Tooltip: React.FC<TooltipProps> = ({ content, children, position = 'top' }) => {
   const [isVisible, setIsVisible] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleMouseEnter = () => {
     timeoutRef.current = setTimeout(() => {


### PR DESCRIPTION
Closes #92
Closes #95
Closes #96
Closes #98

## Changes
- added a mobile hamburger menu to the shared header with framer-motion slide-down animation
- added mobile navigation links, wallet action button, close button, click-outside handling, and auto-close on link click
- enhanced `CreditBadge` with tooltip score breakdown and optional click-through behavior
- enhanced `TransactionStatus` with network-aware Stellar Expert links, copy-hash action, and retry support for error states
- added shared `AmountDisplay` primitive for XLM amounts
- added reusable `TipCard` component with avatar, truncated addresses, amount display, truncated message, and relative timestamp
- fixed shared timer typings in `CopyButton` and `Tooltip` so frontend typecheck passes

## Testing
- `cd frontend-scaffold && npm run typecheck`
- `cd frontend-scaffold && npm run build`
