### PR TITLE
feat: #72 [FRONTEND] Create useProfile hook for profile management

### DIFF
--- a/frontend-scaffold/src/hooks/useProfile.ts
+++ b/frontend-scaffold/src/hooks/useProfile.ts
@@ -1,15 +1,74 @@
+import { useState, useEffect, useCallback } from 'react';
+
+import { useWalletStore } from '../store/walletStore';
 import { useProfileStore } from '../store/profileStore';
+import { useContract } from './useContract';
 
 /**
- * Hook to access the current user's profile and loading state.
+ * Determines whether a contract error indicates the user has no profile,
+ * as opposed to a genuine network/contract failure.
+ */
+const isNotRegisteredError = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    msg.toLowerCase().includes('not found') ||
+    msg.toLowerCase().includes('notfound') ||
+    msg.toLowerCase().includes('not registered') ||
+    msg.toLowerCase().includes('profile not found')
+  );
+};
+
+/**
+ * Manages the connected user's profile state.
+ *
+ * - Auto-fetches from the contract whenever the connected wallet's publicKey changes.
+ * - Updates the profile store on a successful fetch.
+ * - Clears the profile store when the wallet disconnects.
+ * - Treats an unregistered address as isRegistered = false (no error state).
  */
 export const useProfile = () => {
-  const { profile, loading, error } = useProfileStore();
+  const { publicKey } = useWalletStore();
+  const { profile, loading, error, setProfile, clearProfile, setLoading, setError } = useProfileStore();
+  const { getProfile } = useContract();
 
-  return {
-    profile,
-    loading,
-    error,
-    hasProfile: !!profile,
-  };
+  const [isRegistered, setIsRegistered] = useState(false);
+
+  const fetchProfile = useCallback(async (address: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const fetched = await getProfile(address);
+      setProfile(fetched);
+      setIsRegistered(true);
+    } catch (err) {
+      if (isNotRegisteredError(err)) {
+        clearProfile();
+        setIsRegistered(false);
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to fetch profile');
+        setIsRegistered(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [getProfile, setProfile, clearProfile, setLoading, setError]);
+
+  // Auto-fetch when the connected wallet changes; clear store on disconnect.
+  useEffect(() => {
+    if (publicKey) {
+      fetchProfile(publicKey);
+    } else {
+      clearProfile();
+      setIsRegistered(false);
+    }
+  }, [publicKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const refetch = useCallback(() => {
+    if (publicKey) {
+      fetchProfile(publicKey);
+    }
+  }, [publicKey, fetchProfile]);
+
+  return { profile, loading, error, isRegistered, refetch };
 };


### PR DESCRIPTION
## Summary

- Implements `frontend-scaffold/src/hooks/useProfile.ts` replacing the earlier stub
- Watches `publicKey` in the wallet store and auto-fetches the connected user's profile from the contract on every wallet change
- On successful fetch: calls `setProfile` on the profile store and sets `isRegistered = true`
- On disconnect (`publicKey → null`): calls `clearProfile` and resets `isRegistered = false`
- Gracefully handles "not registered" contract errors — sets `isRegistered = false` without surfacing an error to the consumer
- Exposes: `profile`, `loading`, `error`, `isRegistered`, `refetch()`
- `refetch()` manually re-triggers a fetch for the currently connected address

## Dependencies

- Depends on #65 (profileStore)
- Depends on #71 (wallet store / useContract)

Closes #72