### PR TITLE
feat(frontend): add page transitions, scroll-to-top, how-it-works, and creator search

### DIFF
--- a/frontend-scaffold/src/App.tsx
+++ b/frontend-scaffold/src/App.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import Header from '@/components/layout/Header';
 import Footer from './components/layout/Footer';
+import ScrollToTop from './components/shared/ScrollToTop';
+import PageTransition from './components/shared/PageTransition';
 import LandingPage from './features/landing/LandingPage';
 
 // Feature pages - will be implemented in frontend issues
@@ -14,16 +16,17 @@ import LandingPage from './features/landing/LandingPage';
 const App: React.FC = () => {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <div className="min-h-screen flex flex-col bg-white">
         <Header />
         <div className="flex-1">
           <Routes>
-            <Route path="/" element={<LandingPage />} />
+            <Route path="/" element={<PageTransition><LandingPage /></PageTransition>} />
             {/* Routes to be enabled as features are built:
-            <Route path="/@:username" element={<TipPage />} />
-            <Route path="/profile" element={<ProfilePage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/leaderboard" element={<LeaderboardPage />} />
+            <Route path="/@:username" element={<PageTransition><TipPage /></PageTransition>} />
+            <Route path="/profile" element={<PageTransition><ProfilePage /></PageTransition>} />
+            <Route path="/dashboard" element={<PageTransition><DashboardPage /></PageTransition>} />
+            <Route path="/leaderboard" element={<PageTransition><LeaderboardPage /></PageTransition>} />
             */}
           </Routes>
         </div>

--- a/frontend-scaffold/src/components/shared/CreatorSearch.tsx
+++ b/frontend-scaffold/src/components/shared/CreatorSearch.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Search, Loader2 } from 'lucide-react';
+import type { Profile } from '@/types';
+import { useContract } from '@/hooks/useContract';
+import Avatar from '@/components/ui/Avatar';
+import { truncateString } from '@/helpers/format';
+
+interface CreatorSearchProps {
+  onSelect: (profile: Profile) => void;
+  placeholder?: string;
+}
+
+const DEBOUNCE_MS = 300;
+
+const isValidStellarAddress = (input: string): boolean =>
+  input.startsWith('G') && input.length === 56;
+
+const CreatorSearch: React.FC<CreatorSearchProps> = ({
+  onSelect,
+  placeholder = 'Search by username or Stellar address...',
+}) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Profile[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const { getProfile, getProfileByUsername } = useContract();
+
+  const performSearch = useCallback(
+    async (searchQuery: string) => {
+      const trimmed = searchQuery.trim();
+      if (!trimmed) {
+        setResults([]);
+        setHasSearched(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setHasSearched(true);
+
+      try {
+        let profile: Profile | null = null;
+
+        if (isValidStellarAddress(trimmed)) {
+          try {
+            profile = await getProfile(trimmed);
+          } catch {
+            // Not found by address
+          }
+        } else {
+          try {
+            profile = await getProfileByUsername(trimmed);
+          } catch {
+            // Not found by username
+          }
+        }
+
+        setResults(profile ? [profile] : []);
+      } catch {
+        setResults([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [getProfile, getProfileByUsername],
+  );
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!query.trim()) {
+      setResults([]);
+      setHasSearched(false);
+      setShowDropdown(false);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      performSearch(query);
+      setShowDropdown(true);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, performSearch]);
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (profile: Profile) => {
+    onSelect(profile);
+    setQuery('');
+    setShowDropdown(false);
+    setResults([]);
+    setHasSearched(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => {
+            if (query.trim()) setShowDropdown(true);
+          }}
+          placeholder={placeholder}
+          className="w-full pl-10 pr-10 py-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent bg-white"
+        />
+        {isLoading && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 animate-spin" />
+        )}
+      </div>
+
+      {showDropdown && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-50 max-h-64 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-6 text-gray-400 text-sm">
+              <Loader2 className="w-4 h-4 animate-spin mr-2" />
+              Searching...
+            </div>
+          ) : results.length > 0 ? (
+            results.map((profile) => (
+              <button
+                key={profile.owner}
+                onClick={() => handleSelect(profile)}
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
+              >
+                <Avatar alt={profile.displayName || profile.username} size="sm" />
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-sm truncate">
+                    {profile.displayName || profile.username}
+                  </p>
+                  <p className="text-xs text-gray-400 truncate">
+                    @{profile.username} · {truncateString(profile.owner)}
+                  </p>
+                </div>
+              </button>
+            ))
+          ) : hasSearched ? (
+            <div className="py-6 text-center text-gray-400 text-sm">
+              No results found
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CreatorSearch;

--- a/frontend-scaffold/src/components/shared/PageTransition.tsx
+++ b/frontend-scaffold/src/components/shared/PageTransition.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+interface PageTransitionProps {
+  children: React.ReactNode;
+}
+
+const PageTransition: React.FC<PageTransitionProps> = ({ children }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 10 }}
+      transition={{ duration: 0.3, ease: 'easeOut' }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default PageTransition;

--- a/frontend-scaffold/src/components/shared/ScrollToTop.tsx
+++ b/frontend-scaffold/src/components/shared/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/frontend-scaffold/src/features/landing/HowItWorksSection.tsx
+++ b/frontend-scaffold/src/features/landing/HowItWorksSection.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Wallet, User, Link, Zap } from 'lucide-react';
+
+interface Step {
+  number: number;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+const steps: Step[] = [
+  {
+    number: 1,
+    icon: <Wallet className="w-6 h-6" />,
+    title: 'Connect your Stellar wallet',
+    description: 'Link your Freighter or other Stellar wallet to get started in seconds.',
+  },
+  {
+    number: 2,
+    icon: <User className="w-6 h-6" />,
+    title: 'Register your profile',
+    description: 'Create your unique creator profile with a custom username and bio.',
+  },
+  {
+    number: 3,
+    icon: <Link className="w-6 h-6" />,
+    title: 'Share your tip link',
+    description: 'Share your personalized tip link on social media, streams, or anywhere.',
+  },
+  {
+    number: 4,
+    icon: <Zap className="w-6 h-6" />,
+    title: 'Receive XLM tips!',
+    description: 'Supporters send XLM tips directly to your wallet — instant and fee-free.',
+  },
+];
+
+const stepVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: i * 0.15,
+      duration: 0.4,
+      ease: 'easeOut' as const,
+    },
+  }),
+};
+
+const HowItWorksSection: React.FC = () => {
+  return (
+    <section className="py-20 px-4 bg-gray-50">
+      <div className="max-w-6xl mx-auto">
+        <motion.h2
+          className="text-3xl md:text-4xl font-bold text-center mb-4"
+          initial={{ opacity: 0, y: 10 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4 }}
+        >
+          HOW IT WORKS
+        </motion.h2>
+        <motion.p
+          className="text-gray-500 text-center mb-16 max-w-xl mx-auto"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+        >
+          Start receiving tips in four simple steps
+        </motion.p>
+
+        {/* Desktop: horizontal layout */}
+        <div className="hidden md:flex items-start justify-between gap-4">
+          {steps.map((step, i) => (
+            <React.Fragment key={step.number}>
+              <motion.div
+                className="flex flex-col items-center text-center flex-1"
+                custom={i}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true }}
+                variants={stepVariants}
+              >
+                <div className="relative mb-4">
+                  <div className="w-14 h-14 rounded-full bg-indigo-600 text-white flex items-center justify-center text-lg font-bold">
+                    {step.number}
+                  </div>
+                  <div className="absolute -bottom-1 -right-1 w-8 h-8 rounded-full bg-indigo-100 text-indigo-600 flex items-center justify-center">
+                    {step.icon}
+                  </div>
+                </div>
+                <h3 className="font-semibold text-lg mb-2">{step.title}</h3>
+                <p className="text-gray-500 text-sm leading-relaxed max-w-[200px]">
+                  {step.description}
+                </p>
+              </motion.div>
+
+              {/* Connecting line between steps */}
+              {i < steps.length - 1 && (
+                <motion.div
+                  className="flex-shrink-0 mt-7 w-12 h-0.5 bg-indigo-200"
+                  initial={{ scaleX: 0 }}
+                  whileInView={{ scaleX: 1 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: (i + 1) * 0.15, duration: 0.3 }}
+                />
+              )}
+            </React.Fragment>
+          ))}
+        </div>
+
+        {/* Mobile: vertical layout */}
+        <div className="flex flex-col gap-8 md:hidden">
+          {steps.map((step, i) => (
+            <motion.div
+              key={step.number}
+              className="flex items-start gap-4"
+              custom={i}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true }}
+              variants={stepVariants}
+            >
+              <div className="relative flex-shrink-0">
+                <div className="w-12 h-12 rounded-full bg-indigo-600 text-white flex items-center justify-center text-base font-bold">
+                  {step.number}
+                </div>
+                <div className="absolute -bottom-1 -right-1 w-7 h-7 rounded-full bg-indigo-100 text-indigo-600 flex items-center justify-center">
+                  {step.icon}
+                </div>
+                {/* Vertical connecting line */}
+                {i < steps.length - 1 && (
+                  <div className="absolute top-14 left-1/2 -translate-x-1/2 w-0.5 h-8 bg-indigo-200" />
+                )}
+              </div>
+              <div className="pt-1">
+                <h3 className="font-semibold text-base mb-1">{step.title}</h3>
+                <p className="text-gray-500 text-sm leading-relaxed">
+                  {step.description}
+                </p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HowItWorksSection;


### PR DESCRIPTION
## Summary

### PageTransition (#111)
- Framer Motion wrapper: fade-in + slide-up (opacity 0→1, y 10→0, 300ms ease-out)
- Wraps each route's page component in `App.tsx`

### ScrollToTop (#112)
- Uses `useLocation` to scroll to top on route navigation
- Added inside `BrowserRouter` in `App.tsx`

### HowItWorksSection (#115)
- 4-step process with numbered circles + icons (Wallet, User, Link, Zap)
- Horizontal layout on desktop with connecting lines, vertical on mobile
- Sequential Framer Motion entrance animations

### CreatorSearch (#102)
- Debounced search (300ms) calling `getProfileByUsername` or `getProfile`
- Auto-detects Stellar address format (starts with G, 56 chars)
- Dropdown with Avatar, display name, username, truncated address
- Loading spinner, "No results" empty state, click-outside dismiss

Closes #111
Closes #112
Closes #115
Closes #102

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm run build` — production build passes
- [ ] Verify page transitions animate on route navigation
- [ ] Verify scroll resets to top on navigation
- [ ] Verify HowItWorks renders responsive layout
- [ ] Verify CreatorSearch finds profiles by username and address