### PR TITLE
feat: add component barrel exports

### DIFF
--- a/frontend-scaffold/src/components/index.ts
+++ b/frontend-scaffold/src/components/index.ts
@@ -1,0 +1,3 @@
+export * from "./ui";
+export * from "./shared";
+export * from "./layout";

--- a/frontend-scaffold/src/components/layout/index.ts
+++ b/frontend-scaffold/src/components/layout/index.ts
@@ -1,0 +1,3 @@
+export { default as Footer } from "./Footer";
+export { default as Header } from "./Header";
+export { default as PageContainer } from "./PageContainer";

--- a/frontend-scaffold/src/components/shared/index.ts
+++ b/frontend-scaffold/src/components/shared/index.ts
@@ -1,0 +1,7 @@
+export { default as AmountDisplay } from "./AmountDisplay";
+export { default as CreditBadge } from "./CreditBadge";
+export { default as ErrorBoundary } from "./ErrorBoundary";
+export { default as ShareLink } from "./ShareLink";
+export { default as TipCard } from "./TipCard";
+export { default as TransactionStatus } from "./TransactionStatus";
+export { default as WalletConnect } from "./WalletConnect";

--- a/frontend-scaffold/src/components/ui/index.ts
+++ b/frontend-scaffold/src/components/ui/index.ts
@@ -1,0 +1,16 @@
+export { default as Avatar } from "./Avatar";
+export { default as Badge } from "./Badge";
+export { default as Button } from "./Button";
+export { default as Card } from "./Card";
+export { default as CopyButton } from "./CopyButton";
+export { default as Divider } from "./Divider";
+export { default as EmptyState } from "./EmptyState";
+export { default as Input } from "./Input";
+export { default as Loader } from "./Loader";
+export { default as Modal } from "./Modal";
+export { default as Select } from "./Select";
+export { default as Skeleton } from "./Skeleton";
+export { default as Tabs } from "./Tabs";
+export { default as Textarea } from "./Textarea";
+export { default as Toast } from "./Toast";
+export { default as Tooltip } from "./Tooltip";


### PR DESCRIPTION
## Summary
- add barrel exports for shared components
- add barrel exports for layout components
- add a top-level components barrel for cleaner imports
- add a supporting `ui/index.ts` so the top-level barrel can re-export `ui`, `shared`, and `layout` consistently

## Testing
- git diff --check

## Notes
- the frontend app lives under `frontend-scaffold`, so the barrel files were created there instead of repo-root `src/components`
- full frontend typecheck and build are currently blocked by existing repo/type/install issues outside this change

Closes #105
