### PR TITLE
feat: App shell routing, landing page sections, CTA, and profile registration

### DIFF
--- a/frontend-scaffold/src/App.tsx
+++ b/frontend-scaffold/src/App.tsx
@@ -2,39 +2,30 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import Header from '@/components/layout/Header';
-import Footer from './components/layout/Footer';
-import ScrollToTop from './components/shared/ScrollToTop';
-import PageTransition from './components/shared/PageTransition';
-import LandingPage from './features/landing/LandingPage';
-
-// Feature pages - will be implemented in frontend issues
-import DashboardPage from './features/dashboard/DashboardPage';
-import ProfilePage from './features/profile/ProfilePage';
-import ProtectedRoute from './components/shared/ProtectedRoute';
-import ToastContainer from './components/shared/ToastContainer';
-// import TipPage from './features/tipping/TipPage';
-// import LeaderboardPage from './features/leaderboard/LeaderboardPage';
+import Footer from '@/components/layout/Footer';
+import ScrollToTop from '@/components/shared/ScrollToTop';
+import ErrorBoundary from '@/components/shared/ErrorBoundary';
+import ToastContainer from '@/components/shared/ToastContainer';
+import { routes } from './routes';
 
 const App: React.FC = () => {
   return (
     <BrowserRouter>
       <ScrollToTop />
-      <div className="min-h-screen flex flex-col bg-white">
-        <Header />
-        <div className="flex-1">
-          <Routes>
-            <Route path="/" element={<PageTransition><LandingPage /></PageTransition>} />
-            {/* Routes to be enabled as features are built:
-            <Route path="/@:username" element={<PageTransition><TipPage /></PageTransition>} />
-            <Route path="/profile" element={<PageTransition><ProfilePage /></PageTransition>} />
-            <Route path="/dashboard" element={<PageTransition><DashboardPage /></PageTransition>} />
-            <Route path="/leaderboard" element={<PageTransition><LeaderboardPage /></PageTransition>} />
-            */}
-          </Routes>
+      <ErrorBoundary>
+        <div className="min-h-screen flex flex-col bg-white">
+          <Header />
+          <div className="flex-1">
+            <Routes>
+              {routes.map((route) => (
+                <Route key={route.path} path={route.path} element={route.element} />
+              ))}
+            </Routes>
+          </div>
+          <Footer />
         </div>
-        <Footer />
-        <ToastContainer />
-      </div>
+      </ErrorBoundary>
+      <ToastContainer />
     </BrowserRouter>
   );
 };

--- a/frontend-scaffold/src/features/landing/CTASection.tsx
+++ b/frontend-scaffold/src/features/landing/CTASection.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+import { useWallet } from '@/hooks';
+import { useContract } from '@/hooks';
+
+const CTASection: React.FC = () => {
+  const [totalCreators, setTotalCreators] = useState<number>(0);
+  const { connected, connect } = useWallet();
+  const { getStats } = useContract();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getStats()
+      .then((stats) => setTotalCreators(stats.totalCreators))
+      .catch(() => {
+        // Contract may not be deployed yet — display gracefully
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleCreateProfile = () => {
+    if (!connected) {
+      connect();
+    } else {
+      navigate('/profile');
+    }
+  };
+
+  return (
+    <section className="py-20 px-4 bg-off-white border-t-3 border-black">
+      <div className="max-w-4xl mx-auto text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-5xl md:text-6xl font-black mb-6">
+            Start Receiving Tips Today
+          </h2>
+          <p className="text-xl md:text-2xl mb-12 text-gray-700">
+            Join{' '}
+            {totalCreators > 0 ? (
+              <strong>{totalCreators.toLocaleString()} creators</strong>
+            ) : (
+              'thousands of creators'
+            )}{' '}
+            already on Tipz
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+            <button className="btn-brutalist text-lg group" onClick={handleCreateProfile}>
+              Create Profile
+              <ArrowRight
+                className="inline-block ml-2 group-hover:translate-x-1 transition-transform"
+                size={20}
+              />
+            </button>
+            <button
+              className="btn-brutalist-outline text-lg"
+              onClick={() => navigate('/leaderboard')}
+            >
+              Browse Creators
+            </button>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default CTASection;

--- a/frontend-scaffold/src/features/landing/FeaturesSection.tsx
+++ b/frontend-scaffold/src/features/landing/FeaturesSection.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Sparkles, Zap, Globe, Trophy, Shield } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+const features = [
+  {
+    icon: <Zap size={40} />,
+    title: 'Lightning Fast',
+    description: '3-5 second finality. Tips arrive instantly, not in weeks.',
+  },
+  {
+    icon: <Sparkles size={40} />,
+    title: 'Minimal Fees',
+    description: 'Only 2% withdrawal fee. Keep 98% of what you earn.',
+  },
+  {
+    icon: <Globe size={40} />,
+    title: 'Global Access',
+    description: 'Borderless payments. Anyone, anywhere, anytime.',
+  },
+  {
+    icon: <Trophy size={40} />,
+    title: 'Credit Score',
+    description: 'Transparent credibility based on X (Twitter) metrics.',
+  },
+  {
+    icon: <Shield size={40} />,
+    title: 'Fully On-Chain',
+    description: 'All transactions transparent and verifiable on Stellar.',
+  },
+  {
+    icon: <Sparkles size={40} />,
+    title: 'Simple URLs',
+    description: 'Share your tipz.app/@username everywhere.',
+  },
+];
+
+const FeaturesSection: React.FC = () => {
+  return (
+    <section className="py-20 px-4 bg-off-white border-t-3 border-b-3 border-black">
+      <div className="max-w-6xl mx-auto">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="text-5xl md:text-6xl font-black text-center mb-16"
+        >
+          WHY TIPZ?
+        </motion.h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {features.map((feature, index) => (
+            <motion.div
+              key={index}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="card-brutalist hover:-translate-x-1 hover:-translate-y-1 transition-transform duration-200"
+            >
+              <div className="mb-4">{feature.icon}</div>
+              <h3 className="text-2xl font-bold mb-3 uppercase">{feature.title}</h3>
+              <p className="text-gray-700">{feature.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FeaturesSection;

--- a/frontend-scaffold/src/features/landing/HeroSection.tsx
+++ b/frontend-scaffold/src/features/landing/HeroSection.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+
+const HeroSection: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <section id="hero" className="relative min-h-screen flex items-center justify-center px-4 py-20">
+      <div className="max-w-6xl mx-auto text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="mb-8"
+        >
+          <h1 className="text-8xl md:text-9xl font-black mb-4 tracking-tight">
+            TIPZ
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ delay: 0.3, type: 'spring', stiffness: 200 }}
+              className="inline-block ml-4"
+            >
+              💫
+            </motion.span>
+          </h1>
+          <div className="h-2 w-32 bg-black mx-auto mb-8" />
+        </motion.div>
+
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="text-3xl md:text-5xl font-bold mb-6 max-w-4xl mx-auto leading-tight"
+        >
+          Empowering Creators Through
+          <br />
+          Decentralized Tipping
+        </motion.h2>
+
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+          className="text-xl md:text-2xl mb-12 max-w-3xl mx-auto text-gray-700"
+        >
+          Send instant XLM tips to creators. Only 2% fees. 3-5 second finality.
+          <br />
+          Built on Stellar&apos;s lightning-fast blockchain.
+        </motion.p>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.6 }}
+          className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16"
+        >
+          <button
+            className="btn-brutalist text-lg group"
+            onClick={() => navigate('/register')}
+          >
+            Get Started
+            <ArrowRight
+              className="inline-block ml-2 group-hover:translate-x-1 transition-transform"
+              size={20}
+            />
+          </button>
+          <a href="#how-it-works" className="btn-brutalist-outline text-lg">
+            Learn More
+          </a>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.8 }}
+          className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto"
+        >
+          <div className="card-brutalist text-center">
+            <div className="text-4xl font-black mb-2">2%</div>
+            <div className="text-sm uppercase font-bold tracking-wide">Platform Fee</div>
+            <div className="text-xs text-gray-600 mt-1">(vs 30–50% traditional)</div>
+          </div>
+          <div className="card-brutalist text-center">
+            <div className="text-4xl font-black mb-2">3-5s</div>
+            <div className="text-sm uppercase font-bold tracking-wide">Transaction Time</div>
+            <div className="text-xs text-gray-600 mt-1">(vs 7–30 days traditional)</div>
+          </div>
+          <div className="card-brutalist text-center">
+            <div className="text-4xl font-black mb-2">$0.0001</div>
+            <div className="text-sm uppercase font-bold tracking-wide">Transaction Cost</div>
+            <div className="text-xs text-gray-600 mt-1">(virtually free)</div>
+          </div>
+        </motion.div>
+      </div>
+
+      {/* Scroll indicator */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.6, delay: 1 }}
+        className="absolute bottom-8 left-1/2 -translate-x-1/2"
+      >
+        <motion.div
+          animate={{ y: [0, 10, 0] }}
+          transition={{ repeat: Infinity, duration: 1.5 }}
+          className="w-6 h-10 border-2 border-black rounded-full flex items-start justify-center p-2"
+        >
+          <div className="w-1 h-2 bg-black rounded-full" />
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+};
+
+export default HeroSection;

--- a/frontend-scaffold/src/features/landing/LandingPage.tsx
+++ b/frontend-scaffold/src/features/landing/LandingPage.tsx
@@ -1,6 +1,35 @@
-// Re-export the LandingPage from its original location for backward compatibility
-// The canonical LandingPage lives at src/LandingPage.tsx and is imported here
-// into the features directory for the new routing structure.
+import React from 'react';
+import Divider from '@/components/ui/Divider';
+import HeroSection from './HeroSection';
+import FeaturesSection from './FeaturesSection';
+import HowItWorksSection from './HowItWorksSection';
+import StatsSection from './StatsSection';
+import TopCreatorsSection from './TopCreatorsSection';
+import CTASection from './CTASection';
 
-import LandingPage from '../../LandingPage';
+/**
+ * Landing page assembled from individual section components.
+ * Each section is separated by a Divider. The page renders gracefully
+ * even when the contract is not yet deployed.
+ */
+const LandingPage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-white">
+      <HeroSection />
+      <Divider />
+      <FeaturesSection />
+      <Divider />
+      <section id="how-it-works">
+        <HowItWorksSection />
+      </section>
+      <Divider />
+      <StatsSection />
+      <Divider />
+      <TopCreatorsSection />
+      <Divider />
+      <CTASection />
+    </div>
+  );
+};
+
 export default LandingPage;

--- a/frontend-scaffold/src/features/landing/StatsSection.tsx
+++ b/frontend-scaffold/src/features/landing/StatsSection.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { useContract } from '@/hooks';
+import { ContractStats } from '@/types/contract';
+
+const FALLBACK_STATS = {
+  feePct: 2,
+  settlementTime: '3-5s',
+  txCost: '$0.0001',
+  feesSaved: '95%',
+  speedup: '10,000×',
+};
+
+const comparisonRows = [
+  { feature: 'Fees', traditional: '30–50%', tipz: '2%', highlight: true },
+  { feature: 'Settlement', traditional: '7–30 days', tipz: '3-5 seconds', highlight: true },
+  { feature: 'Access', traditional: 'Regional', tipz: 'Global', highlight: false },
+  { feature: 'Transparency', traditional: 'Hidden', tipz: 'On-Chain', highlight: false },
+];
+
+const StatsSection: React.FC = () => {
+  const [stats, setStats] = useState<ContractStats | null>(null);
+  const { getStats } = useContract();
+
+  useEffect(() => {
+    getStats()
+      .then(setStats)
+      .catch(() => {
+        // Contract may not be deployed yet — render gracefully with fallback
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <section className="py-20 px-4 bg-off-white border-t-3 border-b-3 border-black">
+      <div className="max-w-6xl mx-auto">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="text-5xl md:text-6xl font-black text-center mb-16"
+        >
+          TIPZ VS TRADITIONAL
+        </motion.h2>
+
+        {/* Live stats if contract is deployed */}
+        {stats && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12"
+          >
+            <div className="card-brutalist text-center">
+              <div className="text-4xl font-black mb-1">{stats.totalCreators.toLocaleString()}</div>
+              <div className="text-sm uppercase font-bold tracking-wide">Creators</div>
+            </div>
+            <div className="card-brutalist text-center">
+              <div className="text-4xl font-black mb-1">{stats.totalTipsCount.toLocaleString()}</div>
+              <div className="text-sm uppercase font-bold tracking-wide">Tips Sent</div>
+            </div>
+            <div className="card-brutalist text-center">
+              <div className="text-4xl font-black mb-1">{stats.feeBps / 100}%</div>
+              <div className="text-sm uppercase font-bold tracking-wide">Platform Fee</div>
+            </div>
+          </motion.div>
+        )}
+
+        {/* Comparison table */}
+        <div className="card-brutalist overflow-x-auto mb-8">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b-2 border-black">
+                <th className="text-left py-4 px-4 font-black uppercase">Feature</th>
+                <th className="text-left py-4 px-4 font-black uppercase">Traditional</th>
+                <th className="text-left py-4 px-4 font-black uppercase bg-black text-white">Tipz</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comparisonRows.map((row) => (
+                <tr key={row.feature} className="border-b border-gray-300">
+                  <td className="py-4 px-4 font-bold">{row.feature}</td>
+                  <td className="py-4 px-4 text-gray-600">{row.traditional}</td>
+                  <td className={`py-4 px-4 font-bold ${row.highlight ? 'text-green-600' : ''}`}>
+                    {row.tipz}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="text-center"
+        >
+          <div className="inline-block card-brutalist bg-black text-white px-8 py-4">
+            <p className="text-2xl font-black">
+              {FALLBACK_STATS.feesSaved} SAVINGS | {FALLBACK_STATS.speedup} FASTER
+            </p>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default StatsSection;

--- a/frontend-scaffold/src/features/landing/TopCreatorsSection.tsx
+++ b/frontend-scaffold/src/features/landing/TopCreatorsSection.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Trophy } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useContract } from '@/hooks';
+import { LeaderboardEntry } from '@/types/contract';
+
+const MEDAL = ['🥇', '🥈', '🥉'];
+
+const TopCreatorsSection: React.FC = () => {
+  const [creators, setCreators] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { getLeaderboard } = useContract();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getLeaderboard(5)
+      .then(setCreators)
+      .catch(() => {
+        // Contract may not be deployed yet — render empty gracefully
+      })
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!loading && creators.length === 0) return null;
+
+  return (
+    <section className="py-20 px-4">
+      <div className="max-w-4xl mx-auto">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="text-5xl md:text-6xl font-black text-center mb-4"
+        >
+          TOP CREATORS
+        </motion.h2>
+        <motion.p
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.1 }}
+          className="text-center text-gray-600 mb-12"
+        >
+          The most-tipped creators on Tipz this week
+        </motion.p>
+
+        {loading ? (
+          <div className="space-y-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="card-brutalist animate-pulse h-16" />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {creators.map((creator, index) => (
+              <motion.button
+                key={creator.address}
+                initial={{ opacity: 0, x: -20 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: index * 0.08 }}
+                className="card-brutalist w-full flex items-center gap-4 text-left hover:-translate-y-0.5 transition-transform duration-150"
+                onClick={() => navigate(`/@${creator.username}`)}
+              >
+                <span className="text-2xl w-8 flex-shrink-0">
+                  {index < 3 ? MEDAL[index] : <Trophy size={20} />}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="font-black text-lg truncate">@{creator.username}</div>
+                  <div className="text-sm text-gray-600 truncate">
+                    Score: {creator.creditScore}
+                  </div>
+                </div>
+                <div className="text-right flex-shrink-0">
+                  <div className="font-bold">{creator.totalTipsReceived} XLM</div>
+                  <div className="text-xs text-gray-500 uppercase tracking-wide">received</div>
+                </div>
+              </motion.button>
+            ))}
+          </div>
+        )}
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.4 }}
+          className="text-center mt-10"
+        >
+          <button
+            className="btn-brutalist-outline"
+            onClick={() => navigate('/leaderboard')}
+          >
+            View Full Leaderboard →
+          </button>
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default TopCreatorsSection;

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+
+const LeaderboardPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="py-16 px-4 text-center">
+      <h1 className="text-4xl font-black mb-4">Leaderboard</h1>
+      <p className="text-gray-600 mb-8">Top creators ranked by tips — coming soon.</p>
+      <Button variant="outline" onClick={() => navigate('/')}>
+        Back to Home
+      </Button>
+    </div>
+  );
+};
+
+export default LeaderboardPage;

--- a/frontend-scaffold/src/features/profile/ProfileEditPage.tsx
+++ b/frontend-scaffold/src/features/profile/ProfileEditPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+
+const ProfileEditPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="py-16 px-4 text-center">
+      <h1 className="text-4xl font-black mb-4">Edit Profile</h1>
+      <p className="text-gray-600 mb-8">Profile editing — coming soon.</p>
+      <Button variant="outline" onClick={() => navigate('/profile')}>
+        Back to Profile
+      </Button>
+    </div>
+  );
+};
+
+export default ProfileEditPage;

--- a/frontend-scaffold/src/features/profile/ProfilePage.tsx
+++ b/frontend-scaffold/src/features/profile/ProfilePage.tsx
@@ -10,27 +10,27 @@ const ProfilePage: React.FC = () => {
     <div className="container mx-auto px-4 py-12 max-w-4xl">
       <div className="flex flex-col md:flex-row gap-12 items-start">
         <div className="w-full md:w-auto shrink-0 sticky top-24">
-          <ProfileCard 
-            handle="creator_preview" 
-            publicKey={publicKey || "G...WALLET"} 
+          <ProfileCard
+            handle="creator_preview"
+            publicKey={publicKey || 'G...WALLET'}
             bio="Setting up my decentralized tipping profile on Stellar Tipz! Stay tuned for more content."
-            onTip={() => console.log("Tip click")}
+            onTip={() => console.log('Tip click')}
           />
         </div>
 
         <div className="flex-1 space-y-8">
           <div>
             <h1 className="text-3xl font-black text-gray-900 mb-2">Profile Settings</h1>
-            <p className="text-gray-500">Customize how you appears to your supporters and manage your creator identity.</p>
+            <p className="text-gray-500">Customize how you appear to your supporters and manage your creator identity.</p>
           </div>
 
           <div className="grid gap-6">
-            <SettingsItem 
+            <SettingsItem
               icon={<Settings className="h-5 w-5 text-gray-400" />}
               label="Account Details"
               description="Update your handle, bio, and social links."
             />
-            <SettingsItem 
+            <SettingsItem
               icon={<ShieldCheck className="h-5 w-5 text-emerald-500" />}
               label="Verification"
               description="Get verified to build trust with your community."
@@ -47,7 +47,12 @@ const ProfilePage: React.FC = () => {
   );
 };
 
-const SettingsItem: React.FC<{ icon: React.ReactNode; label: string; description: string; status?: string }> = ({ icon, label, description, status }) => (
+const SettingsItem: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+  status?: string;
+}> = ({ icon, label, description, status }) => (
   <div className="bg-white border border-gray-200 rounded-2xl p-6 flex items-center justify-between hover:border-blue-200 transition-colors shadow-sm">
     <div className="flex items-center gap-4">
       <div className="h-12 w-12 bg-gray-50 rounded-xl flex items-center justify-center">{icon}</div>

--- a/frontend-scaffold/src/features/profile/RegisterForm.tsx
+++ b/frontend-scaffold/src/features/profile/RegisterForm.tsx
@@ -1,0 +1,196 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Input from '@/components/ui/Input';
+import Textarea from '@/components/ui/Textarea';
+import Button from '@/components/ui/Button';
+import TransactionStatus from '@/components/shared/TransactionStatus';
+import { useContract } from '@/hooks';
+import { useToastStore } from '@/store/toastStore';
+import { ProfileFormData } from '@/types/profile';
+
+type TxStatus = 'idle' | 'signing' | 'submitting' | 'confirming' | 'success' | 'error';
+
+interface FormErrors {
+  username?: string;
+  displayName?: string;
+  bio?: string;
+  imageUrl?: string;
+  xHandle?: string;
+}
+
+const USERNAME_RE = /^[a-z][a-z0-9_]{2,31}$/;
+
+function validate(data: ProfileFormData): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!USERNAME_RE.test(data.username)) {
+    errors.username =
+      'Username must be 3–32 chars, start with a letter, and use only lowercase letters, digits, or underscores.';
+  }
+
+  if (!data.displayName.trim() || data.displayName.length > 64) {
+    errors.displayName = 'Display name is required and must be 1–64 characters.';
+  }
+
+  if (data.bio.length > 280) {
+    errors.bio = 'Bio must be 280 characters or fewer.';
+  }
+
+  return errors;
+}
+
+const RegisterForm: React.FC = () => {
+  const [form, setForm] = useState<ProfileFormData>({
+    username: '',
+    displayName: '',
+    bio: '',
+    imageUrl: '',
+    xHandle: '',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [txStatus, setTxStatus] = useState<TxStatus>('idle');
+  const [txHash, setTxHash] = useState<string | undefined>(undefined);
+  const [txError, setTxError] = useState<string | undefined>(undefined);
+
+  const { registerProfile } = useContract();
+  const { addToast } = useToastStore();
+  const navigate = useNavigate();
+
+  const handleChange =
+    (field: keyof ProfileFormData) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setForm((prev) => ({ ...prev, [field]: e.target.value }));
+      if (errors[field]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }));
+      }
+    };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const validationErrors = validate(form);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    try {
+      setTxStatus('signing');
+      setTxError(undefined);
+      setTxHash(undefined);
+
+      const formData: ProfileFormData = {
+        ...form,
+        username: form.username.trim().toLowerCase(),
+        displayName: form.displayName.trim(),
+        bio: form.bio.trim(),
+        imageUrl: form.imageUrl.trim(),
+        xHandle: form.xHandle.trim().replace(/^@/, ''),
+      };
+
+      setTxStatus('submitting');
+      const hash = await registerProfile(formData);
+
+      setTxStatus('confirming');
+      setTxHash(hash);
+
+      setTxStatus('success');
+      addToast({ message: 'Profile registered successfully!', type: 'success', duration: 5000 });
+
+      setTimeout(() => navigate('/profile'), 1500);
+    } catch (err) {
+      setTxStatus('error');
+      setTxError(err instanceof Error ? err.message : 'Registration failed. Please try again.');
+    }
+  };
+
+  const isSubmitting = ['signing', 'submitting', 'confirming'].includes(txStatus);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-lg mx-auto">
+      {/* Username */}
+      <div>
+        <Input
+          label="Username"
+          placeholder="your_handle"
+          value={form.username}
+          onChange={handleChange('username')}
+          error={errors.username}
+          disabled={isSubmitting}
+          maxLength={32}
+          required
+        />
+        <p className="mt-1 text-xs text-gray-500">
+          Your profile will be at tipz.app/@{form.username || 'username'}
+        </p>
+      </div>
+
+      {/* Display Name */}
+      <Input
+        label="Display Name"
+        placeholder="Your Name"
+        value={form.displayName}
+        onChange={handleChange('displayName')}
+        error={errors.displayName}
+        disabled={isSubmitting}
+        maxLength={64}
+        required
+      />
+
+      {/* Bio */}
+      <Textarea
+        label="Bio"
+        placeholder="Tell supporters about yourself…"
+        value={form.bio}
+        onChange={handleChange('bio')}
+        error={errors.bio}
+        disabled={isSubmitting}
+        maxLength={280}
+        rows={4}
+      />
+
+      {/* X Handle */}
+      <Input
+        label="X (Twitter) Handle (optional)"
+        placeholder="@yourhandle"
+        value={form.xHandle}
+        onChange={handleChange('xHandle')}
+        error={errors.xHandle}
+        disabled={isSubmitting}
+      />
+
+      {/* Image URL */}
+      <Input
+        label="Profile Image URL (optional)"
+        placeholder="https://example.com/avatar.png"
+        type="url"
+        value={form.imageUrl}
+        onChange={handleChange('imageUrl')}
+        error={errors.imageUrl}
+        disabled={isSubmitting}
+      />
+
+      {/* Transaction status */}
+      {txStatus !== 'idle' && (
+        <TransactionStatus
+          status={txStatus}
+          txHash={txHash}
+          errorMessage={txError}
+          onRetry={() => setTxStatus('idle')}
+        />
+      )}
+
+      <Button
+        type="submit"
+        variant="primary"
+        size="lg"
+        disabled={isSubmitting || txStatus === 'success'}
+        className="w-full"
+      >
+        {isSubmitting ? 'Registering…' : 'Register Profile'}
+      </Button>
+    </form>
+  );
+};
+
+export default RegisterForm;

--- a/frontend-scaffold/src/features/profile/RegisterPage.tsx
+++ b/frontend-scaffold/src/features/profile/RegisterPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import RegisterForm from './RegisterForm';
+
+const RegisterPage: React.FC = () => {
+  return (
+    <div className="py-16 px-4">
+      <div className="max-w-lg mx-auto">
+        <h1 className="text-4xl font-black mb-2">Create Your Profile</h1>
+        <p className="text-gray-600 mb-10">
+          Register once on-chain. Supporters will find you at tipz.app/@you.
+        </p>
+        <RegisterForm />
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/frontend-scaffold/src/features/tipping/TipPage.tsx
+++ b/frontend-scaffold/src/features/tipping/TipPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+
+const TipPage: React.FC = () => {
+  const { username } = useParams<{ username: string }>();
+  const navigate = useNavigate();
+
+  return (
+    <div className="py-16 px-4 text-center">
+      <h1 className="text-4xl font-black mb-4">@{username}</h1>
+      <p className="text-gray-600 mb-8">Tipping page — coming soon.</p>
+      <Button variant="outline" onClick={() => navigate('/')}>
+        Back to Home
+      </Button>
+    </div>
+  );
+};
+
+export default TipPage;

--- a/frontend-scaffold/src/routes.tsx
+++ b/frontend-scaffold/src/routes.tsx
@@ -1,0 +1,60 @@
+import React, { lazy, Suspense } from 'react';
+import { RouteObject } from 'react-router-dom';
+import PageTransition from '@/components/shared/PageTransition';
+import ProtectedRoute from '@/components/shared/ProtectedRoute';
+import Loader from '@/components/ui/Loader';
+
+const LandingPage = lazy(() => import('@/features/landing/LandingPage'));
+const RegisterPage = lazy(() => import('@/features/profile/RegisterPage'));
+const ProfilePage = lazy(() => import('@/features/profile/ProfilePage'));
+const ProfileEditPage = lazy(() => import('@/features/profile/ProfileEditPage'));
+const DashboardPage = lazy(() => import('@/features/dashboard/DashboardPage'));
+const LeaderboardPage = lazy(() => import('@/features/leaderboard/LeaderboardPage'));
+const TipPage = lazy(() => import('@/features/tipping/TipPage'));
+
+const PageLoader: React.FC = () => (
+  <div className="flex-1 flex items-center justify-center py-20">
+    <Loader />
+  </div>
+);
+
+const wrap = (element: React.ReactElement) => (
+  <Suspense fallback={<PageLoader />}>
+    <PageTransition>{element}</PageTransition>
+  </Suspense>
+);
+
+const protect = (element: React.ReactElement) => (
+  <ProtectedRoute>{wrap(element)}</ProtectedRoute>
+);
+
+export const routes: RouteObject[] = [
+  {
+    path: '/',
+    element: wrap(<LandingPage />),
+  },
+  {
+    path: '/register',
+    element: wrap(<RegisterPage />),
+  },
+  {
+    path: '/@:username',
+    element: wrap(<TipPage />),
+  },
+  {
+    path: '/leaderboard',
+    element: wrap(<LeaderboardPage />),
+  },
+  {
+    path: '/profile',
+    element: protect(<ProfilePage />),
+  },
+  {
+    path: '/profile/edit',
+    element: protect(<ProfileEditPage />),
+  },
+  {
+    path: '/dashboard',
+    element: protect(<DashboardPage />),
+  },
+];


### PR DESCRIPTION
## Summary

Implements four frontend issues in a single branch — one merge closes all.

- **#108** — Update `App.tsx` with route config, global providers, and error boundary
- **#118** — Create `CTASection.tsx` at the bottom of the landing page
- **#119** — Assemble the complete landing page from extracted section components
- **#120** — Create `RegisterForm.tsx` for on-chain profile registration

## Changes

### Issue #108 — App shell & routing
- `src/routes.tsx`: lazy-loaded route config for all app routes (`/`, `/register`, `/@:username`, `/leaderboard`, `/profile`, `/profile/edit`, `/dashboard`)
- `src/components/shared/ProtectedRoute.tsx`: redirects unauthenticated users to `/` for protected routes (`/profile`, `/profile/edit`, `/dashboard`)
- `src/components/shared/ToastContainer.tsx`: renders active toasts from `useToastStore` in a fixed bottom-right stack
- `src/App.tsx`: wrapped with `ErrorBoundary`, `ToastContainer` added outside layout, routes driven by `routes.tsx`

### Issue #118 — CTA section
- `src/features/landing/CTASection.tsx`: "Start Receiving Tips Today" heading, live `totalCreators` count from contract (graceful fallback if not deployed), "Create Profile" and "Browse Creators" buttons

### Issue #119 — Complete landing page
- `src/features/landing/HeroSection.tsx`: animated hero extracted from monolithic `LandingPage.tsx`
- `src/features/landing/FeaturesSection.tsx`: "Why Tipz?" 6-card grid
- `src/features/landing/StatsSection.tsx`: live contract stats + Tipz vs Traditional comparison table
- `src/features/landing/TopCreatorsSection.tsx`: top-5 leaderboard from contract with loading skeleton
- `src/features/landing/LandingPage.tsx`: assembles all sections in order with `Divider` separators; smooth scroll target `#how-it-works`

### Issue #120 — Profile registration form
- `src/features/profile/RegisterForm.tsx`: username/display name/bio/X handle/image URL fields, client-side validation (username regex, display name length, bio 280-char limit), `useContract().registerProfile()` call, `TransactionStatus` during submission, toast + redirect to `/profile` on success

## Test plan

- [ ] Landing page renders all sections with dividers; "Learn More" scrolls to `#how-it-works`
- [ ] Unauthenticated visit to `/profile` or `/dashboard` redirects to `/`
- [ ] Toast appears and dismisses correctly
- [ ] Register form shows inline validation errors before submitting
- [ ] Register form shows `TransactionStatus` states during wallet signing
- [ ] Page renders gracefully when contract is not deployed (no crashes, fallback text shown)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

Closes #108
Closes #118
Closes #119
Closes #120