### PR TITLE
feat: implement tip flow UI and credit breakdown constants

### DIFF
--- a/contracts/tipz/src/credit.rs
+++ b/contracts/tipz/src/credit.rs
@@ -36,22 +36,86 @@ use soroban_sdk::{Address, Env};
 
 use crate::errors::ContractError;
 use crate::storage;
-use crate::types::{CreditTier, Profile};
+use crate::types::{CreditBreakdown, CreditTier, Profile};
 
 /// Base score awarded to every registered profile.
 /// Places new creators in the Silver tier (40–59) by default.
 pub const BASE_SCORE: u32 = 40;
 
-/// Tip volume (in stroops) that yields the maximum tip sub-score of 100.
-/// 1_000_000_000 stroops = 100 XLM.
-const TIP_VOLUME_CAP: i128 = 1_000_000_000;
+/// Maximum possible credit score.
+pub const MAX_SCORE: u32 = 100;
 
-/// Stroops per XLM (used to normalise tip volume to 0–100).
-const STROOPS_PER_XLM: i128 = 10_000_000;
+/// Weight (percent) applied to the tip sub-score.
+pub const TIP_WEIGHT: u32 = 20;
 
-/// Seconds in one day — the minimum account age for the age component to
+/// Weight (percent) applied to the X metrics sub-score.
+pub const X_WEIGHT: u32 = 30;
+
+/// Weight (percent) applied to the account age sub-score.
+pub const AGE_WEIGHT: u32 = 10;
+
+/// Divisor used to transform stroop tip volume into a 0-100 sub-score.
+pub const TIP_DIVISOR: i128 = 10_000_000;
+
+/// Divisor used to map followers into the follower contribution.
+pub const FOLLOWER_DIVISOR: u32 = 50;
+
+/// Divisor used to map engagement average into the engagement contribution.
+pub const ENGAGEMENT_DIVISOR: u32 = 10;
+
+/// Divisor used to map account age in days into a 0-100 age sub-score.
+pub const AGE_DIVISOR: u32 = 10;
+
+/// Hard cap for normalized tip sub-score.
+pub const TIP_CAP: u32 = 100;
+
+/// Hard cap applied to each X sub-component (followers and engagement).
+pub const X_SUB_CAP: u32 = 50;
+
+/// Hard cap for normalized age sub-score.
+pub const AGE_CAP: u32 = 100;
+
+/// Tip volume (in stroops) that yields the maximum tip sub-score.
+const TIP_VOLUME_CAP: i128 = (TIP_CAP as i128) * TIP_DIVISOR;
+
+/// Seconds in one day - the minimum account age for the age component to
 /// contribute anything to the score.
 const SECONDS_PER_DAY: u64 = 86_400;
+
+/// Build the weighted credit component breakdown for `profile` at `now`.
+pub fn get_credit_breakdown_for_profile(profile: &Profile, now: u64) -> CreditBreakdown {
+    let tip_sub: u32 = (profile.total_tips_received.clamp(0, TIP_VOLUME_CAP) / TIP_DIVISOR) as u32;
+
+    let x_sub: u32 = if profile.x_followers == 0 && profile.x_engagement_avg == 0 {
+        0
+    } else {
+        let follower_part = (profile.x_followers / FOLLOWER_DIVISOR).min(X_SUB_CAP);
+        let engagement_part = (profile.x_engagement_avg / ENGAGEMENT_DIVISOR).min(X_SUB_CAP);
+
+        follower_part + engagement_part
+    };
+
+    let age_sub: u32 =
+        if now <= profile.registered_at || now - profile.registered_at < SECONDS_PER_DAY {
+            0
+        } else {
+            let age_days = (now - profile.registered_at) / SECONDS_PER_DAY;
+            (age_days as u32 / AGE_DIVISOR).min(AGE_CAP)
+        };
+
+    let tip_score = tip_sub * TIP_WEIGHT / MAX_SCORE;
+    let x_score = x_sub * X_WEIGHT / MAX_SCORE;
+    let age_score = age_sub * AGE_WEIGHT / MAX_SCORE;
+    let total = (BASE_SCORE + tip_score + x_score + age_score).min(MAX_SCORE);
+
+    CreditBreakdown {
+        base: BASE_SCORE,
+        tip_score,
+        x_score,
+        age_score,
+        total,
+    }
+}
 
 /// Compute the credit score (0–100) for `profile` at the given `now` timestamp
 /// (seconds since the Unix epoch, obtained from `env.ledger().timestamp()`).
@@ -64,45 +128,7 @@ const SECONDS_PER_DAY: u64 = 86_400;
 /// | all X metric fields are 0                | X component = 0                |
 /// | account age < 1 day                      | age component = 0              |
 pub fn calculate_credit_score(profile: &Profile, now: u64) -> u32 {
-    // ── Tip volume sub-score (0–100) ─────────────────────────────────────────
-    // Clamp negative balances to 0 (defensive), then cap at TIP_VOLUME_CAP so
-    // arbitrarily large values don't overflow the cast to u32.
-    let tip_sub: u32 =
-        (profile.total_tips_received.clamp(0, TIP_VOLUME_CAP) / STROOPS_PER_XLM) as u32;
-    // tip_sub is guaranteed 0..=100
-
-    // ── X metrics sub-score (0–100) ──────────────────────────────────────────
-    // All three X fields at 0 → the whole component contributes 0.
-    let x_sub: u32 = if profile.x_followers == 0 && profile.x_engagement_avg == 0 {
-        0
-    } else {
-        // Followers half (0–50): saturates at 2 500 followers.
-        let follower_part = (profile.x_followers / 50).min(50);
-
-        // Engagement half (0–50): saturates at an average engagement of 500.
-        let engagement_part = (profile.x_engagement_avg / 10).min(50);
-
-        follower_part + engagement_part // 0..=100
-    };
-
-    // ── Account age sub-score (0–100) ─────────────────────────────────────────
-    // Age component is 0 when account is less than one day old.
-    // Reaches 100 at 1 000 days (~2.7 years).
-    let age_sub: u32 =
-        if now <= profile.registered_at || now - profile.registered_at < SECONDS_PER_DAY {
-            0
-        } else {
-            let age_days = (now - profile.registered_at) / SECONDS_PER_DAY;
-            (age_days as u32 / 10).min(100)
-        };
-
-    // ── Weighted contributions ────────────────────────────────────────────────
-    let tip_pts = tip_sub * 20 / 100; // 0–20
-    let x_pts = x_sub * 30 / 100; // 0–30
-    let age_pts = age_sub * 10 / 100; // 0–10
-
-    // Total is capped at 100.  Maximum possible: 40 + 20 + 30 + 10 = 100.
-    (BASE_SCORE + tip_pts + x_pts + age_pts).min(100)
+    get_credit_breakdown_for_profile(profile, now).total
 }
 
 /// Map a credit score (0–100) to its [`CreditTier`].
@@ -136,4 +162,18 @@ pub fn get_credit_tier(env: &Env, address: &Address) -> Result<(u32, CreditTier)
     let tier = get_tier(score);
 
     Ok((score, tier))
+}
+
+/// Load the profile for `address` and return the score component breakdown.
+pub fn get_credit_breakdown(
+    env: &Env,
+    address: &Address,
+) -> Result<CreditBreakdown, ContractError> {
+    if !storage::has_profile(env, address) {
+        return Err(ContractError::NotRegistered);
+    }
+
+    let profile: Profile = storage::get_profile(env, address);
+    let now = env.ledger().timestamp();
+    Ok(get_credit_breakdown_for_profile(&profile, now))
 }

--- a/contracts/tipz/src/fees.rs
+++ b/contracts/tipz/src/fees.rs
@@ -44,6 +44,8 @@ pub fn calculate_fee(amount: i128, fee_bps: u32) -> Result<(i128, i128), Contrac
         .checked_sub(fee)
         .ok_or(ContractError::OverflowError)?;
 
+    debug_assert_eq!(fee + net, amount);
+
     Ok((fee, net))
 }
 

--- a/contracts/tipz/src/lib.rs
+++ b/contracts/tipz/src/lib.rs
@@ -33,7 +33,7 @@ mod test;
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 use crate::errors::ContractError;
-use crate::types::{ContractStats, CreditTier, LeaderboardEntry, Profile, Tip};
+use crate::types::{ContractStats, CreditBreakdown, CreditTier, LeaderboardEntry, Profile, Tip};
 
 #[contract]
 pub struct TipzContract;
@@ -197,6 +197,14 @@ impl TipzContract {
     /// `address`.
     pub fn get_credit_tier(env: Env, address: Address) -> Result<(u32, CreditTier), ContractError> {
         credit::get_credit_tier(&env, &address)
+    }
+
+    /// Return the weighted credit score breakdown for a registered profile.
+    pub fn get_credit_breakdown(
+        env: Env,
+        address: Address,
+    ) -> Result<CreditBreakdown, ContractError> {
+        credit::get_credit_breakdown(&env, &address)
     }
 
     // ──────────────────────────────────────────────

--- a/contracts/tipz/src/types.rs
+++ b/contracts/tipz/src/types.rs
@@ -87,6 +87,22 @@ pub enum CreditTier {
     Diamond,
 }
 
+/// Component-level breakdown of a profile credit score.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreditBreakdown {
+    /// Fixed score every registered profile receives.
+    pub base: u32,
+    /// Weighted contribution from lifetime tips.
+    pub tip_score: u32,
+    /// Weighted contribution from X metrics.
+    pub x_score: u32,
+    /// Weighted contribution from account age.
+    pub age_score: u32,
+    /// Final score after summing all components (capped at 100).
+    pub total: u32,
+}
+
 /// Global contract statistics.
 #[contracttype]
 #[derive(Clone, Debug)]

--- a/frontend-scaffold/src/features/tipping/TipPage.tsx
+++ b/frontend-scaffold/src/features/tipping/TipPage.tsx
@@ -10,14 +10,15 @@ import Avatar from "../../components/ui/Avatar";
 import Button from "../../components/ui/Button";
 import Card from "../../components/ui/Card";
 import Textarea from "../../components/ui/Textarea";
-import { useTipz, useWallet } from "../../hooks";
+import { useWallet } from "../../hooks";
 import { mockProfile, mockTips } from "../mockData";
 import TipAmountInput from "./TipAmountInput";
+import TipResult from "./TipResult";
+import { useTipFlow } from "./useTipFlow";
 
 const TipPage: React.FC = () => {
   const { username } = useParams<{ username: string }>();
   const { connected, connect } = useWallet();
-  const { sendTip, txHash, txStatus, error, sending, reset } = useTipz();
   const [amount, setAmount] = useState("5");
   const [message, setMessage] = useState("");
 
@@ -25,10 +26,11 @@ const TipPage: React.FC = () => {
     ...mockProfile,
     username: username || mockProfile.username,
   };
+  const { step, goToConfirm, confirmAndSign, reset, error, txHash } = useTipFlow(creator.owner);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await sendTip(creator.owner, amount, message);
+    goToConfirm(amount, message);
   };
 
   return (
@@ -93,8 +95,18 @@ const TipPage: React.FC = () => {
             </div>
           )}
 
-          <form className="space-y-4" onSubmit={handleSubmit}>
-            <TipAmountInput amount={amount} onChange={setAmount} balance={creator.balance} />
+          {step === "success" || step === "error" ? (
+            <TipResult
+              status={step === "success" ? "success" : "error"}
+              txHash={txHash ?? undefined}
+              amount={amount}
+              creator={creator}
+              errorMessage={error ?? undefined}
+              onPrimaryAction={reset}
+            />
+          ) : (
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <TipAmountInput amount={amount} onChange={setAmount} balance={creator.balance} />
 
             <Textarea
               label="Message"
@@ -108,12 +120,12 @@ const TipPage: React.FC = () => {
               {connected ? (
                 <Button
                   type="submit"
-                  loading={sending}
+                  loading={step === "signing" || step === "submitting"}
                   icon={<HeartHandshake size={18} />}
                   iconRight={<ArrowRight size={18} />}
                   className="sm:flex-1"
                 >
-                  Send tip
+                  {step === "confirm" ? "Continue" : "Send tip"}
                 </Button>
               ) : (
                 <Button
@@ -130,14 +142,33 @@ const TipPage: React.FC = () => {
                 Clear
               </Button>
             </div>
-          </form>
+            </form>
+          )}
 
-          <TransactionStatus
-            status={txStatus}
-            txHash={txHash ?? undefined}
-            errorMessage={error ?? undefined}
-            onRetry={() => void sendTip(creator.owner, amount, message)}
-          />
+          {step === "confirm" && (
+            <div className="space-y-3 border-2 border-black bg-yellow-50 p-4">
+              <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-600">Confirm tip</p>
+              <p className="text-sm font-bold text-gray-700">
+                You are about to send {amount} XLM to @{creator.username}.
+              </p>
+              <div className="flex gap-2">
+                <Button type="button" onClick={() => void confirmAndSign()} icon={<HeartHandshake size={16} />}>
+                  Confirm and sign
+                </Button>
+                <Button type="button" variant="outline" onClick={reset}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {step === "signing" || step === "submitting" ? (
+            <TransactionStatus
+              status={step === "signing" ? "signing" : "submitting"}
+              txHash={txHash ?? undefined}
+              errorMessage={error ?? undefined}
+            />
+          ) : null}
         </Card>
       </section>
 

--- a/frontend-scaffold/src/features/tipping/TipResult.tsx
+++ b/frontend-scaffold/src/features/tipping/TipResult.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import type { Profile } from "../../types";
+import Button from "../../components/ui/Button";
+
+interface TipResultProps {
+  status: "success" | "error";
+  txHash?: string;
+  amount?: string;
+  creator?: Profile;
+  errorMessage?: string;
+  onPrimaryAction?: () => void;
+}
+
+const explorerBase = "https://stellar.expert/explorer/testnet/tx/";
+
+const TipResult: React.FC<TipResultProps> = ({
+  status,
+  txHash,
+  amount,
+  creator,
+  errorMessage,
+  onPrimaryAction,
+}) => {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 16, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: 0.35, ease: "easeOut" }}
+      className="relative overflow-hidden border-2 border-black bg-white p-6"
+    >
+      {status === "success" && (
+        <>
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,#fde68a_0%,transparent_35%),radial-gradient(circle_at_80%_15%,#bfdbfe_0%,transparent_32%),radial-gradient(circle_at_60%_80%,#fecaca_0%,transparent_30%)]" />
+          <div className="pointer-events-none absolute inset-0">
+            <span className="confetti confetti-a" />
+            <span className="confetti confetti-b" />
+            <span className="confetti confetti-c" />
+            <span className="confetti confetti-d" />
+            <span className="confetti confetti-e" />
+          </div>
+        </>
+      )}
+
+      <div className="relative z-10 space-y-4">
+        {status === "success" ? (
+          <>
+            <h3 className="text-3xl font-black uppercase tracking-tight">Tip sent! 🎉</h3>
+            <p className="text-sm font-medium text-gray-700">
+              {amount ? `${amount} XLM sent` : "Your tip was sent"}
+              {creator ? ` to ${creator.displayName}` : ""}.
+            </p>
+            {txHash && (
+              <a
+                href={`${explorerBase}${txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex text-sm font-black uppercase underline"
+              >
+                View transaction hash
+              </a>
+            )}
+            <Button type="button" onClick={onPrimaryAction}>
+              Send Another
+            </Button>
+          </>
+        ) : (
+          <>
+            <h3 className="text-2xl font-black uppercase text-red-700">Payment failed</h3>
+            <p className="text-sm font-medium text-gray-700">
+              {errorMessage || "Something went wrong while sending your tip."}
+            </p>
+            <Button type="button" variant="outline" onClick={onPrimaryAction}>
+              Try Again
+            </Button>
+          </>
+        )}
+      </div>
+
+      <AnimatePresence>
+        {status === "success" && (
+          <motion.style
+            key="confetti-style"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            {`
+              .confetti {
+                position: absolute;
+                width: 10px;
+                height: 16px;
+                opacity: 0.9;
+                animation: tip-result-fall 1.8s ease-in infinite;
+              }
+              .confetti-a { left: 8%; top: -12%; background: #f97316; animation-delay: 0s; }
+              .confetti-b { left: 26%; top: -15%; background: #2563eb; animation-delay: 0.3s; }
+              .confetti-c { left: 50%; top: -10%; background: #16a34a; animation-delay: 0.15s; }
+              .confetti-d { left: 72%; top: -16%; background: #ef4444; animation-delay: 0.45s; }
+              .confetti-e { left: 90%; top: -11%; background: #eab308; animation-delay: 0.6s; }
+              @keyframes tip-result-fall {
+                0% { transform: translateY(0) rotate(0deg); }
+                100% { transform: translateY(180px) rotate(230deg); }
+              }
+            `}
+          </motion.style>
+        )}
+      </AnimatePresence>
+    </motion.section>
+  );
+};
+
+export default TipResult;

--- a/frontend-scaffold/src/features/tipping/useTipFlow.ts
+++ b/frontend-scaffold/src/features/tipping/useTipFlow.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useTipz } from "../../hooks";
+
+export type TipFlowStep = "form" | "confirm" | "signing" | "submitting" | "success" | "error";
+
+interface UseTipFlowReturn {
+  step: TipFlowStep;
+  goToConfirm: (amount: string, message: string) => void;
+  confirmAndSign: () => Promise<void>;
+  reset: () => void;
+  error: string | null;
+  txHash: string | null;
+}
+
+export const useTipFlow = (creatorAddress: string): UseTipFlowReturn => {
+  const { sendTip, txHash, txStatus, error, reset: resetTipz } = useTipz();
+  const [step, setStep] = useState<TipFlowStep>("form");
+  const [draft, setDraft] = useState<{ amount: string; message: string } | null>(null);
+
+  useEffect(() => {
+    if (txStatus === "signing") {
+      setStep("signing");
+      return;
+    }
+
+    if (txStatus === "submitting" || txStatus === "confirming") {
+      setStep("submitting");
+      return;
+    }
+
+    if (txStatus === "success") {
+      setStep("success");
+      return;
+    }
+
+    if (txStatus === "error") {
+      setStep("error");
+    }
+  }, [txStatus]);
+
+  const goToConfirm = useCallback((amount: string, message: string) => {
+    setDraft({ amount, message });
+    setStep("confirm");
+  }, []);
+
+  const confirmAndSign = useCallback(async () => {
+    if (!draft) {
+      setStep("form");
+      return;
+    }
+
+    await sendTip(creatorAddress, draft.amount, draft.message);
+  }, [creatorAddress, draft, sendTip]);
+
+  const reset = useCallback(() => {
+    setStep("form");
+    setDraft(null);
+    resetTipz();
+  }, [resetTipz]);
+
+  return useMemo(
+    () => ({
+      step,
+      goToConfirm,
+      confirmAndSign,
+      reset,
+      error,
+      txHash,
+    }),
+    [step, goToConfirm, confirmAndSign, reset, error, txHash],
+  );
+};


### PR DESCRIPTION
## Summary
- implement tipping flow orchestration with `useTipFlow` and integrate it into `TipPage` for form -> confirm -> signing/submitting -> success/error progression
- add a dedicated `TipResult` screen with Framer Motion entrance and CSS confetti for success plus retry UX for failures
- extract credit-score magic numbers into named constants, add `CreditBreakdown` type, expose `get_credit_breakdown`, and add an invariant `debug_assert` in fee calculation

Closes #226
Closes #225
Closes #139
Closes #140