### PR TITLE
Created StatCard component for dashboard metrics

### DIFF
--- a/frontend-scaffold/src/components/ui/StartCard.tsx
+++ b/frontend-scaffold/src/components/ui/StartCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+interface ChangeProps {
+  value: number;
+  positive: boolean;
+}
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  icon?: React.ReactNode;
+  change?: ChangeProps;
+  className?: string;
+}
+
+export const StatCard: React.FC<StatCardProps> = ({
+  label,
+  value,
+  icon,
+  change,
+  className = '',
+}) => {
+  const isPositive = change?.positive ?? false;
+  const changeValue = Math.abs(change?.value ?? 0);
+  const formattedChange = `${isPositive ? '+' : '-'}${changeValue}%`;
+
+  return (
+    <div
+      className={`
+        bg-white dark:bg-zinc-950 
+        border-4 border-black dark:border-white 
+        p-6 
+        shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] 
+        dark:shadow-[8px_8px_0px_0px_rgba(255,255,255,0.2)]
+        hover:shadow-[12px_12px_0px_0px_rgba(0,0,0,1)] 
+        dark:hover:shadow-[12px_12px_0px_0px_rgba(255,255,255,0.3)]
+        transition-all duration-200
+        flex flex-col
+        ${className}
+      `}
+    >
+      {/* Label + Icon */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-sm font-mono uppercase tracking-[3px] text-zinc-500 dark:text-zinc-400 font-bold">
+          {label}
+        </div>
+        
+        {icon && <div className="text-3xl">{icon}</div>}
+      </div>
+
+      {/* Value */}
+      <div className="text-5xl font-black tracking-tighter text-black dark:text-white mb-4">
+        {value}
+      </div>
+
+      {/* Change Indicator */}
+      {change && (
+        <div
+          className={`flex items-center gap-2 text-sm font-semibold ${
+            isPositive 
+              ? 'text-emerald-600 dark:text-emerald-400' 
+              : 'text-red-600 dark:text-red-400'
+          }`}
+        >
+          <span className="text-xl">
+            {isPositive ? '↑' : '↓'}
+          </span>
+          <span>{formattedChange}</span>
+          <span className="text-zinc-400 font-normal text-xs">from last period</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StatCard;


### PR DESCRIPTION
Closes #87  
This PR introduces a new StatCard component – a reusable, visually distinctive card designed to display key metrics (e.g., dashboard stats). It follows a neubrutalist design language with bold borders, strong shadows, dark mode support, and optional trend indicators.
Features
a. Customizable via props:
label: string – The card's title (uppercased, monospace font)
value: string | number – The main metric to display
icon: React.ReactNode – Optional icon rendered on the top-right corner
change: { value: number; positive: boolean } – Optional trend data (percent change, direction)
className: string – Additional Tailwind classes for layout overrides
b. Responsive & Accessible: Uses semantic HTML, scalable typography, and interactive hover effects.
c. Dark Mode Ready: Automatically adapts colors and shadows when dark mode is active.
d. Trend Indicators: Displays a green upward arrow / red downward arrow with the percentage change and a “from last period” label.