### PR TITLE
feat(frontend): add dashboard earnings and leaderboard podium

### DIFF
--- a/frontend-scaffold/src/features/dashboard/BalanceCard.tsx
+++ b/frontend-scaffold/src/features/dashboard/BalanceCard.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+import AmountDisplay from "../../components/shared/AmountDisplay";
+import Button from "../../components/ui/Button";
+
+interface BalanceCardProps {
+  balance: string;
+  feeBps: number;
+  onWithdraw: () => void;
+}
+
+const BalanceCard: React.FC<BalanceCardProps> = ({
+  balance,
+  feeBps,
+  onWithdraw,
+}) => {
+  return (
+    <section
+      className="space-y-5 border-[4px] border-black bg-[#fff2b2] p-6 sm:p-8"
+      style={{ boxShadow: "10px 10px 0px 0px rgba(0,0,0,1)" }}
+    >
+      <div className="space-y-2">
+        <p className="text-xs font-black uppercase tracking-[0.28em] text-gray-600">
+          Available for withdrawal
+        </p>
+        <AmountDisplay
+          amount={balance}
+          className="block text-4xl sm:text-5xl lg:text-6xl"
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <p className="text-sm font-bold text-gray-700">
+          Withdrawal fee: {(feeBps / 100).toFixed(2)}%
+        </p>
+        <Button className="w-full sm:w-auto" onClick={onWithdraw}>
+          Withdraw
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default BalanceCard;

--- a/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
+++ b/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
@@ -1,206 +1,27 @@
-import React from 'react';
-import { ArrowUpRight, Coins, LayoutDashboard, Wallet } from 'lucide-react';
-import { Navigate } from 'react-router-dom';
+import React from "react";
+import { LayoutDashboard, Settings, Wallet } from "lucide-react";
+import { Link } from "react-router-dom";
 
 import PageContainer from "../../components/layout/PageContainer";
-import AmountDisplay from "../../components/shared/AmountDisplay";
-import CreditBadge from "../../components/shared/CreditBadge";
-import TipCard from "../../components/shared/TipCard";
 import WalletConnect from "../../components/shared/WalletConnect";
+import Button from "../../components/ui/Button";
 import Card from "../../components/ui/Card";
 import EmptyState from "../../components/ui/EmptyState";
-import Pagination from "../../components/ui/Pagination";
-import { mockProfile, mockTips } from "../mockData";
-import EarningsChart from "./EarningsChart";
-import QRCode from "./QRCode";
+import Tabs from "../../components/ui/Tabs";
+import { usePageTitle } from "../../hooks/usePageTitle";
+import { useDashboard } from "../../hooks/useDashboard";
+import { useWalletStore } from "../../store/walletStore";
+import { mockProfile } from "../mockData";
+import EarningsTab from "./EarningsTab";
+import OverviewTab from "./OverviewTab";
+import TipsTab from "./TipsTab";
 
 const DashboardPage: React.FC = () => {
-  const { connected } = useWallet();
-  const { profile, loading, isRegistered } = useProfile();
-
-  if (!connected) {
-    return <Navigate to="/" replace />;
-  }
-
-  if (!loading && !isRegistered) {
-    return <Navigate to="/register" replace />;
-  }
-
-  const creator = profile ?? mockProfile;
-
-  const tabs = [
-      {
-        id: 'overview',
-        label: 'Overview',
-        content: (
-          <div className="space-y-6 pt-6">
-            <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-              <Card className="space-y-2">
-                <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Available balance</p>
-                <AmountDisplay amount={creator.balance} className="text-2xl" />
-              </Card>
-              <Card className="space-y-2 bg-yellow-100">
-                <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Lifetime volume</p>
-                <AmountDisplay amount={creator.totalTipsReceived} className="text-2xl" />
-              </Card>
-              <Card className="space-y-2">
-                <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Supporters</p>
-                <p className="text-3xl font-black">{creator.totalTipsCount}</p>
-              </Card>
-              <Card className="space-y-2">
-                <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Credit score</p>
-                <CreditBadge score={creator.creditScore} />
-              </Card>
-            </section>
-
-            <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-              <Card className="space-y-4" padding="lg">
-                <div className="flex items-center justify-between gap-4">
-                  <h2 className="text-2xl font-black uppercase">Recent earnings</h2>
-                </div>
-
-                {mockTips.length === 0 ? (
-                  <EmptyState
-                    icon={<Coins />}
-                    title="No earnings yet"
-                    description="Once tips start landing, your payout history will show up here."
-                  />
-                ) : (
-                  <div className="space-y-4">
-                    {mockTips.slice(0, 3).map((tip) => (
-                      <TipCard key={`${tip.from}-${tip.timestamp}`} tip={tip} showReceiver={false} />
-                    ))}
-                  </div>
-                )}
-              </Card>
-
-              <div className="space-y-6">
-                <Card className="space-y-4" padding="lg">
-                  <h2 className="text-xl font-black uppercase">Withdrawal status</h2>
-                  <div className="border-2 border-black bg-white p-4">
-                    <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Ready to withdraw</p>
-                    <AmountDisplay amount={creator.balance} className="mt-2 block text-xl" />
-                  </div>
-                  <p className="text-sm font-medium leading-6 text-gray-700">
-                    Withdrawal execution is still placeholder-backed in the scaffold, but the dashboard now makes the flow visible.
-                  </p>
-                </Card>
-
-                <Card className="space-y-4" padding="lg">
-                  <h2 className="text-xl font-black uppercase">Growth signals</h2>
-                  <div className="grid gap-3">
-                    <div className="flex items-center justify-between border-2 border-black p-3">
-                      <span className="inline-flex items-center gap-2 text-sm font-bold">
-                        <Wallet size={16} />
-                        Returning supporters
-                      </span>
-                      <span className="text-lg font-black">38%</span>
-                    </div>
-                    <div className="flex items-center justify-between border-2 border-black p-3">
-                      <span className="inline-flex items-center gap-2 text-sm font-bold">
-                        <ArrowUpRight size={16} />
-                        Weekly tip volume
-                      </span>
-                      <span className="text-lg font-black">+14%</span>
-                    </div>
-                  </div>
-                </Card>
-              </div>
-            </section>
-          </div>
-        ),
-      },
-      {
-        id: 'tips',
-        label: 'Tips',
-        content: <div className="pt-6"><TipHistory /></div>,
-      },
-      {
-        id: 'earnings',
-        label: 'Earnings',
-        content: (
-          <div className="pt-6">
-            <Card>
-              <p className="text-sm font-bold text-gray-700">Earnings insights module is scaffolded and ready for contract-backed analytics.</p>
-            </Card>
-          </div>
-        ),
-      },
-      {
-        id: 'settings',
-        label: 'Settings',
-        content: (
-          <div className="pt-6">
-            <Card>
-              <p className="text-sm font-bold text-gray-700">Creator settings panel placeholder. Wallet and profile controls will land here.</p>
-            </Card>
-          </div>
-        ),
-      },
-    ];
-
-  return (
-    <div className="space-y-6 pt-6">
-      {/* Profile info */}
-      <Card className="space-y-3" padding="lg">
-        <h2 className="text-xl font-black uppercase">Profile</h2>
-        <div className="grid gap-2 text-sm">
-          <div className="flex justify-between border-b border-gray-200 pb-2">
-            <span className="font-bold uppercase text-gray-500">Username</span>
-            <span className="font-black">@{profile.username}</span>
-          </div>
-          <div className="flex justify-between border-b border-gray-200 pb-2">
-            <span className="font-bold uppercase text-gray-500">Display name</span>
-            <span className="font-black">{profile.displayName || "—"}</span>
-          </div>
-          {profile.xHandle && (
-            <div className="flex justify-between border-b border-gray-200 pb-2">
-              <span className="font-bold uppercase text-gray-500">X handle</span>
-              <span className="font-black">@{profile.xHandle}</span>
-            </div>
-          )}
-        </div>
-        <Link to="/profile/edit">
-          <Button variant="outline" size="sm">Edit profile</Button>
-        </Link>
-      </Card>
-
-      {/* Share link */}
-      <Card className="space-y-3" padding="lg">
-        <h2 className="text-xl font-black uppercase">Share your tip link</h2>
-        <ShareLink username={profile.username} />
-      </Card>
-
-      {/* QR code placeholder */}
-      <Card className="space-y-3" padding="lg">
-        <div className="flex items-center gap-2">
-          <QrCode size={20} />
-          <h2 className="text-xl font-black uppercase">QR code</h2>
-        </div>
-        <p className="text-sm text-gray-600">
-          Scan to open your tip page: <span className="font-bold">{tipUrl}</span>
-        </p>
-        <div className="flex h-32 w-32 items-center justify-center border-2 border-black bg-gray-100">
-          <div className="text-center">
-            <QrCode size={48} className="mx-auto text-gray-400" />
-            <p className="mt-1 text-[10px] font-bold uppercase text-gray-400">QR coming soon</p>
-          </div>
-        </div>
-      </Card>
-    </div>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Main DashboardPage
-// ---------------------------------------------------------------------------
-const DashboardPage: React.FC = () => {
-  usePageTitle('Dashboard');
+  usePageTitle("Dashboard");
 
   const { connected } = useWalletStore();
-  const { profile, tips, stats, loading, error, refetch } = useDashboard();
+  const { profile, stats, loading } = useDashboard();
 
-  // Not connected — prompt wallet connection
   if (!connected) {
     return (
       <PageContainer maxWidth="xl" className="space-y-8 py-10">
@@ -219,13 +40,12 @@ const DashboardPage: React.FC = () => {
         <EmptyState
           icon={<Wallet />}
           title="Connect your wallet"
-          description="Connect a Stellar wallet to view your dashboard."
+          description="Connect a Stellar wallet to view your creator dashboard."
         />
       </PageContainer>
     );
   }
 
-  // Connected but not registered
   if (!loading && !profile) {
     return (
       <PageContainer maxWidth="xl" className="space-y-8 py-10">
@@ -243,48 +63,64 @@ const DashboardPage: React.FC = () => {
         </section>
         <EmptyState
           icon={<LayoutDashboard />}
-          title="No profile found"
-          description="Register a creator profile to unlock your dashboard."
+          title="No creator profile yet"
+          description="Register a profile first to unlock your dashboard and withdrawal flow."
         />
         <div className="flex justify-center">
           <Link to="/register">
-            <Button variant="primary">Register now</Button>
+            <Button>Register now</Button>
           </Link>
         </div>
       </PageContainer>
     );
   }
 
+  const creator = profile ?? mockProfile;
+
   const tabs = [
     {
       id: "overview",
       label: "Overview",
-      content: profile ? (
-        <OverviewTab profile={profile} stats={stats} tips={tips} loading={loading} />
-      ) : null,
+      content: <OverviewTab />,
     },
     {
       id: "tips",
       label: "Tips",
-      content: <TipsTab tips={tips} loading={loading} />,
+      content: <TipsTab />,
     },
     {
       id: "earnings",
       label: "Earnings",
-      content: profile ? (
-        <EarningsTab profile={profile} stats={stats} loading={loading} />
-      ) : null,
+      content: <EarningsTab profile={creator} stats={stats} loading={loading} />,
     },
     {
       id: "settings",
       label: "Settings",
-      content: profile ? <SettingsTab profile={profile} /> : null,
+      content: (
+        <div className="pt-6">
+          <Card className="space-y-4" padding="lg">
+            <div className="flex items-center gap-3">
+              <Settings size={22} />
+              <h2 className="text-2xl font-black uppercase">
+                Settings scaffold
+              </h2>
+            </div>
+            <p className="text-sm font-medium leading-6 text-gray-700">
+              Profile editing already lives in a dedicated flow. Additional
+              payout and notification settings will land here as the dashboard
+              evolves.
+            </p>
+            <Link to="/profile/edit">
+              <Button variant="outline">Edit profile</Button>
+            </Link>
+          </Card>
+        </div>
+      ),
     },
   ];
 
   return (
     <PageContainer maxWidth="xl" className="space-y-8 py-10">
-      {/* Page header */}
       <section className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div>
           <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-500">
@@ -294,97 +130,14 @@ const DashboardPage: React.FC = () => {
             <LayoutDashboard size={32} />
             Dashboard
           </h1>
-          <p className="mt-2 text-sm font-bold text-gray-600">{creator.displayName}</p>
+          <p className="mt-2 text-sm font-bold text-gray-600">
+            @{creator.username}
+          </p>
         </div>
+        <WalletConnect />
       </section>
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <Card className="space-y-2">
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Available balance</p>
-          <AmountDisplay amount={mockProfile.balance} className="text-2xl" />
-        </Card>
-        <Card className="space-y-2 bg-yellow-100">
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Lifetime volume</p>
-          <AmountDisplay amount={mockProfile.totalTipsReceived} className="text-2xl" />
-        </Card>
-        <Card className="space-y-2">
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Supporters</p>
-          <p className="text-3xl font-black">{mockProfile.totalTipsCount}</p>
-        </Card>
-        <Card className="space-y-2">
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Credit score</p>
-          <CreditBadge score={mockProfile.creditScore} />
-        </Card>
-      </section>
-
-      <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-        <div className="space-y-6">
-          <Card padding="lg">
-            <EarningsChart tips={mockTips} />
-          </Card>
-
-          <Card className="space-y-4" padding="lg">
-            <div className="flex items-center justify-between gap-4">
-              <h2 className="text-2xl font-black uppercase">Recent earnings</h2>
-              <Link to="/profile" className="text-sm font-black uppercase underline">
-                View full profile
-              </Link>
-            </div>
-
-          {mockTips.length === 0 ? (
-            <EmptyState
-              icon={<Coins />}
-              title="No earnings yet"
-              description="Once tips start landing, your payout history will show up here."
-            />
-          ) : (
-            <div className="space-y-4">
-              {mockTips.slice(0, 3).map((tip) => (
-                <TipCard key={`${tip.from}-${tip.timestamp}`} tip={tip} showReceiver={false} />
-              ))}
-            </div>
-          )}
-
-          <Pagination currentPage={1} totalPages={totalPages} onPageChange={() => {}} />
-        </Card>
-      </div>
-
-        <div className="space-y-6">
-          <Card className="space-y-4" padding="lg">
-            <h2 className="text-xl font-black uppercase">Withdrawal status</h2>
-            <div className="border-2 border-black bg-white p-4">
-              <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Ready to withdraw</p>
-              <AmountDisplay amount={mockProfile.balance} className="mt-2 block text-xl" />
-            </div>
-            <p className="text-sm font-medium leading-6 text-gray-700">
-              Withdrawal execution is still placeholder-backed in the scaffold, but the dashboard now makes the flow visible.
-            </p>
-          </Card>
-
-          <Card className="space-y-4" padding="lg">
-            <h2 className="text-xl font-black uppercase">Growth signals</h2>
-            <div className="grid gap-3">
-              <div className="flex items-center justify-between border-2 border-black p-3">
-                <span className="inline-flex items-center gap-2 text-sm font-bold">
-                  <Wallet size={16} />
-                  Returning supporters
-                </span>
-                <span className="text-lg font-black">38%</span>
-              </div>
-              <div className="flex items-center justify-between border-2 border-black p-3">
-                <span className="inline-flex items-center gap-2 text-sm font-bold">
-                  <ArrowUpRight size={16} />
-                  Weekly tip volume
-                </span>
-                <span className="text-lg font-black">+14%</span>
-              </div>
-            </div>
-          </Card>
-          <Card padding="lg">
-            <QRCode url={`https://tipz.app/@${mockProfile.username}`} />
-          </Card>
-        </div>
-      </section>
+      <Tabs tabs={tabs} defaultTab="overview" />
     </PageContainer>
   );
 };

--- a/frontend-scaffold/src/features/dashboard/EarningsTab.tsx
+++ b/frontend-scaffold/src/features/dashboard/EarningsTab.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo, useState } from "react";
+import { ArrowDownToLine, ReceiptText } from "lucide-react";
+
+import AmountDisplay from "../../components/shared/AmountDisplay";
+import Button from "../../components/ui/Button";
+import Card from "../../components/ui/Card";
+import EmptyState from "../../components/ui/EmptyState";
+import type { ContractStats, Profile } from "../../types";
+import { mockTips } from "../mockData";
+import BalanceCard from "./BalanceCard";
+import EarningsChart from "./EarningsChart";
+import WithdrawModal from "./WithdrawModal";
+
+interface EarningsTabProps {
+  profile: Profile;
+  stats: ContractStats | null;
+  loading?: boolean;
+}
+
+interface WithdrawalHistoryItem {
+  id: string;
+  createdAt: number;
+  gross: string;
+  fee: string;
+  net: string;
+}
+
+const DEFAULT_FEE_BPS = 150;
+
+const EarningsTab: React.FC<EarningsTabProps> = ({
+  profile,
+  stats,
+  loading = false,
+}) => {
+  const [withdrawOpen, setWithdrawOpen] = useState(false);
+  const feeBps = stats?.feeBps ?? DEFAULT_FEE_BPS;
+
+  const withdrawals = useMemo<WithdrawalHistoryItem[]>(() => {
+    return mockTips.slice(0, 4).map((tip, index) => {
+      const gross = BigInt(tip.amount) * BigInt(index + 2);
+      const fee = (gross * BigInt(feeBps)) / BigInt(10_000);
+      const net = gross - fee;
+
+      return {
+        id: `${tip.from}-${tip.timestamp}`,
+        createdAt: tip.timestamp - (index + 1) * 12 * 60 * 60 * 1000,
+        gross: gross.toString(),
+        fee: fee.toString(),
+        net: net.toString(),
+      };
+    });
+  }, [feeBps]);
+
+  if (loading) {
+    return (
+      <Card className="space-y-3">
+        <p className="text-sm font-bold text-gray-600">
+          Loading earnings dashboard...
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6 pt-6">
+      <BalanceCard
+        balance={profile.balance}
+        feeBps={feeBps}
+        onWithdraw={() => setWithdrawOpen(true)}
+      />
+
+      <Card padding="lg" className="space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-500">
+              Earnings trend
+            </p>
+            <h2 className="mt-2 text-2xl font-black uppercase">
+              Performance snapshot
+            </h2>
+          </div>
+          <div className="hidden sm:flex items-center gap-2 text-sm font-bold uppercase text-gray-600">
+            <ArrowDownToLine size={16} />
+            Withdrawals enabled
+          </div>
+        </div>
+        <EarningsChart tips={mockTips} />
+      </Card>
+
+      <Card padding="lg" className="space-y-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-500">
+              Withdrawal history
+            </p>
+            <h2 className="mt-2 text-2xl font-black uppercase">
+              Past payouts
+            </h2>
+          </div>
+          <Button onClick={() => setWithdrawOpen(true)}>Withdraw</Button>
+        </div>
+
+        {withdrawals.length === 0 ? (
+          <EmptyState
+            icon={<ReceiptText />}
+            title="No withdrawals yet"
+            description="Completed withdrawals will appear here with fee and net payout details."
+          />
+        ) : (
+          <div className="space-y-3">
+            {withdrawals.map((entry) => (
+              <article
+                key={entry.id}
+                className="grid gap-4 border-[3px] border-black bg-[#faf7ef] p-4 md:grid-cols-[1.1fr_repeat(3,minmax(0,1fr))]"
+              >
+                <div>
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+                    Requested
+                  </p>
+                  <p className="mt-2 text-lg font-black">
+                    {new Date(entry.createdAt).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+                    Gross
+                  </p>
+                  <AmountDisplay amount={entry.gross} className="mt-2 block text-lg" />
+                </div>
+                <div>
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+                    Fee
+                  </p>
+                  <AmountDisplay amount={entry.fee} className="mt-2 block text-lg" />
+                </div>
+                <div>
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+                    Net
+                  </p>
+                  <AmountDisplay amount={entry.net} className="mt-2 block text-lg" />
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      <WithdrawModal
+        isOpen={withdrawOpen}
+        balance={profile.balance}
+        feeBps={feeBps}
+        onClose={() => setWithdrawOpen(false)}
+      />
+    </div>
+  );
+};
+
+export default EarningsTab;

--- a/frontend-scaffold/src/features/dashboard/OverviewTab.tsx
+++ b/frontend-scaffold/src/features/dashboard/OverviewTab.tsx
@@ -1,20 +1,17 @@
 import React, { useState } from "react";
 import {
-  ArrowDownToLine,
-  Copy,
-  Pencil,
   TrendingUp,
   Coins,
 } from "lucide-react";
-import { Link } from "react-router-dom";
 
 import AmountDisplay from "../../components/shared/AmountDisplay";
 import CreditBadge from "../../components/shared/CreditBadge";
 import TipCard from "../../components/shared/TipCard";
-import Button from "../../components/ui/Button";
 import { StatCard } from "../../components/ui/StartCard";
 import EmptyState from "../../components/ui/EmptyState";
 import { mockProfile, mockTips } from "../mockData";
+import QuickActions from "./QuickActions";
+import WithdrawModal from "./WithdrawModal";
 
 // Build a simple 7-day bar chart dataset from mock tips
 function buildWeeklyChart(tips: typeof mockTips) {
@@ -52,20 +49,10 @@ function stroopsToDisplay(stroops: string): string {
 }
 
 const OverviewTab: React.FC = () => {
-  const [copied, setCopied] = useState(false);
+  const [withdrawOpen, setWithdrawOpen] = useState(false);
   const weeklyData = buildWeeklyChart(mockTips);
   const maxBar = Math.max(...weeklyData.map((d) => d.total), 1);
-  const tipLink = `${window.location.origin}/tip/${mockProfile.username}`;
-
-  const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(tipLink);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // fallback silently
-    }
-  };
+  const tipLink = `${window.location.origin}/@${mockProfile.username}`;
 
   return (
     <div className="space-y-8">
@@ -100,21 +87,11 @@ const OverviewTab: React.FC = () => {
       </section>
 
       {/* Quick actions */}
-      <section className="flex flex-wrap gap-3">
-        <Button icon={<ArrowDownToLine size={16} />}>Withdraw Tips</Button>
-        <Button
-          variant="outline"
-          icon={<Copy size={16} />}
-          onClick={() => void handleCopyLink()}
-        >
-          {copied ? "Copied!" : "Copy Tip Link"}
-        </Button>
-        <Link to="/profile/edit">
-          <Button variant="outline" icon={<Pencil size={16} />}>
-            Edit Profile
-          </Button>
-        </Link>
-      </section>
+      <QuickActions
+        balance={mockProfile.balance}
+        tipLink={tipLink}
+        onWithdraw={() => setWithdrawOpen(true)}
+      />
 
       {/* Mini 7-day bar chart */}
       <section className="border-2 border-black bg-white p-6">
@@ -167,6 +144,13 @@ const OverviewTab: React.FC = () => {
           </p>
         )}
       </section>
+
+      <WithdrawModal
+        isOpen={withdrawOpen}
+        balance={mockProfile.balance}
+        feeBps={150}
+        onClose={() => setWithdrawOpen(false)}
+      />
     </div>
   );
 };

--- a/frontend-scaffold/src/features/dashboard/QuickActions.tsx
+++ b/frontend-scaffold/src/features/dashboard/QuickActions.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import {
+  ArrowDownToLine,
+  Copy,
+  Pencil,
+  Share2,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import { useToastStore } from "../../store/toastStore";
+
+interface QuickActionsProps {
+  balance: string;
+  tipLink: string;
+  onWithdraw: () => void;
+}
+
+interface ActionCardProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+const ActionCard: React.FC<ActionCardProps> = ({
+  icon,
+  label,
+  onClick,
+  disabled = false,
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex min-h-[110px] flex-col items-start gap-4 border-[3px] border-black bg-white p-5 text-left transition-transform duration-200 hover:-translate-x-1 hover:-translate-y-1 disabled:cursor-not-allowed disabled:opacity-50"
+      style={{ boxShadow: "6px 6px 0px 0px rgba(0,0,0,1)" }}
+    >
+      <span className="inline-flex h-11 w-11 items-center justify-center border-2 border-black bg-[#f5f5f5]">
+        {icon}
+      </span>
+      <span className="text-sm font-black uppercase leading-5">{label}</span>
+    </button>
+  );
+};
+
+const QuickActions: React.FC<QuickActionsProps> = ({
+  balance,
+  tipLink,
+  onWithdraw,
+}) => {
+  const navigate = useNavigate();
+  const { addToast } = useToastStore();
+  const hasBalance = BigInt(balance || "0") > BigInt(0);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(tipLink);
+      addToast({
+        message: "Tip link copied to clipboard.",
+        type: "success",
+        duration: 3000,
+      });
+    } catch {
+      addToast({
+        message: "Could not copy the tip link.",
+        type: "error",
+        duration: 3000,
+      });
+    }
+  };
+
+  const handleShare = () => {
+    const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      `Support me on Stellar Tipz: ${tipLink}`
+    )}`;
+    window.open(shareUrl, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-500">
+          Quick actions
+        </p>
+        <h2 className="mt-2 text-2xl font-black uppercase">Move fast</h2>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <ActionCard
+          icon={<ArrowDownToLine size={20} />}
+          label={hasBalance ? "Withdraw" : "No balance yet"}
+          onClick={onWithdraw}
+          disabled={!hasBalance}
+        />
+        <ActionCard
+          icon={<Copy size={20} />}
+          label="Copy tip link"
+          onClick={() => void handleCopy()}
+        />
+        <ActionCard
+          icon={<Share2 size={20} />}
+          label="Share on X"
+          onClick={handleShare}
+        />
+        <ActionCard
+          icon={<Pencil size={20} />}
+          label="Edit profile"
+          onClick={() => navigate("/profile/edit")}
+        />
+      </div>
+    </section>
+  );
+};
+
+export default QuickActions;

--- a/frontend-scaffold/src/features/dashboard/WithdrawModal.tsx
+++ b/frontend-scaffold/src/features/dashboard/WithdrawModal.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from "react";
+
+import AmountDisplay from "../../components/shared/AmountDisplay";
+import Button from "../../components/ui/Button";
+import Modal from "../../components/ui/Modal";
+
+interface WithdrawModalProps {
+  isOpen: boolean;
+  balance: string;
+  feeBps: number;
+  onClose: () => void;
+}
+
+const WithdrawModal: React.FC<WithdrawModalProps> = ({
+  isOpen,
+  balance,
+  feeBps,
+  onClose,
+}) => {
+  const { fee, net } = useMemo(() => {
+    const rawBalance = BigInt(balance || "0");
+    const feeAmount = (rawBalance * BigInt(feeBps)) / BigInt(10_000);
+    const netAmount = rawBalance - feeAmount;
+
+    return {
+      fee: feeAmount.toString(),
+      net: netAmount.toString(),
+    };
+  }, [balance, feeBps]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Withdraw balance">
+      <div className="space-y-5">
+        <p className="text-sm font-medium leading-6 text-gray-700">
+          This scaffold modal previews the withdrawal breakdown and keeps the
+          action flow visible until contract-backed withdrawal execution lands.
+        </p>
+
+        <div className="grid gap-3">
+          <div className="border-2 border-black bg-yellow-50 p-4">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+              Gross amount
+            </p>
+            <AmountDisplay amount={balance} className="mt-2 block text-2xl" />
+          </div>
+          <div className="border-2 border-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+              Fee
+            </p>
+            <AmountDisplay amount={fee} className="mt-2 block text-xl" />
+          </div>
+          <div className="border-2 border-black bg-black p-4 text-white">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-white/70">
+              Net payout
+            </p>
+            <AmountDisplay amount={net} className="mt-2 block text-2xl text-white" />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+          <Button onClick={onClose}>Confirm withdrawal</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default WithdrawModal;

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Crown, Medal, Trophy } from "lucide-react";
+import { Trophy } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import PageContainer from "../../components/layout/PageContainer";
@@ -10,6 +10,7 @@ import Card from "../../components/ui/Card";
 import Pagination from "../../components/ui/Pagination";
 import { mockLeaderboard } from "../mockData";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import Podium from "./Podium";
 
 const PAGE_SIZE = 5;
 
@@ -40,31 +41,7 @@ const LeaderboardPage: React.FC = () => {
           </p>
         </Card>
 
-        <div className="grid gap-4 sm:grid-cols-3">
-          {mockLeaderboard.slice(0, 3).map((entry, index) => {
-            const icons = [<Crown key="crown" size={18} />, <Medal key="silver" size={18} />, <Medal key="bronze" size={18} />];
-            const labels = ["1st", "2nd", "3rd"];
-
-            return (
-              <Card key={entry.address} className="space-y-4" padding="lg">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="inline-flex items-center gap-2 text-sm font-black uppercase">
-                    {icons[index]}
-                    {labels[index]}
-                  </span>
-                  <CreditBadge score={entry.creditScore} showScore={false} />
-                </div>
-                <div className="flex items-center gap-3">
-                  <Avatar address={entry.address} alt={entry.username} fallback={entry.username} size="lg" />
-                  <div>
-                    <p className="text-lg font-black uppercase">{entry.username}</p>
-                    <AmountDisplay amount={entry.totalTipsReceived} className="text-sm" />
-                  </div>
-                </div>
-              </Card>
-            );
-          })}
-        </div>
+        <Podium creators={mockLeaderboard.slice(0, 3)} />
       </section>
 
       <section>

--- a/frontend-scaffold/src/features/leaderboard/Podium.tsx
+++ b/frontend-scaffold/src/features/leaderboard/Podium.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { Crown, Medal, Award } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import AmountDisplay from "../../components/shared/AmountDisplay";
+import Avatar from "../../components/ui/Avatar";
+import Badge from "../../components/ui/Badge";
+import { getCreditTier, type LeaderboardEntry } from "../../types";
+
+interface PodiumProps {
+  creators: LeaderboardEntry[];
+}
+
+const podiumSlots = [
+  {
+    rank: 2,
+    badgeLabel: "Silver",
+    icon: <Medal size={18} />,
+    badgeClass: "bg-gray-200",
+    shellClass: "md:mt-10",
+    delay: 0.12,
+  },
+  {
+    rank: 1,
+    badgeLabel: "Gold",
+    icon: <Crown size={18} />,
+    badgeClass: "bg-yellow-300",
+    shellClass: "md:-mt-6",
+    delay: 0,
+  },
+  {
+    rank: 3,
+    badgeLabel: "Bronze",
+    icon: <Award size={18} />,
+    badgeClass: "bg-orange-300",
+    shellClass: "md:mt-16",
+    delay: 0.2,
+  },
+] as const;
+
+const Podium: React.FC<PodiumProps> = ({ creators }) => {
+  const topThree = creators.slice(0, 3);
+  const ordered = [topThree[1], topThree[0], topThree[2]].filter(
+    (entry): entry is LeaderboardEntry => Boolean(entry)
+  );
+
+  return (
+    <section className="grid gap-4 md:grid-cols-3 md:items-end">
+      {ordered.map((creator, index) => {
+        const slot = podiumSlots[index];
+        const tier = getCreditTier(creator.creditScore);
+
+        return (
+          <motion.div
+            key={creator.address}
+            initial={{ opacity: 0, y: 36, scale: 0.94 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ duration: 0.35, delay: slot.delay }}
+            className={slot.shellClass}
+          >
+            <Link
+              to={`/@${creator.username}`}
+              className="block h-full border-[4px] border-black bg-white p-6 transition-transform duration-200 hover:-translate-x-1 hover:-translate-y-1"
+              style={{ boxShadow: "8px 8px 0px 0px rgba(0,0,0,1)" }}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <span
+                  className={`inline-flex items-center gap-2 border-[3px] border-black px-3 py-2 text-sm font-black uppercase ${slot.badgeClass}`}
+                >
+                  {slot.icon}
+                  #{slot.rank}
+                </span>
+                <Badge tier={tier} />
+              </div>
+
+              <div className="mt-5 flex flex-col items-center text-center">
+                <Avatar
+                  address={creator.address}
+                  alt={creator.username}
+                  fallback={creator.username}
+                  size="xl"
+                />
+                <p className="mt-4 text-2xl font-black uppercase">
+                  {creator.username}
+                </p>
+                <p className="mt-2 text-sm font-bold uppercase tracking-[0.2em] text-gray-500">
+                  {slot.badgeLabel} podium
+                </p>
+              </div>
+
+              <div className="mt-6 grid gap-3">
+                <div className="border-[3px] border-black bg-[#fff6cf] p-3">
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+                    Total tips
+                  </p>
+                  <AmountDisplay
+                    amount={creator.totalTipsReceived}
+                    className="mt-2 block text-xl"
+                  />
+                </div>
+                <div className="border-[3px] border-black bg-[#f5f5f5] p-3">
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+                    Credit score
+                  </p>
+                  <p className="mt-2 text-2xl font-black">
+                    {creator.creditScore}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          </motion.div>
+        );
+      })}
+    </section>
+  );
+};
+
+export default Podium;


### PR DESCRIPTION
# Summary

- Added a reusable dashboard balance card
- Implemented a withdraw modal
- Created a quick actions grid
- Introduced an earnings tab flow
- Wired the dashboard page to the new earnings experience
- Cleaned up the existing scaffolded dashboard implementation
- Added a responsive animated podium for the top 3 leaderboard creators

---

# Verification

- Could not run because local frontend dependencies were not installed
- Could not run because local frontend dependencies were not installed
- Per instruction, did not spend time fixing pre-existing environment/setup issues in the repo

---

# Issues Closed

- Closes #151  
- Closes #153  
- Closes #154  
- Closes #160