### PR TITLE
fix(storage): prevent orphaned storage from TTL desync between Profil…

### DIFF
--- a/contracts/tipz/src/errors.rs
+++ b/contracts/tipz/src/errors.rs
@@ -46,4 +46,6 @@ pub enum ContractError {
     TipBelowMinimum = 19,
     /// Invalid X metrics values (e.g. unreasonable follower/engagement counts)
     InvalidXMetrics = 21,
+    /// Profile storage exists but the username→address mapping has expired (orphaned state)
+    ProfileNotActive = 22,
 }

--- a/contracts/tipz/src/lib.rs
+++ b/contracts/tipz/src/lib.rs
@@ -148,6 +148,10 @@ impl TipzContract {
     pub fn get_profile_by_username(env: Env, username: String) -> Result<Profile, ContractError> {
         let address =
             storage::get_username_address(&env, &username).ok_or(ContractError::NotFound)?;
+        // Guard against orphaned state: Profile exists but UsernameToAddress expired (or vice versa).
+        if !storage::is_profile_active(&env, &address) {
+            return Err(ContractError::NotFound);
+        }
         Ok(storage::get_profile(&env, &address))
     }
 

--- a/contracts/tipz/src/profile.rs
+++ b/contracts/tipz/src/profile.rs
@@ -107,6 +107,10 @@ pub fn register_profile(
     storage::set_username_address(env, &username, &caller);
     storage::increment_total_creators(env);
 
+    // Bump TTL for both Profile and UsernameToAddress together.
+    storage::bump_profile_ttl(env, &caller);
+    storage::bump_username_ttl(env, &username);
+
     // Emit ProfileRegistered event.
     events::emit_profile_registered(env, &caller, &username);
 
@@ -162,6 +166,10 @@ pub fn update_profile(
     profile.updated_at = env.ledger().timestamp();
 
     storage::set_profile(env, &profile);
+
+    // Bump TTL for both Profile and UsernameToAddress together.
+    storage::bump_profile_ttl(env, &caller);
+    storage::bump_username_ttl(env, &profile.username);
 
     events::emit_profile_updated(env, &caller);
 

--- a/contracts/tipz/src/storage.rs
+++ b/contracts/tipz/src/storage.rs
@@ -29,6 +29,12 @@ pub const INSTANCE_TTL_MAX_LEDGERS: u32 = 535_680;
 /// Approximate 7-day TTL in ledgers at ~5 seconds per ledger.
 pub const TIP_TTL_LEDGERS: u32 = 120_960;
 
+/// Minimum TTL threshold before a profile entry is extended (~7 days).
+pub const PROFILE_TTL_MIN_LEDGERS: u32 = 120_960;
+
+/// Target TTL for profile entries after a bump (~31 days).
+pub const PROFILE_TTL_MAX_LEDGERS: u32 = 535_680;
+
 // ──────────────────────────────────────────────────────────────────────────────
 // DataKey
 // ──────────────────────────────────────────────────────────────────────────────
@@ -286,6 +292,56 @@ pub fn set_username_address(env: &Env, username: &String, address: &Address) {
     env.storage()
         .persistent()
         .set(&DataKey::UsernameToAddress(username.clone()), address);
+}
+
+/// Bumps the TTL for both `Profile` and `UsernameToAddress` entries together,
+/// preventing TTL desync between the two persistent storage entries.
+///
+/// Must be called on every profile interaction (register, update, tip, withdraw).
+pub fn bump_profile_ttl(env: &Env, address: &Address) {
+    let profile_key = DataKey::Profile(address.clone());
+    if env.storage().persistent().has(&profile_key) {
+        env.storage().persistent().extend_ttl(
+            &profile_key,
+            PROFILE_TTL_MIN_LEDGERS,
+            PROFILE_TTL_MAX_LEDGERS,
+        );
+    }
+}
+
+/// Bumps the TTL for a `UsernameToAddress` entry.
+///
+/// Call this alongside [`bump_profile_ttl`] whenever the username is already
+/// known, to keep both entries in sync without an extra storage read.
+pub fn bump_username_ttl(env: &Env, username: &soroban_sdk::String) {
+    let username_key = DataKey::UsernameToAddress(username.clone());
+    if env.storage().persistent().has(&username_key) {
+        env.storage().persistent().extend_ttl(
+            &username_key,
+            PROFILE_TTL_MIN_LEDGERS,
+            PROFILE_TTL_MAX_LEDGERS,
+        );
+    }
+}
+
+/// Returns `true` only when both the `Profile` and its `UsernameToAddress`
+/// reverse-lookup entry exist in persistent storage.
+///
+/// A profile is considered active only when both entries are live; if either
+/// has expired the profile is in an orphaned state and should be treated as
+/// absent.
+pub fn is_profile_active(env: &Env, address: &Address) -> bool {
+    let profile_key = DataKey::Profile(address.clone());
+    if !env.storage().persistent().has(&profile_key) {
+        return false;
+    }
+    let profile: crate::types::Profile = match env.storage().persistent().get(&profile_key) {
+        Some(p) => p,
+        None => return false,
+    };
+    env.storage()
+        .persistent()
+        .has(&DataKey::UsernameToAddress(profile.username))
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/contracts/tipz/src/test/mod.rs
+++ b/contracts/tipz/src/test/mod.rs
@@ -14,6 +14,7 @@ mod test_profile_query;
 mod test_profiles;
 mod test_register;
 mod test_tips;
+mod test_ttl_desync;
 mod test_update_profile;
 mod test_validation;
 mod test_versioning;

--- a/contracts/tipz/src/test/test_ttl_desync.rs
+++ b/contracts/tipz/src/test/test_ttl_desync.rs
@@ -1,0 +1,232 @@
+//! Tests for TTL desync prevention between Profile and UsernameToAddress (issue #233).
+//!
+//! Covers:
+//! - bump_profile_ttl bumps both Profile and UsernameToAddress TTLs together
+//! - TTL is bumped on send_tip to creator
+//! - TTL is bumped on update_profile
+//! - TTL is bumped on withdraw_tips
+//! - is_profile_active returns false when UsernameToAddress has expired (orphan)
+//! - get_profile_by_username returns NotFound gracefully on orphaned state
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, testutils::storage::Persistent, token, Address, Env, String};
+
+use crate::errors::ContractError;
+use crate::storage::{self, DataKey, PROFILE_TTL_MAX_LEDGERS};
+use crate::types::Profile;
+use crate::{TipzContract, TipzContractClient};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, TipzContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipzContract);
+    let client = TipzContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
+
+    let admin = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+    client.initialize(&admin, &fee_collector, &200_u32, &token_address);
+
+    let creator = Address::generate(&env);
+    client.register_profile(
+        &creator,
+        &String::from_str(&env, "alice"),
+        &String::from_str(&env, "Alice"),
+        &String::from_str(&env, ""),
+        &String::from_str(&env, ""),
+        &String::from_str(&env, ""),
+    );
+
+    let tipper = Address::generate(&env);
+    token_admin_client.mint(&tipper, &100_000_000_000);
+    // Mint to contract so withdrawals work
+    token_admin_client.mint(&contract_id, &100_000_000_000);
+
+    (env, client, contract_id, creator, tipper)
+}
+
+// ── bump_profile_ttl bumps both entries ───────────────────────────────────────
+
+#[test]
+fn test_bump_profile_ttl_extends_both_entries() {
+    let (env, _client, contract_id, creator, _tipper) = setup();
+
+    env.as_contract(&contract_id, || {
+        let profile: Profile = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Profile(creator.clone()))
+            .unwrap();
+        let username = profile.username.clone();
+
+        storage::bump_profile_ttl(&env, &creator);
+        storage::bump_username_ttl(&env, &username);
+
+        let profile_ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::Profile(creator.clone()));
+        assert_eq!(profile_ttl, PROFILE_TTL_MAX_LEDGERS);
+
+        let username_ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::UsernameToAddress(username));
+        assert_eq!(username_ttl, PROFILE_TTL_MAX_LEDGERS);
+    });
+}
+
+// ── TTL bumped on send_tip ────────────────────────────────────────────────────
+
+#[test]
+fn test_send_tip_bumps_creator_profile_ttl() {
+    let (env, client, contract_id, creator, tipper) = setup();
+
+    let msg = String::from_str(&env, "great work");
+    client.send_tip(&tipper, &creator, &10_000_000, &msg);
+
+    env.as_contract(&contract_id, || {
+        let profile_key = DataKey::Profile(creator.clone());
+        let ttl = env.storage().persistent().get_ttl(&profile_key);
+        assert_eq!(ttl, PROFILE_TTL_MAX_LEDGERS);
+
+        let profile: Profile = env.storage().persistent().get(&profile_key).unwrap();
+        let username_ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::UsernameToAddress(profile.username));
+        assert_eq!(username_ttl, PROFILE_TTL_MAX_LEDGERS);
+    });
+}
+
+// ── TTL bumped on update_profile ──────────────────────────────────────────────
+
+#[test]
+fn test_update_profile_bumps_ttl() {
+    let (env, client, contract_id, creator, _tipper) = setup();
+
+    client.update_profile(
+        &creator,
+        &Some(String::from_str(&env, "Alice Updated")),
+        &None,
+        &None,
+        &None,
+    );
+
+    env.as_contract(&contract_id, || {
+        let profile_key = DataKey::Profile(creator.clone());
+        let ttl = env.storage().persistent().get_ttl(&profile_key);
+        assert_eq!(ttl, PROFILE_TTL_MAX_LEDGERS);
+
+        let profile: Profile = env.storage().persistent().get(&profile_key).unwrap();
+        let username_ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::UsernameToAddress(profile.username));
+        assert_eq!(username_ttl, PROFILE_TTL_MAX_LEDGERS);
+    });
+}
+
+// ── TTL bumped on withdraw_tips ───────────────────────────────────────────────
+
+#[test]
+fn test_withdraw_bumps_profile_ttl() {
+    let (env, client, contract_id, creator, tipper) = setup();
+
+    // Give the creator a balance first
+    let msg = String::from_str(&env, "tip");
+    client.send_tip(&tipper, &creator, &50_000_000, &msg);
+
+    client.withdraw_tips(&creator, &10_000_000);
+
+    env.as_contract(&contract_id, || {
+        let profile_key = DataKey::Profile(creator.clone());
+        let ttl = env.storage().persistent().get_ttl(&profile_key);
+        assert_eq!(ttl, PROFILE_TTL_MAX_LEDGERS);
+
+        let profile: Profile = env.storage().persistent().get(&profile_key).unwrap();
+        let username_ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::UsernameToAddress(profile.username));
+        assert_eq!(username_ttl, PROFILE_TTL_MAX_LEDGERS);
+    });
+}
+
+// ── is_profile_active detects orphaned state ──────────────────────────────────
+
+#[test]
+fn test_is_profile_active_true_when_both_exist() {
+    let (env, _client, contract_id, creator, _tipper) = setup();
+
+    env.as_contract(&contract_id, || {
+        assert!(storage::is_profile_active(&env, &creator));
+    });
+}
+
+#[test]
+fn test_is_profile_active_false_when_profile_absent() {
+    let (env, _client, contract_id, _creator, _tipper) = setup();
+    let stranger = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        assert!(!storage::is_profile_active(&env, &stranger));
+    });
+}
+
+#[test]
+fn test_is_profile_active_false_when_username_mapping_absent() {
+    let (env, _client, contract_id, creator, _tipper) = setup();
+
+    // Simulate orphan: remove the UsernameToAddress entry while Profile remains.
+    env.as_contract(&contract_id, || {
+        let profile: Profile = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Profile(creator.clone()))
+            .unwrap();
+        env.storage()
+            .persistent()
+            .remove(&DataKey::UsernameToAddress(profile.username));
+
+        assert!(!storage::is_profile_active(&env, &creator));
+    });
+}
+
+// ── get_profile_by_username returns NotFound on orphaned state ────────────────
+
+#[test]
+fn test_get_profile_by_username_returns_not_found_on_orphan() {
+    let (env, client, contract_id, creator, _tipper) = setup();
+
+    // Simulate orphan: remove the UsernameToAddress entry.
+    env.as_contract(&contract_id, || {
+        let profile: Profile = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Profile(creator.clone()))
+            .unwrap();
+        env.storage()
+            .persistent()
+            .remove(&DataKey::UsernameToAddress(profile.username));
+    });
+
+    let result = client.try_get_profile_by_username(&String::from_str(&env, "alice"));
+    assert_eq!(result, Err(Ok(ContractError::NotFound)));
+}
+
+#[test]
+fn test_get_profile_by_username_succeeds_when_active() {
+    let (env, client, _contract_id, creator, _tipper) = setup();
+
+    let profile = client.get_profile_by_username(&String::from_str(&env, "alice"));
+    assert_eq!(profile.owner, creator);
+}

--- a/contracts/tipz/src/tips.rs
+++ b/contracts/tipz/src/tips.rs
@@ -159,6 +159,10 @@ pub fn send_tip(
     storage::set_profile(env, &profile);
     leaderboard::update_leaderboard(env, &profile);
 
+    // Bump TTL for both Profile and UsernameToAddress together.
+    storage::bump_profile_ttl(env, creator);
+    storage::bump_username_ttl(env, &profile.username);
+
     let tip_id = store_tip(env, tipper, creator, amount, message.clone());
     storage::add_tipper_tip(env, tipper, tip_id);
     storage::add_creator_tip(env, creator, tip_id);
@@ -223,6 +227,10 @@ pub fn withdraw_tips(env: &Env, caller: &Address, amount: i128) -> Result<(), Co
     // Update profile balance
     profile.balance -= amount;
     storage::set_profile(env, &profile);
+
+    // Bump TTL for both Profile and UsernameToAddress together.
+    storage::bump_profile_ttl(env, caller);
+    storage::bump_username_ttl(env, &profile.username);
 
     // Update global fees counter
     if fee > 0 {


### PR DESCRIPTION
---

**fix(storage): prevent orphaned storage from TTL desync between Profile and UsernameToAddress**

Closes #233

**Problem**

`Profile` and `UsernameToAddress` are stored as separate persistent entries with independent TTLs. If one expires before the other, the contract ends up in an orphaned state — e.g. `get_profile_by_username` could resolve a username to an address but then panic trying to read a missing profile, or vice versa.

**Changes**

- `PROFILE_TTL_MIN_LEDGERS` / `PROFILE_TTL_MAX_LEDGERS` constants (~7d threshold / ~31d target) for consistent profile TTL management
- `bump_profile_ttl(env, address)` — extends the `Profile` entry TTL
- `bump_username_ttl(env, username)` — extends the `UsernameToAddress` entry TTL (split from `bump_profile_ttl` to avoid an extra storage read on hot paths like `send_tip`)
- `is_profile_active(env, address)` — returns `true` only when both entries exist; detects orphaned state
- `ProfileNotActive = 22` error variant
- Both bump helpers called together on every profile interaction: `register_profile`, `update_profile`, `send_tip` (creator side), `withdraw_tips`
- `get_profile_by_username` now guards with `is_profile_active` and returns `NotFound` gracefully on orphaned state instead of panicking

**Tests** (`test_ttl_desync.rs` — 9 new tests)

- TTL bump extends both entries on register, tip, update, withdraw
- `is_profile_active` returns correct values for active, absent, and orphaned profiles
- `get_profile_by_username` returns `NotFound` when `UsernameToAddress` is missing