### PR TITLE
test: implement core UI unit tests for card, input, modal, badge, toa…

### DIFF
--- a/frontend-scaffold/src/components/ui/__tests__/Badge.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Badge.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Badge, { getTierFromScore } from '../Badge';
+
+describe('Badge Component', () => {
+  it('renders bronze tier correctly', () => {
+    render(<Badge tier="bronze" />);
+    expect(screen.getByText('Bronze')).toBeDefined();
+    expect(screen.getByText('🥉')).toBeDefined();
+    expect(screen.getByText('Bronze').parentElement).toHaveClass('bg-orange-100');
+  });
+
+  it('renders silver tier correctly', () => {
+    render(<Badge tier="silver" />);
+    expect(screen.getByText('Silver')).toBeDefined();
+    expect(screen.getByText('🥈')).toBeDefined();
+    expect(screen.getByText('Silver').parentElement).toHaveClass('bg-gray-100');
+  });
+
+  it('renders gold tier correctly', () => {
+    render(<Badge tier="gold" />);
+    expect(screen.getByText('Gold')).toBeDefined();
+    expect(screen.getByText('🥇')).toBeDefined();
+    expect(screen.getByText('Gold').parentElement).toHaveClass('bg-yellow-100');
+  });
+
+  it('renders diamond tier correctly', () => {
+    render(<Badge tier="diamond" />);
+    expect(screen.getByText('Diamond')).toBeDefined();
+    expect(screen.getByText('💎')).toBeDefined();
+    expect(screen.getByText('Diamond').parentElement).toHaveClass('bg-blue-100');
+  });
+
+  it('displays score when provided', () => {
+    render(<Badge tier="gold" score={500} />);
+    expect(screen.getByText('(500)')).toBeDefined();
+  });
+
+  it('does not display score when not provided', () => {
+    render(<Badge tier="gold" />);
+    expect(screen.queryByText('(')).toBeNull();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Badge tier="bronze" className="test-class" />);
+    expect(container.firstChild).toHaveClass('test-class');
+  });
+});
+
+describe('getTierFromScore utility', () => {
+  it('returns correctly for various scores', () => {
+    expect(getTierFromScore(100)).toBe('bronze');
+    expect(getTierFromScore(400)).toBe('bronze');
+    expect(getTierFromScore(401)).toBe('silver');
+    expect(getTierFromScore(700)).toBe('silver');
+    expect(getTierFromScore(701)).toBe('gold');
+    expect(getTierFromScore(900)).toBe('gold');
+    expect(getTierFromScore(901)).toBe('diamond');
+    expect(getTierFromScore(1500)).toBe('diamond');
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Card.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Card from '../Card';
+
+describe('Card Component', () => {
+  it('renders children correctly', () => {
+    render(
+      <Card>
+        <div data-testid="child">Test Child</div>
+      </Card>
+    );
+    expect(screen.getByTestId('child')).toBeDefined();
+    expect(screen.getByText('Test Child')).toBeDefined();
+  });
+
+  it('applies default padding (md)', () => {
+    const { container } = render(<Card>Default Padding</Card>);
+    expect(container.firstChild).toHaveClass('p-6');
+  });
+
+  it('applies small padding (sm)', () => {
+    const { container } = render(<Card padding="sm">Small Padding</Card>);
+    expect(container.firstChild).toHaveClass('p-4');
+  });
+
+  it('applies large padding (lg)', () => {
+    const { container } = render(<Card padding="lg">Large Padding</Card>);
+    expect(container.firstChild).toHaveClass('p-8');
+  });
+
+  it('applies hover classes when hover prop is true', () => {
+    const { container } = render(<Card hover>Hover Card</Card>);
+    expect(container.firstChild).toHaveClass('hover:-translate-x-1');
+    expect(container.firstChild).toHaveClass('hover:-translate-y-1');
+    expect(container.firstChild).toHaveClass('hover:shadow-brutalist-lg');
+  });
+
+  it('does not apply hover classes when hover prop is false', () => {
+    const { container } = render(<Card hover={false}>No Hover Card</Card>);
+    expect(container.firstChild).not.toHaveClass('hover:-translate-x-1');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Card className="custom-test">Custom Class</Card>);
+    expect(container.firstChild).toHaveClass('custom-test');
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Input.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Input.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Input from '../Input';
+
+describe('Input Component', () => {
+  it('renders label correctly', () => {
+    render(<Input label="Username" id="user-input" />);
+    expect(screen.getByLabelText('Username')).toBeDefined();
+    expect(screen.getByText('Username')).toBeDefined();
+  });
+
+  it('renders without label', () => {
+    render(<Input placeholder="Enter text" />);
+    expect(screen.queryByRole('label')).toBeNull();
+    expect(screen.getByPlaceholderText('Enter text')).toBeDefined();
+  });
+
+  it('displays error message correctly', () => {
+    render(<Input label="Username" error="Field required" />);
+    expect(screen.getByText('Field required')).toBeDefined();
+    expect(screen.getByRole('textbox')).toHaveClass('border-red-600');
+  });
+
+  it('doesn\'t display error message when not provided', () => {
+    render(<Input label="Username" />);
+    expect(screen.queryByText('Field required')).toBeNull();
+    expect(screen.getByRole('textbox')).not.toHaveClass('border-red-600');
+  });
+
+  it('fires onChange event correctly', () => {
+    const handleChange = vi.fn();
+    render(<Input label="Username" onChange={handleChange} />);
+    const input = screen.getByRole('textbox');
+    
+    fireEvent.change(input, { target: { value: 'testuser' } });
+    
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(input).toHaveValue('testuser');
+  });
+
+  it('applies standard accessibility attributes (id, auto-generated id)', () => {
+    const { rerender } = render(<Input label="Email Address" />);
+    const input = screen.getByRole('textbox');
+    expect(input.id).toBe('email-address');
+
+    rerender(<Input label="Email Address" id="custom-id" />);
+    expect(screen.getByRole('textbox').id).toBe('custom-id');
+  });
+
+  it('passes other props correctly', () => {
+    render(<Input type="password" disabled data-testid="test-input" />);
+    const input = screen.getByTestId('test-input');
+    expect(input).toHaveProperty('type', 'password');
+    expect(input).toBeDisabled();
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Loader.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Loader.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Loader from '../Loader';
+
+describe('Loader Component', () => {
+  it('renders correctly with default size (md)', () => {
+    const { container } = render(<Loader />);
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toBeDefined();
+    expect(spinner).toHaveClass('w-8');
+    expect(spinner).toHaveClass('h-8');
+    expect(spinner).toHaveClass('border-3');
+  });
+
+  it('renders small size (sm)', () => {
+    const { container } = render(<Loader size="sm" />);
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toHaveClass('w-4');
+    expect(spinner).toHaveClass('h-4');
+    expect(spinner).toHaveClass('border-2');
+  });
+
+  it('renders large size (lg)', () => {
+    const { container } = render(<Loader size="lg" />);
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toHaveClass('w-12');
+    expect(spinner).toHaveClass('h-12');
+    expect(spinner).toHaveClass('border-3');
+  });
+
+  it('displays loading text when provided', () => {
+    render(<Loader text="Calculating tipping points..." />);
+    expect(screen.getByText('Calculating tipping points...')).toBeDefined();
+  });
+
+  it('does not display text when not provided', () => {
+    const { container } = render(<Loader />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Modal from '../Modal';
+
+describe('Modal Component', () => {
+  it('renders modal content when isOpen is true', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}} title="Test Modal">
+        <div data-testid="modal-content">Modal Content</div>
+      </Modal>
+    );
+    expect(screen.getByText('Test Modal')).toBeDefined();
+    expect(screen.getByTestId('modal-content')).toBeDefined();
+    expect(screen.getByRole('dialog')).toBeDefined();
+  });
+
+  it('does not render modal content when isOpen is false', () => {
+    render(
+      <Modal isOpen={false} onClose={() => {}} title="Test Modal">
+        <div data-testid="modal-content">Modal Content</div>
+      </Modal>
+    );
+    expect(screen.queryByText('Test Modal')).toBeNull();
+    expect(screen.queryByTestId('modal-content')).toBeNull();
+  });
+
+  it('calls onClose when close button (X) is clicked', () => {
+    const handleClose = vi.fn();
+    render(
+      <Modal isOpen={true} onClose={handleClose} title="Test Modal">
+        <div>Modal Content</div>
+      </Modal>
+    );
+    
+    const closeButton = screen.getByLabelText('Close modal');
+    fireEvent.click(closeButton);
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when clicking backdrop', () => {
+    const handleClose = vi.fn();
+    render(
+      <Modal isOpen={true} onClose={handleClose} title="Test Modal">
+        <div>Modal Content</div>
+      </Modal>
+    );
+    
+    const backdrop = screen.getByRole('presentation');
+    fireEvent.click(backdrop);
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const handleClose = vi.fn();
+    render(
+      <Modal isOpen={true} onClose={handleClose} title="Test Modal">
+        <div>Modal Content</div>
+      </Modal>
+    );
+    
+    fireEvent.keyDown(document, { key: 'Escape' });
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without a title', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}}>
+        <div data-testid="modal-content">Modal Content</div>
+      </Modal>
+    );
+    expect(screen.queryByText('Test Modal')).toBeNull();
+    expect(screen.getByTestId('modal-content')).toBeDefined();
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Toast.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Toast.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import Toast from '../Toast';
+
+describe('Toast Component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders message correctly', () => {
+    render(<Toast message="Operation successful" onClose={() => {}} />);
+    expect(screen.getByText('Operation successful')).toBeDefined();
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('applies correct styling for success type', () => {
+    render(<Toast message="Success" type="success" onClose={() => {}} />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-green-100');
+  });
+
+  it('applies correct styling for error type', () => {
+    render(<Toast message="Error" type="error" onClose={() => {}} />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-red-100');
+  });
+
+  it('calls onClose when dismiss button is clicked', () => {
+    const handleClose = vi.fn();
+    render(<Toast message="Dismissible" onClose={handleClose} />);
+    
+    const closeButton = screen.getByLabelText('Dismiss');
+    fireEvent.click(closeButton);
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Dismissible')).toBeNull();
+  });
+
+  it('calls onClose after default duration (4000ms)', () => {
+    const handleClose = vi.fn();
+    render(<Toast message="Auto-dismiss" onClose={handleClose} />);
+    
+    expect(handleClose).not.toHaveBeenCalled();
+    
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Auto-dismiss')).toBeNull();
+  });
+
+  it('calls onClose after custom duration', () => {
+    const handleClose = vi.fn();
+    render(<Toast message="Short-lived" duration={1000} onClose={handleClose} />);
+    
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
closes #175 

Implemented comprehensive unit tests for the core design system atoms as part of Phase 12 (Testing & CI). These tests ensure high reliability for the foundational UI components, verifying visual variants, interactive behaviors, and edge cases.

Key Changes:

Card.test.tsx: Verified children rendering, padding variants (sm, md, lg), and hover class application.
Input.test.tsx: Validated label/error rendering, input accessibility, and onChange event handlers.
Modal.test.tsx: Tested conditional rendering, backdrop and close button triggers, and Escape key dismissal.
Badge.test.tsx: Verified all 4 tiers (bronze, silver, gold, diamond) and tested the getTierFromScore helper utility.
Toast.test.tsx: Validated message rendering and tested auto-dismissal logic using Vitest fake timers.
Loader.test.tsx: Verified size variants and optional loading text display.
Verification: Ran the test suite locally in the frontend-scaffold directory:

Test Files: 6 passed (6 total)
Tests: 39 passed (39 total)
Status: All UI tests in src/components/ui/ are passing.
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)