### PR TITLE
fix(#278): add missing --native_token argument to contract initialize

### DIFF
--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -69,7 +69,8 @@ soroban contract invoke \
     initialize \
     --admin "$DEPLOYER_ADDR" \
     --fee_collector "$DEPLOYER_ADDR" \
-    --fee_bps 200
+    --fee_bps 200 \
+    --native_token "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 echo "Contract initialized with 2% fee."
 echo ""


### PR DESCRIPTION
Closes #278

---


## Testing
The deployment script will now pass all required arguments to the contract initializer, resolving the parameter mismatch error.