### PR TITLE
feat(frontend): create mini activity feed for dashboard overview (#155)

### DIFF
--- a/frontend-scaffold/src/features/dashboard/ActivityMini.tsx
+++ b/frontend-scaffold/src/features/dashboard/ActivityMini.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { ArrowRight, Inbox } from "lucide-react";
+import BigNumber from "bignumber.js";
+
+import { stroopToXlm, truncateString } from "../../helpers/format";
+import type { Tip } from "../../types";
+
+interface ActivityMiniProps {
+  tips: Tip[];
+  onViewAll?: () => void;
+}
+
+const MAX_TIPS = 5;
+
+function formatRelativeTime(timestamp: number): string {
+  const normalizedTs =
+    timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp;
+  const diffSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - normalizedTs) / 1000),
+  );
+
+  if (diffSeconds < 60) return "just now";
+  if (diffSeconds < 3600) {
+    const minutes = Math.floor(diffSeconds / 60);
+    return `${minutes}m ago`;
+  }
+  if (diffSeconds < 86400) {
+    const hours = Math.floor(diffSeconds / 3600);
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(diffSeconds / 86400);
+  return `${days}d ago`;
+}
+
+function formatXlmAmount(stroops: string): string {
+  return stroopToXlm(new BigNumber(stroops)).toFormat(2);
+}
+
+const ActivityMini: React.FC<ActivityMiniProps> = ({ tips, onViewAll }) => {
+  const recentTips = tips.slice(0, MAX_TIPS);
+
+  return (
+    <section className="border-2 border-black bg-white p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-black uppercase">Recent Activity</h2>
+        {tips.length > 0 && onViewAll && (
+          <button
+            type="button"
+            onClick={onViewAll}
+            className="flex items-center gap-1 text-xs font-black uppercase tracking-wide hover:underline"
+          >
+            View All Tips
+            <ArrowRight size={14} />
+          </button>
+        )}
+      </div>
+
+      {recentTips.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <Inbox size={28} className="text-gray-400" />
+          <p className="text-sm font-bold text-gray-500">
+            No tips yet — your recent activity will appear here.
+          </p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-dashed divide-gray-300">
+          {recentTips.map((tip, index) => (
+            <li
+              key={`${tip.from}-${tip.timestamp}-${index}`}
+              className="flex items-center gap-3 py-3 first:pt-0 last:pb-0"
+            >
+              <span className="w-16 flex-shrink-0 text-xs font-bold text-gray-500">
+                {formatRelativeTime(tip.timestamp)}
+              </span>
+
+              <span className="flex-shrink-0 border border-black bg-yellow-100 px-2 py-0.5 text-xs font-black tabular-nums">
+                {formatXlmAmount(tip.amount)} XLM
+              </span>
+
+              <span className="flex-shrink-0 text-xs font-bold">
+                {truncateString(tip.from)}
+              </span>
+
+              <span
+                className="min-w-0 flex-1 truncate text-xs text-gray-600"
+                title={tip.message || "No message"}
+              >
+                {tip.message || "—"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {tips.length > MAX_TIPS && onViewAll && (
+        <p className="mt-3 border-t border-dashed border-gray-300 pt-3 text-xs font-bold text-gray-500">
+          + {tips.length - MAX_TIPS} more tip{tips.length - MAX_TIPS !== 1 ? "s" : ""}
+        </p>
+      )}
+    </section>
+  );
+};
+
+export default ActivityMini;

--- a/frontend-scaffold/src/features/dashboard/OverviewTab.tsx
+++ b/frontend-scaffold/src/features/dashboard/OverviewTab.tsx
@@ -5,9 +5,9 @@ import {
 } from "lucide-react";
 
 import CreditBadge from "../../components/shared/CreditBadge";
-import TipCard from "../../components/shared/TipCard";
 import { StatCard } from "../../components/ui/StartCard";
 import EmptyState from "../../components/ui/EmptyState";
+import ActivityMini from "./ActivityMini";
 import QuickActions from "./QuickActions";
 import WithdrawModal from "./WithdrawModal";
 import { useDashboard } from "../../hooks/useDashboard";
@@ -152,33 +152,8 @@ const OverviewTab: React.FC = () => {
         </div>
       </section>
 
-      {/* Recent 5 tips */}
-      <section className="space-y-3">
-        <h2 className="text-lg font-black uppercase">Recent Tips</h2>
-        {tips.length === 0 ? (
-          <EmptyState
-            icon={<Coins />}
-            title="No tips yet"
-            description="Your recent tips will appear here once they start coming in."
-          />
-        ) : (
-          <div className="space-y-3">
-            {tips.slice(0, 5).map((tip) => (
-              <TipCard
-                key={`${tip.from}-${tip.timestamp}`}
-                tip={tip}
-                showReceiver={false}
-              />
-            ))}
-          </div>
-        )}
-        {tips.length > 5 && (
-          <p className="text-sm font-bold text-gray-500">
-            + {tips.length - 5} more tips — see the{" "}
-            <span className="underline cursor-pointer">Tips tab</span> for full history.
-          </p>
-        )}
-      </section>
+      {/* Mini activity feed */}
+      <ActivityMini tips={tips} />
 
       <WithdrawModal
         isOpen={withdrawOpen}


### PR DESCRIPTION
## What
Creates [ActivityMini.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/dashboard/ActivityMini.tsx:0:0-0:0) — a condensed activity feed showing the last 5 tips in a compact list on the dashboard overview tab.

## Why
Closes #155 — Provides creators with a quick glance at recent tip activity without navigating to the full Tips tab.

## How
- **New file**: [frontend-scaffold/src/features/dashboard/ActivityMini.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/dashboard/ActivityMini.tsx:0:0-0:0)
  - Compact list layout (not full TipCard) with each row showing:
    - Relative time (e.g. "5m ago", "2h ago", "3d ago")
    - Amount in XLM (converted from stroops via existing [stroopToXlm](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/helpers/format.ts:12:0-20:2) helper)
    - Truncated sender address (via existing [truncateString](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/helpers/format.ts:2:0-4:53) helper)
    - Single-line message preview (truncated with CSS)
  - Empty state with icon + message when no tips exist
  - Optional "View All Tips →" button via `onViewAll` callback prop
  - Overflow count ("+ N more tips") when list exceeds 5
- **Modified file**: [frontend-scaffold/src/features/dashboard/OverviewTab.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/dashboard/OverviewTab.tsx:0:0-0:0)
  - Replaced the full [TipCard](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/components/shared/TipCard.tsx:34:0-102:2)-based "Recent Tips" section with [ActivityMini](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/dashboard/ActivityMini.tsx:39:0-102:2)
  - Removed unused [TipCard](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/components/shared/TipCard.tsx:34:0-102:2) import

## Testing
- `npx tsc --noEmit` — no new TypeScript errors from changed files
- Verified component follows existing neobrutalist design patterns (border-2 border-black, font-black uppercase, dashed dividers)

## Checklist
- [x] Code compiles without new errors
- [x] Follows project style guidelines (PascalCase component, functional component with hooks, no `any` types)
- [x] Branch is up to date with `main`
- [x] Uses existing helpers — no duplicate utility code