### PR TITLE
feat(frontend): create tip confirmation modal with summary card (#138)

### DIFF
--- a/frontend-scaffold/src/features/tipping/TipConfirm.tsx
+++ b/frontend-scaffold/src/features/tipping/TipConfirm.tsx
@@ -1,35 +1,113 @@
 import React from 'react';
+import { HeartHandshake } from 'lucide-react';
 
-import Button from '@/components/ui/Button';
-import Modal from '@/components/ui/Modal';
+import Avatar from '../../components/ui/Avatar';
+import Button from '../../components/ui/Button';
+import Modal from '../../components/ui/Modal';
+import type { Profile } from '../../types';
+
+const ESTIMATED_TX_FEE = '0.00001';
 
 interface TipConfirmProps {
-  open: boolean;
-  amount: string;
-  username: string;
+  isOpen: boolean;
+  onClose: () => void;
   onConfirm: () => void;
-  onCancel: () => void;
-  submitting: boolean;
+  creator: Profile;
+  amount: string;
+  message: string;
+  submitting?: boolean;
 }
 
 const TipConfirm: React.FC<TipConfirmProps> = ({
-  open,
-  amount,
-  username,
+  isOpen,
+  onClose,
   onConfirm,
-  onCancel,
-  submitting,
+  creator,
+  amount,
+  message,
+  submitting = false,
 }) => {
   return (
-    <Modal isOpen={open} onClose={onCancel} title="Confirm tip">
-      <div className="space-y-4">
-        <p className="text-sm font-bold text-gray-700">You are about to send {amount} XLM to @{username}.</p>
+    <Modal isOpen={isOpen} onClose={onClose} title="Confirm Tip">
+      <div className="space-y-5">
+        {/* Headline */}
+        <p className="text-sm font-bold text-gray-700">
+          You&apos;re sending{' '}
+          <span className="text-black">{amount} XLM</span> to{' '}
+          <span className="text-black">@{creator.username}</span>
+        </p>
+
+        {/* Summary card */}
+        <div className="border-2 border-black bg-gray-50 p-4 space-y-4">
+          {/* Creator row */}
+          <div className="flex items-center gap-3">
+            <Avatar
+              address={creator.owner}
+              alt={creator.displayName || creator.username}
+              fallback={creator.displayName || creator.username}
+              size="md"
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-black">
+                {creator.displayName || creator.username}
+              </p>
+              <p className="text-xs font-bold text-gray-500">
+                @{creator.username}
+              </p>
+            </div>
+          </div>
+
+          {/* Detail rows */}
+          <dl className="space-y-2 text-sm">
+            <div className="flex items-center justify-between">
+              <dt className="font-bold uppercase tracking-wide text-gray-500 text-xs">
+                Amount
+              </dt>
+              <dd className="font-black tabular-nums">{amount} XLM</dd>
+            </div>
+
+            <div className="flex items-start justify-between gap-4">
+              <dt className="flex-shrink-0 font-bold uppercase tracking-wide text-gray-500 text-xs">
+                Message
+              </dt>
+              <dd
+                className="min-w-0 truncate text-right text-gray-700"
+                title={message || 'No message'}
+              >
+                {message || '—'}
+              </dd>
+            </div>
+
+            <div className="flex items-center justify-between border-t border-dashed border-gray-300 pt-2">
+              <dt className="font-bold uppercase tracking-wide text-gray-500 text-xs">
+                Est. TX Fee
+              </dt>
+              <dd className="font-bold text-gray-500 tabular-nums">
+                ~{ESTIMATED_TX_FEE} XLM
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        {/* Action buttons */}
         <div className="flex flex-col gap-2 sm:flex-row">
-          <Button type="button" loading={submitting} onClick={onConfirm} className="sm:flex-1">
-            Confirm and sign
-          </Button>
-          <Button type="button" variant="outline" onClick={onCancel} className="sm:flex-1">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={submitting}
+            className="sm:flex-1"
+          >
             Cancel
+          </Button>
+          <Button
+            type="button"
+            loading={submitting}
+            onClick={onConfirm}
+            icon={<HeartHandshake size={18} />}
+            className="sm:flex-1"
+          >
+            Confirm &amp; Sign
           </Button>
         </div>
       </div>

--- a/frontend-scaffold/src/features/tipping/TipPage.tsx
+++ b/frontend-scaffold/src/features/tipping/TipPage.tsx
@@ -188,11 +188,12 @@ const TipPage: React.FC = () => {
           )}
 
           <TipConfirm
-            open={step === "confirm"}
-            amount={amount}
-            username={creator.username}
+            isOpen={step === "confirm"}
+            onClose={reset}
             onConfirm={() => void confirmAndSign()}
-            onCancel={reset}
+            creator={creator}
+            amount={amount}
+            message={message}
             submitting={step === "signing" || step === "submitting"}
           />
 


### PR DESCRIPTION
## What
Rewrites [TipConfirm.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/tipping/TipConfirm.tsx:0:0-0:0) into a full confirmation modal that shows tip details
before the user signs the transaction.

## Why
Closes #138 — Users need to review tip details (recipient, amount, message, fees)
before committing to a wallet signature.

## How
- **Modified file**: [frontend-scaffold/src/features/tipping/TipConfirm.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/tipping/TipConfirm.tsx:0:0-0:0)
  - Props: `isOpen`, `onClose`, `onConfirm`, `creator: Profile`, `amount`, `message`, `submitting`
  - Headline: "You're sending {amount} XLM to @{creator.username}"
  - Summary card with:
    - Creator avatar (via Avatar component) + display name + @username
    - Amount in XLM
    - Single-line message preview (truncated)
    - Estimated TX fee (~0.00001 XLM)
  - Two buttons: "Cancel" (outline) and "Confirm & Sign" (primary with HeartHandshake icon)
  - Confirm & Sign triggers the wallet signing flow; Cancel closes the modal
  - Uses existing Modal, Avatar, and Button components
- **Modified file**: [frontend-scaffold/src/features/tipping/TipPage.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/tipping/TipPage.tsx:0:0-0:0)
  - Updated TipConfirm call site to pass new props (`isOpen`, `onClose`, `creator`, `message`)

## Testing
- `npx tsc --noEmit` — no new TypeScript errors from changed files
- Component follows existing neobrutalist design patterns (border-2 border-black, font-black uppercase, tabular-nums)

## Checklist
- [x] Code compiles without new errors
- [x] Follows project style guidelines (PascalCase component, functional component, no `any` types)
- [x] Branch is up to date with `main`
- [x] No `console.log` in production code
- [x] Uses existing shared components — no duplication