### PR TITLE
fix: replace parseInt with BigInt for safe amount conversion in sendTip (closes #277)

### DIFF
--- a/frontend-scaffold/src/hooks/useContract.ts
+++ b/frontend-scaffold/src/hooks/useContract.ts
@@ -28,6 +28,20 @@ import {
 import { ProfileFormData } from '../types/profile';
 
 /**
+ * Safely converts a numeric string to a BigInt.
+ * Validates that the input is a non-empty string of digits.
+ * @param amount The string to convert.
+ * @returns The converted BigInt.
+ * @throws Error if the amount format is invalid.
+ */
+function safeStringToBigInt(amount: string): bigint {
+  if (!amount || !/^\d+$/.test(amount)) {
+    throw new Error("Invalid amount format");
+  }
+  return BigInt(amount);
+}
+
+/**
  * Hook providing typed methods for all Tipz contract operations.
  */
 export const useContract = () => {
@@ -275,7 +289,7 @@ export const useContract = () => {
           "send_tip",
           accountToScVal(wallet.publicKey),
           accountToScVal(creator),
-          numberToI128(parseInt(amount)),
+          numberToI128(safeStringToBigInt(amount)),
           nativeToScVal(message)
         )
       )
@@ -303,7 +317,7 @@ export const useContract = () => {
         contract.call(
           "withdraw_tips",
           accountToScVal(wallet.publicKey),
-          numberToI128(parseInt(amount))
+          numberToI128(safeStringToBigInt(amount))
         )
       )
       .setTimeout(TimeoutInfinite)

--- a/frontend-scaffold/src/services/soroban.ts
+++ b/frontend-scaffold/src/services/soroban.ts
@@ -41,7 +41,7 @@ export const accountToScVal = (account: string) =>
   new Address(account).toScVal();
 
 // Can be used whenever you need an i128 argument for a contract method
-export const numberToI128 = (value: number): xdr.ScVal =>
+export const numberToI128 = (value: number | bigint): xdr.ScVal =>
   nativeToScVal(value, { type: "i128" });
 
 // Get a server configfured for a specific network
@@ -256,8 +256,8 @@ export const getEstimatedFee = async (
   // 'classic' tx fees are measured as the product of tx.fee * 'number of operations', In soroban contract tx,
   // there can only be single operation in the tx, so can make simplification
   // of total classic fees for the soroban transaction will be equal to incoming tx.fee + minResourceFee.
-  const classicFeeNum = parseInt(raw.fee, 10) || 0;
-  const minResourceFeeNum = parseInt(simResponse.minResourceFee, 10) || 0;
+  const classicFeeNum = BigInt(raw.fee || "0");
+  const minResourceFeeNum = BigInt(simResponse.minResourceFee || "0");
   const fee = (classicFeeNum + minResourceFeeNum).toString();
   return fee;
 };


### PR DESCRIPTION
## Fix: Prevent precision loss in sendTip amount conversion

Closes #277

### Problem

The current implementation uses:

```ts
numberToI128(parseInt(amount))
```

### Why this approach

Blockchain amounts require exact precision. Using BigInt ensures that even very large values are handled correctly without rounding or truncation.

This keeps the conversion safe and aligned with how on-chain integer values should be handled.


Focused on ensuring precise on-chain amount handling since even small precision errors can lead to incorrect transfers.

Also cleaned up other unsafe conversions for consistency.