### PR TITLE
feat(test): add unit tests for custom hooks

### DIFF
--- a/frontend-scaffold/src/hooks/__tests__/useProfile.test.ts
+++ b/frontend-scaffold/src/hooks/__tests__/useProfile.test.ts
@@ -1,0 +1,244 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useProfile } from '../useProfile';
+import { useWalletStore } from '../../store/walletStore';
+import { useProfileStore } from '../../store/profileStore';
+import { useContract } from '../useContract';
+import type { Profile } from '../../types/contract';
+
+// Mock the useContract hook
+vi.mock('../useContract');
+const mockUseContract = vi.mocked(useContract);
+
+describe('useProfile', () => {
+  const mockGetProfile = vi.fn();
+  const mockProfile: Profile = {
+    owner: 'GD1234567890ABCDEF',
+    username: 'testuser',
+    displayName: 'Test User',
+    bio: 'Test bio',
+    imageUrl: 'https://example.com/image.jpg',
+    xHandle: '@testuser',
+    xFollowers: 100,
+    xPosts: 50,
+    xReplies: 25,
+    creditScore: 75,
+    totalTipsReceived: '1000000',
+    totalTipsCount: 10,
+    balance: '500000',
+    registeredAt: 1640995200,
+    updatedAt: 1640995200,
+  };
+
+  beforeEach(() => {
+    // Reset stores before each test
+    useWalletStore.setState({
+      publicKey: null,
+      connected: false,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    useProfileStore.setState({
+      profile: null,
+      loading: false,
+      error: null,
+    });
+
+    mockGetProfile.mockClear();
+    mockUseContract.mockReturnValue({
+      getProfile: mockGetProfile,
+    } as any);
+  });
+
+  it('should return initial profile state', () => {
+    const { result } = renderHook(() => useProfile());
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isRegistered).toBe(false);
+  });
+
+  it('should fetch profile when wallet connects', async () => {
+    // Set wallet as connected
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    mockGetProfile.mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useProfile());
+
+    await waitFor(() => {
+      expect(result.current.profile).toEqual(mockProfile);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.isRegistered).toBe(true);
+    });
+
+    expect(mockGetProfile).toHaveBeenCalledWith('GD1234567890ABCDEF');
+  });
+
+  it('should clear profile when wallet disconnects', async () => {
+    // Start with connected state and profile
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    useProfileStore.setState({
+      profile: mockProfile,
+      loading: false,
+      error: null,
+    });
+
+    mockGetProfile.mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useProfile());
+
+    await waitFor(() => {
+      expect(result.current.profile).toEqual(mockProfile);
+    });
+
+    // Disconnect wallet
+    act(() => {
+      useWalletStore.getState().disconnect();
+    });
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isRegistered).toBe(false);
+  });
+
+  it('should handle not registered error', async () => {
+    // Set wallet as connected
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    const notRegisteredError = new Error('Profile not found');
+    mockGetProfile.mockRejectedValue(notRegisteredError);
+
+    const { result } = renderHook(() => useProfile());
+
+    await waitFor(() => {
+      expect(result.current.profile).toBeNull();
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.isRegistered).toBe(false);
+    });
+  });
+
+  it('should handle other errors', async () => {
+    // Set wallet as connected
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    const networkError = new Error('Network error');
+    mockGetProfile.mockRejectedValue(networkError);
+
+    const { result } = renderHook(() => useProfile());
+
+    await waitFor(() => {
+      expect(result.current.profile).toBeNull();
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBe('Network error');
+      expect(result.current.isRegistered).toBe(false);
+    });
+  });
+
+  it('should refetch profile manually', async () => {
+    // Set wallet as connected
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    mockGetProfile.mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useProfile());
+
+    await waitFor(() => {
+      expect(result.current.profile).toEqual(mockProfile);
+    });
+
+    // Clear the mock to test refetch
+    mockGetProfile.mockClear();
+    mockGetProfile.mockResolvedValue(mockProfile);
+
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(mockGetProfile).toHaveBeenCalledTimes(1);
+      expect(mockGetProfile).toHaveBeenCalledWith('GD1234567890ABCDEF');
+    });
+  });
+
+  it('should not fetch profile when wallet is not connected', () => {
+    const { result } = renderHook(() => useProfile());
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isRegistered).toBe(false);
+
+    expect(mockGetProfile).not.toHaveBeenCalled();
+  });
+
+  it('should handle loading state during fetch', async () => {
+    // Set wallet as connected
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    let resolveProfile: (value: Profile) => void;
+    const profilePromise = new Promise<Profile>((resolve) => {
+      resolveProfile = resolve;
+    });
+
+    mockGetProfile.mockReturnValue(profilePromise);
+
+    const { result } = renderHook(() => useProfile());
+
+    // Should be loading initially
+    expect(result.current.loading).toBe(true);
+
+    // Resolve the promise
+    act(() => {
+      resolveProfile!(mockProfile);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.profile).toEqual(mockProfile);
+    });
+  });
+});

--- a/frontend-scaffold/src/hooks/__tests__/useTipz.test.ts
+++ b/frontend-scaffold/src/hooks/__tests__/useTipz.test.ts
@@ -1,0 +1,260 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useTipz } from '../useTipz';
+import { useContract } from '../useContract';
+
+// Mock the useContract hook
+vi.mock('../useContract');
+const mockUseContract = vi.mocked(useContract);
+
+describe('useTipz', () => {
+  const mockContractSendTip = vi.fn();
+  const mockContractWithdrawTips = vi.fn();
+
+  beforeEach(() => {
+    mockContractSendTip.mockClear();
+    mockContractWithdrawTips.mockClear();
+    
+    mockUseContract.mockReturnValue({
+      sendTip: mockContractSendTip,
+      withdrawTips: mockContractWithdrawTips,
+    } as any);
+  });
+
+  it('should return initial state', () => {
+    const { result } = renderHook(() => useTipz());
+
+    expect(result.current.sending).toBe(false);
+    expect(result.current.withdrawing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.txHash).toBeNull();
+    expect(result.current.txStatus).toBe('idle');
+    expect(typeof result.current.sendTip).toBe('function');
+    expect(typeof result.current.withdrawTips).toBe('function');
+    expect(typeof result.current.reset).toBe('function');
+  });
+
+  it('should handle successful tip sending', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    const mockTxHash = 'tx_hash_123';
+    mockContractSendTip.mockResolvedValue(mockTxHash);
+
+    await act(async () => {
+      await result.current.sendTip('creator_address', '1000', 'Great content!');
+    });
+
+    expect(mockContractSendTip).toHaveBeenCalledWith('creator_address', '1000', 'Great content!');
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('success');
+      expect(result.current.sending).toBe(false);
+      expect(result.current.txHash).toBe(mockTxHash);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  it('should handle tip sending error', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    const errorMessage = 'Insufficient balance';
+    mockContractSendTip.mockRejectedValue(new Error(errorMessage));
+
+    await act(async () => {
+      try {
+        await result.current.sendTip('creator_address', '1000', 'Great content!');
+      } catch (error) {
+        // Expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('error');
+      expect(result.current.sending).toBe(false);
+      expect(result.current.error).toBe(errorMessage);
+      expect(result.current.txHash).toBeNull();
+    });
+  });
+
+  it('should handle successful withdrawal', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    const mockTxHash = 'withdraw_tx_hash_456';
+    mockContractWithdrawTips.mockResolvedValue(mockTxHash);
+
+    await act(async () => {
+      await result.current.withdrawTips('5000');
+    });
+
+    expect(mockContractWithdrawTips).toHaveBeenCalledWith('5000');
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('success');
+      expect(result.current.withdrawing).toBe(false);
+      expect(result.current.txHash).toBe(mockTxHash);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  it('should handle withdrawal error', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    const errorMessage = 'Withdrawal failed';
+    mockContractWithdrawTips.mockRejectedValue(new Error(errorMessage));
+
+    await act(async () => {
+      try {
+        await result.current.withdrawTips('5000');
+      } catch (error) {
+        // Expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('error');
+      expect(result.current.withdrawing).toBe(false);
+      expect(result.current.error).toBe(errorMessage);
+      expect(result.current.txHash).toBeNull();
+    });
+  });
+
+  it('should reset state', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    // First, trigger an error state
+    mockContractSendTip.mockRejectedValue(new Error('Test error'));
+
+    await act(async () => {
+      try {
+        await result.current.sendTip('creator_address', '1000', 'Test');
+      } catch (error) {
+        // Expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('error');
+      expect(result.current.error).toBe('Test error');
+    });
+
+    // Reset the state
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.sending).toBe(false);
+    expect(result.current.withdrawing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.txHash).toBeNull();
+    expect(result.current.txStatus).toBe('idle');
+  });
+
+  it('should show signing state during tip sending', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    let resolveTip: (value: string) => void;
+    const tipPromise = new Promise<string>((resolve) => {
+      resolveTip = resolve;
+    });
+
+    mockContractSendTip.mockReturnValue(tipPromise);
+
+    await act(async () => {
+      result.current.sendTip('creator_address', '1000', 'Test');
+    });
+
+    expect(result.current.txStatus).toBe('signing');
+    expect(result.current.sending).toBe(true);
+
+    // Resolve the promise
+    act(() => {
+      resolveTip!('tx_hash_123');
+    });
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('success');
+      expect(result.current.sending).toBe(false);
+    });
+  });
+
+  it('should show signing state during withdrawal', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    let resolveWithdraw: (value: string) => void;
+    const withdrawPromise = new Promise<string>((resolve) => {
+      resolveWithdraw = resolve;
+    });
+
+    mockContractWithdrawTips.mockReturnValue(withdrawPromise);
+
+    await act(async () => {
+      result.current.withdrawTips('5000');
+    });
+
+    expect(result.current.txStatus).toBe('signing');
+    expect(result.current.withdrawing).toBe(true);
+
+    // Resolve the promise
+    act(() => {
+      resolveWithdraw!('withdraw_tx_hash_456');
+    });
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('success');
+      expect(result.current.withdrawing).toBe(false);
+    });
+  });
+
+  it('should handle non-Error objects in error handling', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    // Mock rejection with a string instead of Error
+    mockContractSendTip.mockRejectedValue('String error');
+
+    await act(async () => {
+      try {
+        await result.current.sendTip('creator_address', '1000', 'Test');
+      } catch (error) {
+        // Expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('error');
+      expect(result.current.sending).toBe(false);
+      expect(result.current.error).toBe('Failed to send tip');
+    });
+  });
+
+  it('should clear previous state when starting new operation', async () => {
+    const { result } = renderHook(() => useTipz());
+    
+    // Start with an error state
+    mockContractSendTip.mockRejectedValueOnce(new Error('First error'));
+
+    await act(async () => {
+      try {
+        await result.current.sendTip('creator_address', '1000', 'Test');
+      } catch (error) {
+        // Expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.txStatus).toBe('error');
+      expect(result.current.error).toBe('First error');
+    });
+
+    // Start a successful tip
+    mockContractSendTip.mockResolvedValue('tx_hash_123');
+
+    await act(async () => {
+      await result.current.sendTip('creator_address', '2000', 'Another tip');
+    });
+
+    // State should be reset before the new operation
+    expect(result.current.error).toBeNull();
+    expect(result.current.txHash).toBe('tx_hash_123');
+    expect(result.current.txStatus).toBe('success');
+  });
+});

--- a/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
+++ b/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
@@ -1,0 +1,187 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useWallet } from '../useWallet';
+import { useWalletStore } from '../../store/walletStore';
+
+// Mock the StellarWalletsKit
+vi.mock('@creit.tech/stellar-wallets-kit', () => ({
+  StellarWalletsKit: vi.fn().mockImplementation(() => ({
+    openModal: vi.fn(),
+    setWallet: vi.fn(),
+    getAddress: vi.fn(),
+    signTransaction: vi.fn(),
+  })),
+  WalletNetwork: {
+    TESTNET: 'TESTNET',
+    PUBLIC: 'PUBLIC',
+  },
+  FREIGHTER_ID: 'freighter',
+  FreighterModule: vi.fn(),
+  AlbedoModule: vi.fn(),
+  xBullModule: vi.fn(),
+}));
+
+// Mock window.freighter
+Object.defineProperty(window, 'freighter', {
+  value: {
+    getNetwork: vi.fn(),
+    getAddress: vi.fn(),
+  },
+  writable: true,
+});
+
+describe('useWallet', () => {
+  beforeEach(() => {
+    // Reset the store before each test
+    useWalletStore.setState({
+      publicKey: null,
+      connected: false,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+    vi.clearAllMocks();
+  });
+
+  it('should return initial wallet state', () => {
+    const { result } = renderHook(() => useWallet());
+
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.network).toBe('TESTNET');
+  });
+
+  it('should connect wallet and set publicKey', async () => {
+    const { result } = renderHook(() => useWallet());
+    
+    const mockAddress = 'GD1234567890ABCDEF';
+    const mockOnWalletSelected = vi.fn();
+    
+    // Mock the kit.openModal to call the callback with address
+    const StellarWalletsKit = await import('@creit.tech/stellar-wallets-kit');
+    const mockKit = (StellarWalletsKit.StellarWalletsKit as any).mock.results[0].value;
+    mockKit.openModal.mockImplementation(({ onWalletSelected }) => {
+      mockOnWalletSelected.mockImplementation(async (option: any) => {
+        mockKit.setWallet(option.id);
+        mockKit.getAddress.mockResolvedValue({ address: mockAddress });
+        await onWalletSelected(option);
+      });
+      return Promise.resolve();
+    });
+
+    await act(async () => {
+      result.current.connect();
+    });
+
+    // Simulate wallet selection
+    await act(async () => {
+      await mockOnWalletSelected({ id: 'freighter' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.publicKey).toBe(mockAddress);
+      expect(result.current.connected).toBe(true);
+      expect(result.current.connecting).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  it('should disconnect wallet and clear state', () => {
+    // First set up a connected state
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    const { result } = renderHook(() => useWallet());
+
+    expect(result.current.publicKey).toBe('GD1234567890ABCDEF');
+    expect(result.current.connected).toBe(true);
+
+    act(() => {
+      result.current.disconnect();
+    });
+
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should handle connection errors', async () => {
+    const { result } = renderHook(() => useWallet());
+    
+    const mockOnWalletSelected = vi.fn();
+    
+    // Mock the kit.openModal to call the callback with error
+    const StellarWalletsKit = await import('@creit.tech/stellar-wallets-kit');
+    const mockKit = (StellarWalletsKit.StellarWalletsKit as any).mock.results[0].value;
+    mockKit.openModal.mockImplementation(({ onWalletSelected }) => {
+      mockOnWalletSelected.mockImplementation(async (option: any) => {
+        mockKit.setWallet(option.id);
+        mockKit.getAddress.mockRejectedValue(new Error('Connection failed'));
+        await onWalletSelected(option);
+      });
+      return Promise.resolve();
+    });
+
+    await act(async () => {
+      result.current.connect();
+    });
+
+    // Simulate wallet selection with error
+    await act(async () => {
+      await mockOnWalletSelected({ id: 'freighter' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.publicKey).toBeNull();
+      expect(result.current.connected).toBe(false);
+      expect(result.current.connecting).toBe(false);
+      expect(result.current.error).toBe('Connection failed');
+    });
+  });
+
+  it('should set network', () => {
+    const { result } = renderHook(() => useWallet());
+
+    expect(result.current.network).toBe('TESTNET');
+
+    act(() => {
+      result.current.setNetwork('PUBLIC');
+    });
+
+    expect(result.current.network).toBe('PUBLIC');
+  });
+
+  it('should sign transaction', async () => {
+    const mockXdr = 'AAAAAgAAAAA=';
+    const mockSignedXdr = 'AAAAAwAAAAA=';
+    
+    // Set up connected state
+    useWalletStore.setState({
+      publicKey: 'GD1234567890ABCDEF',
+      connected: true,
+      connecting: false,
+      error: null,
+      network: 'TESTNET',
+    });
+
+    const { result } = renderHook(() => useWallet());
+    
+    const StellarWalletsKit = await import('@creit.tech/stellar-wallets-kit');
+    const mockKit = (StellarWalletsKit.StellarWalletsKit as any).mock.results[0].value;
+    mockKit.signTransaction.mockResolvedValue({ signedTxXdr: mockSignedXdr });
+
+    const signedTx = await result.current.signTransaction(mockXdr);
+
+    expect(signedTx).toBe(mockSignedXdr);
+    expect(mockKit.signTransaction).toHaveBeenCalledWith(mockXdr, {
+      address: 'GD1234567890ABCDEF',
+    });
+  });
+});

--- a/frontend-scaffold/src/test/setup.ts
+++ b/frontend-scaffold/src/test/setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/matchers';


### PR DESCRIPTION
## Summary

- Create useWallet.test.ts with wallet connection/disconnection tests
- Create useProfile.test.ts with profile fetching and state management tests
- Create useTipz.test.ts with tip/withdrawal state transition tests
- Mock contract calls and wallet kit using Vitest
- Use @testing-library/react renderHook for hook testing
- Fix test setup for Vitest compatibility

Closes #176
