### PR TITLE
fix: resolve assigned TipPage and docs issues

### DIFF
--- a/docs/FRONTEND_GUIDE.md
+++ b/docs/FRONTEND_GUIDE.md
@@ -276,6 +276,9 @@ Defined in `tailwind.config.js`:
 
 ## Routing
 
+`App.tsx` mounts `BrowserRouter` and calls `useRoutes(routes)`, while the
+route definitions themselves live in `routes.tsx`.
+
 ```typescript
 // routes.tsx
 import { createBrowserRouter } from 'react-router-dom';

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -109,6 +109,10 @@ npm run dev
 
 The app will be available at **http://localhost:3000**.
 
+`npm run dev` is the recommended Vite workflow for local development in this
+repo. `npm start` is only an alias to `vite`, so docs and examples should use
+the Vite-style command above.
+
 ---
 
 ## 4. Freighter Wallet Setup

--- a/frontend-scaffold/src/features/tipping/TipAmountInput.tsx
+++ b/frontend-scaffold/src/features/tipping/TipAmountInput.tsx
@@ -1,26 +1,33 @@
-import React, { useEffect, useMemo, useState } from "react";
+import BigNumber from "bignumber.js";
+import React, { useEffect, useState } from "react";
 
 import Input from "../../components/ui/Input";
 import Button from "../../components/ui/Button";
 import { env } from "../../helpers/env";
+import { stroopToXlm, xlmToStroop } from "../../helpers/format";
 import { useWallet, useContract } from "../../hooks";
+import { BASE_FEE } from "../../services";
 
 interface TipAmountInputProps {
   amount: string;
   onChange: (amount: string) => void;
-  balance?: string;
 }
 
 const QUICK_AMOUNTS = ["1", "5", "10", "25", "50"];
 const DEFAULT_MIN_TIP_XLM = "0.1"; // 1,000,000 stroops
+const ESTIMATED_NETWORK_FEE_XLM = new BigNumber(stroopToXlm(BASE_FEE, 5));
 
-const TipAmountInput: React.FC<TipAmountInputProps> = ({ amount, onChange, balance }) => {
+const formatXlmDisplay = (value: BigNumber): string => {
+  const decimalPlaces = value.decimalPlaces() ?? 0;
+  return value.toFormat(Math.min(7, Math.max(2, decimalPlaces)));
+};
+
+const TipAmountInput: React.FC<TipAmountInputProps> = ({ amount, onChange }) => {
   const { connected, publicKey } = useWallet();
   const { getMinTipAmount } = useContract();
   const [useCustom, setUseCustom] = useState(!QUICK_AMOUNTS.includes(amount));
   const [fetchedBalance, setFetchedBalance] = useState<string>("");
   const [minTipXlm, setMinTipXlm] = useState<string>(DEFAULT_MIN_TIP_XLM);
-  const [loadingMinTip, setLoadingMinTip] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -66,7 +73,6 @@ const TipAmountInput: React.FC<TipAmountInputProps> = ({ amount, onChange, balan
     let active = true;
 
     const fetchMinTip = async () => {
-      setLoadingMinTip(true);
       try {
         const minTip = await getMinTipAmount();
         if (active) {
@@ -78,10 +84,6 @@ const TipAmountInput: React.FC<TipAmountInputProps> = ({ amount, onChange, balan
         if (active) {
           setMinTipXlm(DEFAULT_MIN_TIP_XLM);
         }
-      } finally {
-        if (active) {
-          setLoadingMinTip(false);
-        }
       }
     };
 
@@ -92,34 +94,42 @@ const TipAmountInput: React.FC<TipAmountInputProps> = ({ amount, onChange, balan
     };
   }, [getMinTipAmount]);
 
-  const effectiveBalance = balance ?? fetchedBalance;
+  const effectiveBalance = fetchedBalance;
   const numericAmount = Number(amount);
   const numericBalance = Number(effectiveBalance);
   const numericMinTip = Number(minTipXlm);
+  const amountBigNumber = Number.isNaN(numericAmount)
+    ? new BigNumber(0)
+    : new BigNumber(amount || "0");
+  const amountInStroops = Number.isNaN(numericAmount) || numericAmount <= 0
+    ? null
+    : xlmToStroop(amount);
+  const totalCost = amountBigNumber.plus(ESTIMATED_NETWORK_FEE_XLM);
+  const balanceBigNumber = !effectiveBalance || Number.isNaN(numericBalance)
+    ? null
+    : new BigNumber(effectiveBalance);
 
-  const amountError = useMemo(() => {
-    if (!amount.trim()) {
-      return "Enter a tip amount.";
-    }
+  let amountError: string | undefined;
 
-    if (Number.isNaN(numericAmount)) {
-      return "Amount must be numeric.";
-    }
-
-    if (numericAmount <= 0) {
-      return "Amount must be greater than 0.";
-    }
-
-    if (numericAmount < numericMinTip) {
-      return `Minimum tip is ${minTipXlm} XLM.`;
-    }
-
-    if (connected && effectiveBalance && !Number.isNaN(numericBalance) && numericAmount > numericBalance) {
-      return "Amount exceeds your available XLM balance.";
-    }
-
-    return undefined;
-  }, [amount, connected, effectiveBalance, numericAmount, numericBalance, minTipXlm, numericMinTip]);
+  if (!amount.trim()) {
+    amountError = "Enter a tip amount.";
+  } else if (Number.isNaN(numericAmount)) {
+    amountError = "Amount must be numeric.";
+  } else if (numericAmount <= 0) {
+    amountError = "Amount must be greater than 0.";
+  } else if (numericAmount < numericMinTip) {
+    amountError = `Minimum tip is ${minTipXlm} XLM.`;
+  } else if (
+    connected &&
+    effectiveBalance &&
+    !Number.isNaN(numericBalance) &&
+    numericAmount > numericBalance
+  ) {
+    amountError = "Amount exceeds your available XLM balance.";
+  } else if (connected && balanceBigNumber && totalCost.gt(balanceBigNumber)) {
+    amountError =
+      "Total cost exceeds your available XLM balance once network fees are included.";
+  }
 
   return (
     <div className="space-y-4">
@@ -178,6 +188,50 @@ const TipAmountInput: React.FC<TipAmountInputProps> = ({ amount, onChange, balan
       {!useCustom && amountError && (
         <p className="text-sm font-medium text-red-600">{amountError}</p>
       )}
+
+      <div className="space-y-3 border-2 border-black bg-white p-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-600">
+            Payment summary
+          </p>
+          <p className="text-[11px] font-bold text-gray-500">
+            Estimated before signing
+          </p>
+        </div>
+
+        <dl className="space-y-2 text-sm">
+          <div className="flex items-center justify-between gap-4">
+            <dt className="font-bold text-gray-600">Tip amount</dt>
+            <dd className="text-right font-black tabular-nums">
+              {formatXlmDisplay(amountBigNumber)} XLM
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <dt className="font-bold text-gray-600">Tip amount (stroops)</dt>
+            <dd className="text-right font-bold tabular-nums text-gray-700">
+              {amountInStroops ? amountInStroops.toFormat(0) : "0"}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <dt className="font-bold text-gray-600">Estimated network fee</dt>
+            <dd className="text-right font-bold tabular-nums text-gray-700">
+              {formatXlmDisplay(ESTIMATED_NETWORK_FEE_XLM)} XLM
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-4 border-t-2 border-dashed border-black pt-2">
+            <dt className="font-black uppercase tracking-wide">Total cost</dt>
+            <dd className="text-right font-black tabular-nums">
+              {formatXlmDisplay(totalCost)} XLM
+            </dd>
+          </div>
+        </dl>
+
+        {connected && balanceBigNumber && totalCost.gt(balanceBigNumber) && (
+          <p className="border-2 border-red-600 bg-red-50 px-3 py-2 text-sm font-bold text-red-700">
+            This tip total is higher than your current wallet balance.
+          </p>
+        )}
+      </div>
 
       <p className="text-sm font-bold text-gray-600">
         Your balance: {effectiveBalance ? `${Number(effectiveBalance).toLocaleString()} XLM` : "Connect wallet to load balance"}

--- a/frontend-scaffold/src/features/tipping/TipForm.tsx
+++ b/frontend-scaffold/src/features/tipping/TipForm.tsx
@@ -35,7 +35,6 @@ const TipForm: React.FC<TipFormProps> = ({ creator, onSubmit, isSubmitting = fal
       <TipAmountInput 
         amount={amount} 
         onChange={setAmount} 
-        balance={creator.balance} 
       />
 
       <TipMessageInput 

--- a/frontend-scaffold/src/features/tipping/TipMessageInput.tsx
+++ b/frontend-scaffold/src/features/tipping/TipMessageInput.tsx
@@ -11,7 +11,7 @@ interface TipMessageInputProps {
 const TipMessageInput: React.FC<TipMessageInputProps> = ({
   message,
   onChange,
-  maxLength = 160,
+  maxLength = 280,
   disabled = false,
 }) => {
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/frontend-scaffold/src/features/tipping/TipPage.tsx
+++ b/frontend-scaffold/src/features/tipping/TipPage.tsx
@@ -136,6 +136,10 @@ const TipPage: React.FC = () => {
             <h2 className="mt-2 text-2xl font-black uppercase">Tip in XLM</h2>
           </div>
 
+          <div className="border-2 border-black bg-yellow-100 p-4 text-sm font-bold text-gray-800">
+            Any connected wallet can send a tip. Supporters do not need to create a Stellar Tipz profile first.
+          </div>
+
           {!connected && (
             <div className="border-2 border-black bg-orange-100 p-4 text-sm font-bold">
               Connect a wallet before signing the transaction.
@@ -153,12 +157,12 @@ const TipPage: React.FC = () => {
             />
           ) : (
             <form className="space-y-4" onSubmit={handleSubmit}>
-              <TipAmountInput amount={amount} onChange={setAmount} balance={creator.balance} />
+              <TipAmountInput amount={amount} onChange={setAmount} />
 
               <Textarea
                 label="Message"
                 placeholder="Say why you are supporting this creator."
-                maxLength={160}
+                maxLength={280}
                 value={message}
                 onChange={(event) => setMessage(event.target.value)}
               />


### PR DESCRIPTION
Closes #354
Closes #352
Closes #346
Closes #344

## Changes
* Add a pre-submit payment summary on `TipPage` showing the selected XLM amount, stroop conversion, estimated network fee, and total cost.
* Warn when the total tip cost exceeds the connected wallet balance and clarify that supporters do not need a Stellar Tipz profile before tipping.
* Raise the tip message character limit from 160 to 280 in the active `TipPage` flow and in the shared tipping message component.
* Stop piping the creator balance into the tipping amount input so the balance display uses the connected tipper wallet instead.
* Clarify in `FRONTEND_GUIDE.md` that `App.tsx` consumes route definitions from `routes.tsx`.
* Reinforce in `SETUP.md` that `npm run dev` is the recommended Vite workflow and `localhost:3000` is the documented dev URL.

## Testing
* Ran `npx eslint src/features/tipping/TipAmountInput.tsx src/features/tipping/TipPage.tsx src/features/tipping/TipForm.tsx src/features/tipping/TipMessageInput.tsx`.
* Confirmed there are no remaining `TipPage`/`TipMessageInput` 160-character limits or `creator.balance` `TipAmountInput` usages.
* Noted that `npm run lint` still reports unrelated pre-existing repo issues outside this change, including `DashboardSkeleton.tsx` using `Math.random()` during render.