### PR TITLE
fix: resolve deploy, wallet, withdraw, and spec issues

### DIFF
--- a/docs/CONTRACT_SPEC.md
+++ b/docs/CONTRACT_SPEC.md
@@ -1,16 +1,16 @@
 # Smart Contract Specification
 
-> Complete technical specification for the Stellar Tipz Soroban smart contract.
+> Technical reference for the Stellar Tipz Soroban smart contract.
 
 ---
 
 ## Overview
 
-The Tipz contract manages creator profiles, tip transactions, balance accounting, credit scores, and a leaderboard — all on-chain via Stellar's Soroban runtime.
+The Tipz contract manages creator profiles, XLM tipping, withdrawal accounting,
+credit scoring, and leaderboard state directly on Soroban.
 
-**Contract ID**: TBD (deployed to Testnet)  
 **Language**: Rust (Soroban SDK)  
-**Network**: Stellar Testnet → Mainnet  
+**Network target**: Stellar Testnet -> Mainnet
 
 ---
 
@@ -20,23 +20,22 @@ The Tipz contract manages creator profiles, tip transactions, balance accounting
 
 ```rust
 #[contracttype]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Profile {
-    pub owner: Address,           // Stellar address of the creator
-    pub username: String,         // Unique @username (lowercase, alphanumeric + underscore)
-    pub display_name: String,     // Display name (max 64 chars)
-    pub bio: String,              // Short bio (max 280 chars)
-    pub image_url: String,        // IPFS CID or URL for profile image
-    pub x_handle: String,         // X (Twitter) handle
-    pub x_followers: u32,         // Follower count (updated off-chain)
-    pub x_posts: u32,             // Post count
-    pub x_replies: u32,           // Reply count
-    pub credit_score: u32,        // Calculated score (0-1000)
-    pub total_tips_received: i128,// Lifetime tips received (in stroops)
-    pub total_tips_count: u32,    // Number of tips received
-    pub balance: i128,            // Current withdrawable balance (in stroops)
-    pub registered_at: u64,       // Ledger timestamp of registration
-    pub updated_at: u64,          // Last update timestamp
+    pub owner: Address,            // Stellar address of the creator
+    pub username: String,          // Unique username (3-32 chars, lowercase)
+    pub display_name: String,      // Display name (1-64 chars)
+    pub bio: String,               // Bio (0-280 chars)
+    pub image_url: String,         // Profile image URL or IPFS CID
+    pub x_handle: String,          // X handle
+    pub x_followers: u32,          // X follower count
+    pub x_engagement_avg: u32,     // Average X engagement per post
+    pub credit_score: u32,         // Current credit score (0-100)
+    pub total_tips_received: i128, // Lifetime tips received in stroops
+    pub total_tips_count: u32,     // Number of tips received
+    pub balance: i128,             // Current withdrawable balance in stroops
+    pub registered_at: u64,        // Ledger timestamp of registration
+    pub updated_at: u64,           // Last profile update timestamp
 }
 ```
 
@@ -46,12 +45,12 @@ pub struct Profile {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct Tip {
-    pub id: u32,              // Unique tip ID
-    pub tipper: Address,      // Tipper's address
-    pub creator: Address,     // Creator's address
-    pub amount: i128,         // Tip amount (in stroops)
-    pub message: String,      // Optional message (max 280 chars)
-    pub timestamp: u64,       // Timestamp of the tip
+    pub id: u32,          // Global tip id
+    pub tipper: Address,  // Sender address
+    pub creator: Address, // Recipient address
+    pub amount: i128,     // Tip amount in stroops
+    pub message: String,  // Optional message
+    pub timestamp: u64,   // Ledger timestamp
 }
 ```
 
@@ -68,217 +67,11 @@ pub struct LeaderboardEntry {
 }
 ```
 
-### DataKey (Storage Keys)
+### ContractStats
 
 ```rust
 #[contracttype]
-pub enum DataKey {
-    Admin,                     // Address — contract admin
-    FeePercent,               // u32 — withdrawal fee (basis points, e.g., 200 = 2%)
-    FeeCollector,             // Address — receives collected fees
-    TotalFeesCollected,       // i128 — lifetime fees collected
-    Profile(Address),         // Profile struct for a creator
-    UsernameToAddress(String),// Reverse lookup: username → address
-    TipCount,                // u32 — global tip counter
-    Tip(u32),                // Individual tip record by index
-    Leaderboard,             // Vec<LeaderboardEntry> — top creators
-    TotalCreators,           // u32 — total registered creators
-    TotalTipsVolume,         // i128 — lifetime tip volume
-}
-```
-
----
-
-## Public Functions
-
-### Initialization
-
-#### `initialize(admin: Address, fee_collector: Address, fee_bps: u32)`
-
-Initializes the contract. Can only be called once.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `admin` | `Address` | Admin address (can update config) |
-| `fee_collector` | `Address` | Address that receives withdrawal fees |
-| `fee_bps` | `u32` | Fee in basis points (200 = 2%) |
-
-**Errors**: `AlreadyInitialized`
-
----
-
-### Profile Management
-
-#### `register_profile(caller: Address, username: String, display_name: String, bio: String, image_url: String, x_handle: String)`
-
-Register a new creator profile.
-
-| Parameter | Type | Constraints |
-|-----------|------|-------------|
-| `caller` | `Address` | Must authorize |
-| `username` | `String` | 3-32 chars, lowercase alphanumeric + underscore, unique |
-| `display_name` | `String` | 1-64 chars |
-| `bio` | `String` | 0-280 chars |
-| `image_url` | `String` | 0-256 chars |
-| `x_handle` | `String` | 0-32 chars |
-
-**Returns**: `Profile`  
-**Errors**: `AlreadyRegistered`, `UsernameTaken`, `InvalidUsername`, `InvalidDisplayName`
-
----
-
-#### `update_profile(caller: Address, display_name: Option<String>, bio: Option<String>, image_url: Option<String>, x_handle: Option<String>)`
-
-Update an existing profile. Only the profile owner can call this.
-
-**Errors**: `NotRegistered`, `InvalidDisplayName`
-
----
-
-#### `update_x_metrics(caller: Address, target: Address, followers: u32, posts: u32, replies: u32)`
-
-Update X (Twitter) metrics for a profile. Admin-only (metrics are fetched off-chain).
-
-**Errors**: `NotAdmin`, `NotRegistered`
-
----
-
-#### `get_profile(address: Address) → Profile`
-
-Read a creator's profile.
-
-**Errors**: `NotRegistered`
-
----
-
-#### `get_profile_by_username(username: String) → Profile`
-
-Look up a profile by username.
-
-**Errors**: `NotFound`
-
----
-
-### Tipping
-
-#### `send_tip(tipper: Address, creator: Address, amount: i128, message: String)`
-
-Send an XLM tip to a registered creator.
-
-| Parameter | Type | Constraints |
-|-----------|------|-------------|
-| `tipper` | `Address` | Must authorize, cannot tip self |
-| `creator` | `Address` | Must be registered |
-| `amount` | `i128` | > 0, in stroops (1 XLM = 10,000,000 stroops) |
-| `message` | `String` | 0-280 chars |
-
-**Flow**:
-1. Validate tipper authorization
-2. Validate creator is registered
-3. Validate amount > 0
-4. Transfer XLM from tipper to contract
-5. Credit creator's balance
-6. Update tip stats (count, volume)
-7. Store tip record
-8. Update leaderboard if applicable
-9. Emit `TipSent` event
-
-**Errors**: `NotRegistered`, `InvalidAmount`, `CannotTipSelf`, `InsufficientBalance`
-
----
-
-#### `withdraw_tips(caller: Address, amount: i128)`
-
-Withdraw accumulated tips. A percentage fee is deducted.
-
-| Parameter | Type | Constraints |
-|-----------|------|-------------|
-| `caller` | `Address` | Must authorize, must be registered |
-| `amount` | `i128` | > 0, ≤ caller's balance |
-
-**Flow**:
-1. Validate caller authorization
-2. Validate caller is registered
-3. Validate amount ≤ balance
-4. Calculate fee: `amount × fee_bps / 10000`
-5. Transfer `amount - fee` to caller
-6. Transfer `fee` to fee collector
-7. Deduct `amount` from caller's balance
-8. Emit `TipsWithdrawn` event
-
-**Errors**: `NotRegistered`, `InvalidAmount`, `InsufficientBalance`
-
----
-
-### Credit Score
-
-#### `calculate_credit_score(address: Address) → u32`
-
-Calculate and store the credit score for a profile.
-
-**Formula**:
-```
-follower_score = min(followers / 10, 500) × 50%
-activity_score = min((posts + replies × 1.5) / 5, 300) × 30%
-base_score     = 200 × 20%
-
-credit_score   = follower_score + activity_score + base_score
-max            = 1000
-```
-
-**Tiers**:
-| Range | Tier |
-|-------|------|
-| 0-400 | Bronze |
-| 401-700 | Silver |
-| 701-900 | Gold |
-| 901-1000 | Diamond |
-
----
-
-### Leaderboard
-
-#### `get_leaderboard(limit: u32) → Vec<LeaderboardEntry>`
-
-Get the top creators by total tips received.
-
-| Parameter | Type | Constraints |
-|-----------|------|-------------|
-| `limit` | `u32` | 1-100 |
-
----
-
-### Admin
-
-#### `set_fee(caller: Address, fee_bps: u32)`
-
-Update the withdrawal fee. Admin-only.
-
-| Parameter | Type | Constraints |
-|-----------|------|-------------|
-| `fee_bps` | `u32` | 0-1000 (0-10%) |
-
-**Errors**: `NotAdmin`, `InvalidFee`
-
----
-
-#### `set_fee_collector(caller: Address, new_collector: Address)`
-
-Update the fee collector address. Admin-only.
-
----
-
-#### `set_admin(caller: Address, new_admin: Address)`
-
-Transfer admin role. Admin-only.
-
----
-
-#### `get_stats() → ContractStats`
-
-Get global contract statistics.
-
-```rust
+#[derive(Clone, Debug)]
 pub struct ContractStats {
     pub total_creators: u32,
     pub total_tips_count: u32,
@@ -288,57 +81,227 @@ pub struct ContractStats {
 }
 ```
 
+### ContractConfig
+
+```rust
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContractConfig {
+    pub admin: Address,
+    pub fee_collector: Address,
+    pub fee_bps: u32,
+    pub native_token: Address,
+    pub total_creators: u32,
+    pub total_tips_count: u32,
+    pub total_tips_volume: i128,
+    pub total_fees_collected: i128,
+    pub is_initialized: bool,
+    pub version: u32,
+}
+```
+
+### DataKey (Storage Keys)
+
+The current contract defines **21 `DataKey` variants** across Soroban's
+`instance`, `persistent`, and `temporary` storage tiers.
+
+| DataKey                     | Storage tier | Stored value            | Purpose                                                          |
+| --------------------------- | ------------ | ----------------------- | ---------------------------------------------------------------- |
+| `Admin`                     | Instance     | `Address`               | Current contract admin                                           |
+| `FeePercent`                | Instance     | `u32`                   | Withdrawal fee in basis points                                   |
+| `FeeCollector`              | Instance     | `Address`               | Address that receives protocol fees                              |
+| `ContractVersion`           | Instance     | `u32`                   | On-chain interface version written at init and bumped on upgrade |
+| `TotalFeesCollected`        | Instance     | `i128`                  | Lifetime protocol fees collected                                 |
+| `Profile(Address)`          | Persistent   | `Profile`               | Creator profile keyed by owner address                           |
+| `UsernameToAddress(String)` | Persistent   | `Address`               | Reverse lookup from username to creator address                  |
+| `TipCount`                  | Instance     | `u32`                   | Global monotonic tip counter                                     |
+| `Tip(u32)`                  | Temporary    | `Tip`                   | Individual tip record by global tip id                           |
+| `Leaderboard`               | Instance     | `Vec<LeaderboardEntry>` | Cached top-creators leaderboard                                  |
+| `TotalCreators`             | Instance     | `u32`                   | Total registered creators                                        |
+| `TotalTipsVolume`           | Instance     | `i128`                  | Lifetime tip volume                                              |
+| `Initialized`               | Instance     | `bool`                  | One-time initialization guard                                    |
+| `NativeToken`               | Instance     | `Address`               | Native XLM SAC address used for transfers                        |
+| `Paused`                    | Instance     | `bool`                  | Emergency pause flag                                             |
+| `MinTipAmount`              | Instance     | `i128`                  | Minimum allowed tip amount in stroops                            |
+| `TipperTipCount(Address)`   | Temporary    | `u32`                   | Number of tips sent by a specific tipper                         |
+| `TipperTip(Address, u32)`   | Temporary    | `u32`                   | Reverse index from `(tipper, local_index)` to global tip id      |
+| `CreatorTipCount(Address)`  | Temporary    | `u32`                   | Number of tips received by a specific creator                    |
+| `CreatorTip(Address, u32)`  | Temporary    | `u32`                   | Reverse index from `(creator, local_index)` to global tip id     |
+| `PendingAdmin`              | Instance     | `Address`               | Proposed admin during the two-step admin transfer flow           |
+
 ---
 
-## Events
+## Public Functions
 
-| Event | Fields | When |
-|-------|--------|------|
-| `ProfileRegistered` | `(address, username)` | New profile created |
-| `ProfileUpdated` | `(address)` | Profile info changed |
-| `TipSent` | `(from, to, amount, message)` | Tip successfully sent |
-| `TipsWithdrawn` | `(address, amount, fee)` | Tips withdrawn |
-| `CreditScoreUpdated` | `(address, old_score, new_score)` | Score recalculated |
-| `AdminChanged` | `(old_admin, new_admin)` | Admin role transferred |
-| `FeeUpdated` | `(old_fee, new_fee)` | Fee percentage changed |
+### Initialization
 
----
+#### `initialize(admin: Address, fee_collector: Address, fee_bps: u32, native_token: Address)`
 
-## Error Codes
+Initializes the contract. This can only be called once.
 
-| Code | Name | Description |
-|------|------|-------------|
-| 1 | `AlreadyInitialized` | Contract already initialized |
-| 2 | `NotInitialized` | Contract not yet initialized |
-| 3 | `NotAdmin` | Caller is not the admin |
-| 4 | `AlreadyRegistered` | Address already has a profile |
-| 5 | `NotRegistered` | Address does not have a profile |
-| 6 | `UsernameTaken` | Username already in use |
-| 7 | `InvalidUsername` | Username format invalid |
-| 8 | `InvalidDisplayName` | Display name too long or empty |
-| 9 | `InvalidAmount` | Tip/withdrawal amount invalid |
-| 10 | `InsufficientBalance` | Not enough balance to withdraw |
-| 11 | `CannotTipSelf` | Cannot send tip to own profile |
-| 12 | `InvalidFee` | Fee exceeds maximum allowed |
-| 13 | `MessageTooLong` | Tip message exceeds 280 chars |
-| 14 | `NotFound` | Username not found |
+| Parameter       | Type      | Description                                   |
+| --------------- | --------- | --------------------------------------------- |
+| `admin`         | `Address` | Admin address                                 |
+| `fee_collector` | `Address` | Address that receives withdrawal fees         |
+| `fee_bps`       | `u32`     | Fee in basis points                           |
+| `native_token`  | `Address` | Stellar Asset Contract address for native XLM |
+
+**Errors**: `AlreadyInitialized`, `InvalidFee`
+
+### Profile Management
+
+#### `register_profile(caller, username, display_name, bio, image_url, x_handle) -> Profile`
+
+Registers a new creator profile.
+
+#### `update_profile(caller, display_name, bio, image_url, x_handle)`
+
+Updates an existing creator profile.
+
+#### `deregister_profile(caller)`
+
+Removes a creator profile. Caller must be registered, have zero balance, and
+the contract must not be paused.
+
+#### `get_profile(address) -> Profile`
+
+Returns a profile by owner address.
+
+#### `get_profile_by_username(username) -> Profile`
+
+Returns a profile by username.
+
+### Tipping
+
+#### `send_tip(tipper, creator, amount, message)`
+
+Transfers native XLM from the tipper to the contract, credits the creator,
+stores a temporary tip record, updates counters, and refreshes leaderboard
+state.
+
+#### `withdraw_tips(caller, amount)`
+
+Withdraws part or all of the creator's balance. The contract computes the fee
+as `amount * fee_bps / 10000`, transfers the net payout to the creator, and
+sends the fee to the fee collector.
+
+#### `get_tip(tip_id) -> Tip`
+
+Fetches one tip record by global tip id.
+
+#### `get_recent_tips(creator, limit, offset) -> Vec<Tip>`
+
+Fetches recent tips for a creator, newest first, skipping expired temporary
+entries.
+
+#### `get_tips_by_tipper(tipper, limit) -> Vec<Tip>`
+
+Fetches recent tips sent by a specific tipper.
+
+#### `get_creator_tip_count(creator) -> u32`
+
+Returns how many tips a creator has received.
+
+#### `get_tipper_tip_count(tipper) -> u32`
+
+Returns how many tips a tipper has sent.
+
+### Credit and Leaderboard
+
+#### `get_credit_tier(address) -> CreditTier`
+
+Returns the creator's current credit tier derived from their on-chain score.
+
+#### `get_credit_breakdown(address) -> CreditBreakdown`
+
+Returns the component-level breakdown of the creator's score.
+
+#### `get_leaderboard(limit) -> Vec<LeaderboardEntry>`
+
+Returns the top creators by total tips received.
+
+### Admin and Config
+
+#### `get_stats() -> ContractStats`
+
+Returns aggregate platform statistics.
+
+#### `get_config() -> ContractConfig`
+
+Returns the full contract configuration, including admin and native token.
+
+#### `set_fee(caller, fee_bps)`
+
+Updates the withdrawal fee. Admin-only.
+
+#### `set_fee_collector(caller, new_collector)`
+
+Updates the fee collector. Admin-only.
+
+#### `set_admin(caller, new_admin)`
+
+Immediate admin transfer. Admin-only.
+
+#### `propose_admin(caller, new_admin)`
+
+Starts a two-step admin transfer. Admin-only.
+
+#### `accept_admin(caller)`
+
+Accepts a pending admin transfer. Callable only by the pending admin.
+
+#### `cancel_admin_proposal(caller)`
+
+Cancels the pending admin transfer. Admin-only.
+
+#### `pause_contract(caller)` / `unpause_contract(caller)`
+
+Toggles the emergency pause flag. Admin-only.
+
+#### `set_min_tip_amount(caller, amount)` / `get_min_tip_amount() -> i128`
+
+Updates or reads the minimum allowed tip amount.
+
+#### `update_x_metrics(caller, creator, x_followers, x_engagement_avg)`
+
+Updates creator X metrics. Admin-only.
+
+#### `batch_update_x_metrics(caller, updates) -> Vec<BatchSkip>`
+
+Batch updates X metrics for multiple creators. Admin-only.
+
+#### `batch_update_x_metrics_preview(caller, updates) -> Vec<BatchSkip>`
+
+Dry-run preview for batch X metric updates. Admin-only.
 
 ---
 
 ## Storage Layout
 
-| Key | Type | TTL |
-|-----|------|-----|
-| `DataKey::Admin` | `Address` | Persistent |
-| `DataKey::FeePercent` | `u32` | Persistent |
-| `DataKey::FeeCollector` | `Address` | Persistent |
-| `DataKey::Profile(addr)` | `Profile` | Persistent |
-| `DataKey::UsernameToAddress(name)` | `Address` | Persistent |
-| `DataKey::TipCount` | `u32` | Persistent |
-| `DataKey::Tip(index)` | `Tip` | Temporary (30 days) |
-| `DataKey::Leaderboard` | `Vec<LeaderboardEntry>` | Persistent |
-| `DataKey::TotalCreators` | `u32` | Persistent |
-| `DataKey::TotalTipsVolume` | `i128` | Persistent |
-| `DataKey::TotalFeesCollected` | `i128` | Persistent |
+| Key                                | Type                    | Tier / TTL behavior                             |
+| ---------------------------------- | ----------------------- | ----------------------------------------------- |
+| `DataKey::Admin`                   | `Address`               | Instance, bumped with contract writes           |
+| `DataKey::FeePercent`              | `u32`                   | Instance, bumped with contract writes           |
+| `DataKey::FeeCollector`            | `Address`               | Instance, bumped with contract writes           |
+| `DataKey::ContractVersion`         | `u32`                   | Instance, bumped with contract writes           |
+| `DataKey::TotalFeesCollected`      | `i128`                  | Instance, bumped with contract writes           |
+| `DataKey::Profile(addr)`           | `Profile`               | Persistent, refreshed on profile activity       |
+| `DataKey::UsernameToAddress(name)` | `Address`               | Persistent, refreshed alongside `Profile(addr)` |
+| `DataKey::TipCount`                | `u32`                   | Instance, bumped with contract writes           |
+| `DataKey::Tip(index)`              | `Tip`                   | Temporary, approximately 7-day TTL              |
+| `DataKey::Leaderboard`             | `Vec<LeaderboardEntry>` | Instance, bumped with contract writes           |
+| `DataKey::TotalCreators`           | `u32`                   | Instance, bumped with contract writes           |
+| `DataKey::TotalTipsVolume`         | `i128`                  | Instance, bumped with contract writes           |
+| `DataKey::Initialized`             | `bool`                  | Instance, bumped with contract writes           |
+| `DataKey::NativeToken`             | `Address`               | Instance, bumped with contract writes           |
+| `DataKey::Paused`                  | `bool`                  | Instance, bumped with contract writes           |
+| `DataKey::MinTipAmount`            | `i128`                  | Instance, bumped with contract writes           |
+| `DataKey::TipperTipCount(addr)`    | `u32`                   | Temporary, follows tip index TTL                |
+| `DataKey::TipperTip(addr, idx)`    | `u32`                   | Temporary, follows tip index TTL                |
+| `DataKey::CreatorTipCount(addr)`   | `u32`                   | Temporary, follows tip index TTL                |
+| `DataKey::CreatorTip(addr, idx)`   | `u32`                   | Temporary, follows tip index TTL                |
+| `DataKey::PendingAdmin`            | `Address`               | Instance, bumped with contract writes           |
 
-> **Note**: Tip records use temporary storage to keep costs low. The contract maintains aggregate stats in persistent storage.
+> Contract-wide config and counters live in `instance()` storage, profile
+> records live in `persistent()` storage, and tip history plus reverse tip
+> indexes live in `temporary()` storage.

--- a/frontend-scaffold/src/components/ui/Button.tsx
+++ b/frontend-scaffold/src/components/ui/Button.tsx
@@ -1,42 +1,44 @@
-import React from 'react';
-import Loader from './Loader';
+import React from "react";
+import Loader from "./Loader";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'outline' | 'ghost';
-  size?: 'sm' | 'md' | 'lg';
+  variant?: "primary" | "outline" | "ghost";
+  size?: "sm" | "md" | "lg";
   loading?: boolean;
   icon?: React.ReactNode;
   iconRight?: React.ReactNode;
 }
 
 const Button: React.FC<ButtonProps> = ({
-  variant = 'primary',
-  size = 'md',
+  variant = "primary",
+  size = "md",
   loading = false,
   icon,
   iconRight,
   children,
-  className = '',
+  className = "",
   disabled,
   ...props
 }) => {
-  const base = 'font-bold uppercase tracking-wide transition-transform duration-200 border-2 border-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2';
+  const base =
+    "font-bold uppercase tracking-wide transition-transform duration-200 border-2 border-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2";
 
   const variants: Record<string, string> = {
-    primary: 'bg-black text-white hover:-translate-x-1 hover:-translate-y-1',
-    outline: 'bg-white text-black hover:-translate-x-1 hover:-translate-y-1',
-    ghost: 'bg-transparent text-black border-transparent hover:border-black',
+    primary: "bg-black text-white hover:-translate-x-1 hover:-translate-y-1",
+    outline: "bg-white text-black hover:-translate-x-1 hover:-translate-y-1",
+    ghost: "bg-transparent text-black border-transparent hover:border-black",
   };
 
   const sizes: Record<string, string> = {
-    sm: 'px-3 py-1.5 text-sm',
-    md: 'px-6 py-3 text-base',
-    lg: 'px-8 py-4 text-lg',
+    sm: "px-3 py-1.5 text-sm",
+    md: "px-6 py-3 text-base",
+    lg: "px-8 py-4 text-lg",
   };
 
-  const shadow = variant !== 'ghost' ? '4px 4px 0px 0px rgba(0,0,0,1)' : 'none';
+  const shadow = variant !== "ghost" ? "4px 4px 0px 0px rgba(0,0,0,1)" : "none";
 
   const leadingIcon = loading ? <Loader size="sm" /> : icon;
+  const content = loading ? "Loading..." : children;
 
   return (
     <button
@@ -46,7 +48,7 @@ const Button: React.FC<ButtonProps> = ({
       {...props}
     >
       {leadingIcon}
-      {children}
+      {content}
       {!loading && iconRight}
     </button>
   );

--- a/frontend-scaffold/src/features/dashboard/DashboardSkeleton.tsx
+++ b/frontend-scaffold/src/features/dashboard/DashboardSkeleton.tsx
@@ -1,96 +1,98 @@
-import React from 'react';
+import React from "react";
 import PageContainer from "../../components/layout/PageContainer";
 import Card from "../../components/ui/Card";
 import Skeleton from "../../components/ui/Skeleton";
 
+const CHART_BAR_HEIGHTS = ["28%", "52%", "44%", "68%", "34%", "58%", "40%"];
+
 const DashboardSkeleton: React.FC = () => {
-    return (
-        <PageContainer maxWidth="xl" className="space-y-6 py-10">
-            <section className="flex flex-col gap-3">
-                <div className="space-y-2">
-                    <Skeleton width="100px" height="10px" />
-                    <Skeleton width="220px" height="32px" />
-                    <Skeleton width="140px" height="14px" />
+  return (
+    <PageContainer maxWidth="xl" className="space-y-6 py-10">
+      <section className="flex flex-col gap-3">
+        <div className="space-y-2">
+          <Skeleton width="100px" height="10px" />
+          <Skeleton width="220px" height="32px" />
+          <Skeleton width="140px" height="14px" />
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i} className="space-y-2">
+            <Skeleton width="100px" height="10px" />
+            <Skeleton width="140px" height="24px" />
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-6">
+          <Card padding="lg">
+            <div className="space-y-6">
+              <div className="flex items-center justify-between">
+                <Skeleton width="180px" height="24px" />
+                <Skeleton width="140px" height="32px" />
+              </div>
+              <div className="relative border-2 border-black bg-white p-6 pb-2">
+                <div className="flex h-48 items-end gap-2 md:gap-4">
+                  {CHART_BAR_HEIGHTS.map((height, i) => (
+                    <div key={i} className="flex flex-1 flex-col items-center">
+                      <Skeleton width="100%" height={height} />
+                      <Skeleton width="30px" height="10px" className="mt-2" />
+                    </div>
+                  ))}
                 </div>
-            </section>
+              </div>
+            </div>
+          </Card>
 
-            <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                {[1, 2, 3, 4].map((i) => (
-                    <Card key={i} className="space-y-2">
-                        <Skeleton width="100px" height="10px" />
-                        <Skeleton width="140px" height="24px" />
-                    </Card>
-                ))}
-            </section>
+          <Card className="space-y-4" padding="lg">
+            <div className="flex items-center justify-between gap-4">
+              <Skeleton width="180px" height="24px" />
+              <Skeleton width="120px" height="14px" />
+            </div>
+            <div className="space-y-4">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} height="80px" />
+              ))}
+            </div>
+            <Skeleton width="200px" height="30px" className="mx-auto" />
+          </Card>
+        </div>
 
-            <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-                <div className="space-y-6">
-                    <Card padding="lg">
-                        <div className="space-y-6">
-                            <div className="flex items-center justify-between">
-                                <Skeleton width="180px" height="24px" />
-                                <Skeleton width="140px" height="32px" />
-                            </div>
-                            <div className="relative border-2 border-black bg-white p-6 pb-2">
-                                <div className="flex h-48 items-end gap-2 md:gap-4">
-                                    {[1, 2, 3, 4, 5, 6, 7].map((i) => (
-                                        <div key={i} className="flex flex-1 flex-col items-center">
-                                            <Skeleton width="100%" height={`${Math.random() * 60 + 20}%`} />
-                                            <Skeleton width="30px" height="10px" className="mt-2" />
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        </div>
-                    </Card>
+        <div className="space-y-6">
+          <Card className="space-y-4" padding="lg">
+            <Skeleton width="180px" height="24px" />
+            <div className="border-2 border-black bg-white p-4 space-y-2">
+              <Skeleton width="120px" height="10px" />
+              <Skeleton width="100px" height="20px" />
+            </div>
+            <Skeleton lines={2} />
+          </Card>
 
-                    <Card className="space-y-4" padding="lg">
-                        <div className="flex items-center justify-between gap-4">
-                            <Skeleton width="180px" height="24px" />
-                            <Skeleton width="120px" height="14px" />
-                        </div>
-                        <div className="space-y-4">
-                            {[1, 2, 3].map((i) => (
-                                <Skeleton key={i} height="80px" />
-                            ))}
-                        </div>
-                        <Skeleton width="200px" height="30px" className="mx-auto" />
-                    </Card>
-                </div>
+          <Card className="space-y-4" padding="lg">
+            <Skeleton width="150px" height="24px" />
+            <div className="grid gap-3">
+              <Skeleton height="50px" />
+              <Skeleton height="50px" />
+            </div>
+          </Card>
 
-                <div className="space-y-6">
-                    <Card className="space-y-4" padding="lg">
-                        <Skeleton width="180px" height="24px" />
-                        <div className="border-2 border-black bg-white p-4 space-y-2">
-                            <Skeleton width="120px" height="10px" />
-                            <Skeleton width="100px" height="20px" />
-                        </div>
-                        <Skeleton lines={2} />
-                    </Card>
-
-                    <Card className="space-y-4" padding="lg">
-                        <Skeleton width="150px" height="24px" />
-                        <div className="grid gap-3">
-                            <Skeleton height="50px" />
-                            <Skeleton height="50px" />
-                        </div>
-                    </Card>
-                    
-                    <Card padding="lg" className="flex flex-col items-center space-y-4">
-                        <div className="space-y-2 text-center">
-                           <Skeleton width="80px" height="10px" className="mx-auto" />
-                           <Skeleton width="120px" height="20px" className="mx-auto" />
-                        </div>
-                        <Skeleton width="160px" height="160px" />
-                        <div className="w-full space-y-3">
-                           <Skeleton height="40px" />
-                           <Skeleton height="45px" />
-                        </div>
-                    </Card>
-                </div>
-            </section>
-        </PageContainer>
-    );
+          <Card padding="lg" className="flex flex-col items-center space-y-4">
+            <div className="space-y-2 text-center">
+              <Skeleton width="80px" height="10px" className="mx-auto" />
+              <Skeleton width="120px" height="20px" className="mx-auto" />
+            </div>
+            <Skeleton width="160px" height="160px" />
+            <div className="w-full space-y-3">
+              <Skeleton height="40px" />
+              <Skeleton height="45px" />
+            </div>
+          </Card>
+        </div>
+      </section>
+    </PageContainer>
+  );
 };
 
 export default DashboardSkeleton;

--- a/frontend-scaffold/src/features/dashboard/WithdrawModal.tsx
+++ b/frontend-scaffold/src/features/dashboard/WithdrawModal.tsx
@@ -1,8 +1,11 @@
-import React, { useMemo } from "react";
+import BigNumber from "bignumber.js";
+import React, { useEffect, useMemo, useState } from "react";
 
 import AmountDisplay from "../../components/shared/AmountDisplay";
 import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
 import Modal from "../../components/ui/Modal";
+import { stroopToXlmBigNumber, xlmToStroop } from "../../helpers/format";
 import { useTipz } from "../../hooks";
 
 interface WithdrawModalProps {
@@ -19,36 +22,92 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
   onClose,
 }) => {
   const { withdrawTips, withdrawing, error, txHash, reset } = useTipz();
+  const [amount, setAmount] = useState("");
+
+  const balanceXlm = useMemo(
+    () => stroopToXlmBigNumber(balance || "0"),
+    [balance],
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      setAmount(balanceXlm.toFixed());
+    }
+  }, [balanceXlm, isOpen]);
+
+  const parsedAmount = useMemo(() => {
+    const trimmedAmount = amount.trim();
+    if (!trimmedAmount) {
+      return null;
+    }
+
+    const nextAmount = new BigNumber(trimmedAmount);
+    return nextAmount.isFinite() ? nextAmount : null;
+  }, [amount]);
+
+  const amountError = useMemo(() => {
+    if (!amount.trim()) {
+      return "Enter the amount you want to withdraw.";
+    }
+
+    if (!parsedAmount) {
+      return "Enter a valid XLM amount.";
+    }
+
+    if (parsedAmount.lte(0)) {
+      return "Withdrawal amount must be greater than zero.";
+    }
+
+    if (parsedAmount.gt(balanceXlm)) {
+      return "Withdrawal amount cannot exceed your available balance.";
+    }
+
+    return null;
+  }, [amount, parsedAmount, balanceXlm]);
+
+  const requestedStroops = useMemo(() => {
+    if (!parsedAmount || amountError) {
+      return "0";
+    }
+
+    return xlmToStroop(parsedAmount).toFixed(0);
+  }, [amountError, parsedAmount]);
 
   const handleWithdraw = async () => {
+    if (amountError) {
+      return;
+    }
+
     try {
-      await withdrawTips(balance);
+      await withdrawTips(amount);
     } catch (err) {
-      console.error('Withdrawal failed:', err);
+      console.error("Withdrawal failed:", err);
     }
   };
 
   const handleClose = () => {
     reset();
+    setAmount(balanceXlm.toFixed());
     onClose();
   };
+
   const { fee, net } = useMemo(() => {
-    const rawBalance = BigInt(balance || "0");
-    const feeAmount = (rawBalance * BigInt(feeBps)) / BigInt(10_000);
-    const netAmount = rawBalance - feeAmount;
+    const rawAmount = BigInt(requestedStroops);
+    const feeAmount = (rawAmount * BigInt(feeBps)) / BigInt(10_000);
+    const netAmount = rawAmount - feeAmount;
 
     return {
       fee: feeAmount.toString(),
       net: netAmount.toString(),
     };
-  }, [balance, feeBps]);
+  }, [feeBps, requestedStroops]);
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title="Withdraw balance">
       <div className="space-y-5">
         <p className="text-sm font-medium leading-6 text-gray-700">
-          This scaffold modal previews the withdrawal breakdown and keeps the
-          action flow visible until contract-backed withdrawal execution lands.
+          Choose how much of your current balance you want to withdraw. The fee
+          and estimated net payout update before you confirm.
         </p>
 
         {error && (
@@ -56,23 +115,55 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
             {error}
           </div>
         )}
-        
+
         {txHash && (
           <div className="p-3 border-2 border-green-500 bg-green-50 text-green-700 text-sm">
             Withdrawal successful! Transaction hash: {txHash}
           </div>
         )}
 
+        <div className="relative">
+          <Input
+            label="Amount to withdraw"
+            type="number"
+            step="0.0000001"
+            min="0"
+            max={balanceXlm.toFixed()}
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+            placeholder="0.00"
+            disabled={withdrawing}
+            error={amountError ?? undefined}
+          />
+          <button
+            type="button"
+            onClick={() => setAmount(balanceXlm.toFixed())}
+            className="absolute right-3 top-[38px] text-xs font-black uppercase underline hover:text-gray-600"
+            disabled={withdrawing}
+          >
+            Max
+          </button>
+        </div>
+
         <div className="grid gap-3">
           <div className="border-2 border-black bg-yellow-50 p-4">
             <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
-              Gross amount
+              Available balance
             </p>
             <AmountDisplay amount={balance} className="mt-2 block text-2xl" />
           </div>
           <div className="border-2 border-black bg-white p-4">
             <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
-              Fee
+              Requested amount
+            </p>
+            <AmountDisplay
+              amount={requestedStroops}
+              className="mt-2 block text-xl"
+            />
+          </div>
+          <div className="border-2 border-black bg-white p-4">
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+              Estimated fee
             </p>
             <AmountDisplay amount={fee} className="mt-2 block text-xl" />
           </div>
@@ -80,7 +171,10 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
             <p className="text-xs font-black uppercase tracking-[0.2em] text-white/70">
               Net payout
             </p>
-            <AmountDisplay amount={net} className="mt-2 block text-2xl text-white" />
+            <AmountDisplay
+              amount={net}
+              className="mt-2 block text-2xl text-white"
+            />
           </div>
         </div>
 
@@ -88,8 +182,11 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
           <Button variant="outline" onClick={handleClose}>
             Close
           </Button>
-          <Button onClick={handleWithdraw} disabled={withdrawing}>
-            {withdrawing ? 'Withdrawing...' : 'Confirm withdrawal'}
+          <Button
+            onClick={handleWithdraw}
+            disabled={withdrawing || Boolean(amountError)}
+          >
+            {withdrawing ? "Withdrawing..." : "Confirm withdrawal"}
           </Button>
         </div>
       </div>

--- a/frontend-scaffold/src/features/landing/TopCreatorsSection.test.tsx
+++ b/frontend-scaffold/src/features/landing/TopCreatorsSection.test.tsx
@@ -1,101 +1,130 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BrowserRouter } from 'react-router-dom';
-import TopCreatorsSection from './TopCreatorsSection';
-import * as hooks from '@/hooks';
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import TopCreatorsSection from "./TopCreatorsSection";
+import * as hooks from "@/hooks";
 
 // Mock the hooks
-vi.mock('@/hooks', () => ({
-    useContract: vi.fn(),
+vi.mock("@/hooks", () => ({
+  useContract: vi.fn(),
 }));
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
-    return {
-        ...actual,
-        useNavigate: () => mockNavigate,
-    };
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
 });
 
 const mockLeaderboardData = [
-    { address: 'G1', username: 'user1', totalTipsReceived: '100', creditScore: 500 },
-    { address: 'G2', username: 'user2', totalTipsReceived: '200', creditScore: 600 },
-    { address: 'G3', username: 'user3', totalTipsReceived: '300', creditScore: 700 },
-    { address: 'G4', username: 'user4', totalTipsReceived: '400', creditScore: 800 },
-    { address: 'G5', username: 'user5', totalTipsReceived: '500', creditScore: 900 },
+  {
+    address: "G1",
+    username: "user1",
+    totalTipsReceived: "100",
+    creditScore: 500,
+  },
+  {
+    address: "G2",
+    username: "user2",
+    totalTipsReceived: "200",
+    creditScore: 600,
+  },
+  {
+    address: "G3",
+    username: "user3",
+    totalTipsReceived: "300",
+    creditScore: 700,
+  },
+  {
+    address: "G4",
+    username: "user4",
+    totalTipsReceived: "400",
+    creditScore: 800,
+  },
+  {
+    address: "G5",
+    username: "user5",
+    totalTipsReceived: "500",
+    creditScore: 900,
+  },
 ];
 
-describe('TopCreatorsSection', () => {
-    const mockGetLeaderboard = vi.fn();
+describe("TopCreatorsSection", () => {
+  const mockGetLeaderboard = vi.fn();
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.mocked(hooks.useContract).mockReturnValue({
-            getLeaderboard: mockGetLeaderboard,
-        } as unknown as ReturnType<typeof hooks.useContract>);
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hooks.useContract).mockReturnValue({
+      getLeaderboard: mockGetLeaderboard,
+    } as unknown as ReturnType<typeof hooks.useContract>);
+  });
+
+  const renderComponent = () =>
+    render(
+      <BrowserRouter>
+        <TopCreatorsSection />
+      </BrowserRouter>,
+    );
+
+  it("renders loading state with 5 skeletons", () => {
+    mockGetLeaderboard.mockReturnValue(new Promise(() => {})); // Never resolves
+    renderComponent();
+
+    const skeletons = screen.getAllByTestId("skeleton-rect");
+    expect(skeletons).toHaveLength(5);
+    expect(screen.getByText(/View Full Leaderboard/i)).toBeInTheDocument();
+  });
+
+  it("renders empty state when no creators exist", async () => {
+    mockGetLeaderboard.mockResolvedValue([]);
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/No creators yet/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("profile-card")).not.toBeInTheDocument();
+    expect(screen.getByText(/Top Creators/i)).toBeInTheDocument();
+    expect(screen.getByText(/View Full Leaderboard/i)).toBeInTheDocument();
+  });
+
+  it("renders top 5 creators when data is available", async () => {
+    mockGetLeaderboard.mockResolvedValue(mockLeaderboardData);
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/@user/i)).toHaveLength(5);
     });
 
-    const renderComponent = () =>
-        render(
-            <BrowserRouter>
-                <TopCreatorsSection />
-            </BrowserRouter>
-        );
-
-    it('renders loading state with 5 skeletons', () => {
-        mockGetLeaderboard.mockReturnValue(new Promise(() => { })); // Never resolves
-        renderComponent();
-
-        const skeletons = screen.getAllByTestId('skeleton-rect');
-        expect(skeletons).toHaveLength(5);
-        expect(screen.getByText(/View Full Leaderboard/i)).toBeInTheDocument();
+    mockLeaderboardData.forEach((creator) => {
+      expect(screen.getByText(`@${creator.username}`)).toBeInTheDocument();
     });
 
-    it('renders empty state when no creators exist', async () => {
-        mockGetLeaderboard.mockResolvedValue([]);
-        renderComponent();
+    expect(screen.getByText(/Top Creators/i)).toBeInTheDocument();
+    expect(screen.getByText(/View Full Leaderboard/i)).toBeInTheDocument();
+  });
 
-        await waitFor(() => {
-            expect(screen.getByText(/No creators yet/i)).toBeInTheDocument();
-        });
-        expect(screen.queryByTestId('profile-card')).not.toBeInTheDocument();
-        expect(screen.getByText(/Top Creators/i)).toBeInTheDocument();
-        expect(screen.getByText(/View Full Leaderboard/i)).toBeInTheDocument();
+  it("handles error state gracefully", async () => {
+    mockGetLeaderboard.mockRejectedValue(new Error("Fetch failed"));
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Unable to connect\. Please check your internet connection\./i,
+        ),
+      ).toBeInTheDocument();
     });
+  });
 
-    it('renders top 5 creators when data is available', async () => {
-        mockGetLeaderboard.mockResolvedValue(mockLeaderboardData);
-        renderComponent();
+  it("navigates to leaderboard on link click", async () => {
+    mockGetLeaderboard.mockResolvedValue(mockLeaderboardData);
+    renderComponent();
 
-        await waitFor(() => {
-            expect(screen.getAllByText(/@user/i)).toHaveLength(5);
-        });
-
-        mockLeaderboardData.forEach((creator) => {
-            expect(screen.getByText(`@${creator.username}`)).toBeInTheDocument();
-        });
-
-        expect(screen.getByText(/Top Creators/i)).toBeInTheDocument();
-        expect(screen.getByText(/View Full Leaderboard/i)).toBeInTheDocument();
+    await waitFor(() => {
+      screen.getByText(/View Full Leaderboard/i).click();
     });
-
-    it('handles error state gracefully', async () => {
-        mockGetLeaderboard.mockRejectedValue(new Error('Fetch failed'));
-        renderComponent();
-
-        await waitFor(() => {
-            expect(screen.getByText(/Could not load top creators/i)).toBeInTheDocument();
-        });
-    });
-
-    it('navigates to leaderboard on link click', async () => {
-        mockGetLeaderboard.mockResolvedValue(mockLeaderboardData);
-        renderComponent();
-
-        await waitFor(() => {
-            screen.getByText(/View Full Leaderboard/i).click();
-        });
-        expect(mockNavigate).toHaveBeenCalledWith('/leaderboard');
-    });
+    expect(mockNavigate).toHaveBeenCalledWith("/leaderboard");
+  });
 });

--- a/frontend-scaffold/src/features/profile/WithdrawModal.tsx
+++ b/frontend-scaffold/src/features/profile/WithdrawModal.tsx
@@ -1,8 +1,9 @@
 import React from "react";
+import BigNumber from "bignumber.js";
 import Modal from "@/components/ui/Modal";
 import Button from "@/components/ui/Button";
 import AmountDisplay from "@/components/shared/AmountDisplay";
-import { hasPositiveBalance } from "@/helpers/balance";
+import { stroopToXlmBigNumber, xlmToStroop } from "@/helpers/format";
 import { useTipz, useProfile } from "@/hooks";
 import Input from "@/components/ui/Input";
 import TransactionStatus from "@/components/shared/TransactionStatus";
@@ -26,17 +27,72 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
   feeBps,
 }) => {
   const [amount, setAmount] = React.useState("");
-  const { withdrawTips, withdrawing, error, txHash, txStatus, reset } = useTipz();
+  const { withdrawTips, withdrawing, error, txHash, txStatus, reset } =
+    useTipz();
   const { refetch } = useProfile();
   const { addToast } = useToastStore();
 
-  const numericBalance = parseFloat(balance);
-  const numericAmount = parseFloat(amount) || 0;
-  
-  const fee = (numericAmount * feeBps) / 10000;
-  const netAmount = Math.max(0, numericAmount - fee);
+  const balanceXlm = React.useMemo(
+    () => stroopToXlmBigNumber(balance || "0"),
+    [balance],
+  );
 
-  const canWithdraw = numericAmount > 0 && numericAmount <= numericBalance;
+  React.useEffect(() => {
+    if (isOpen) {
+      setAmount(balanceXlm.toFixed());
+    }
+  }, [balanceXlm, isOpen]);
+
+  const parsedAmount = React.useMemo(() => {
+    const trimmedAmount = amount.trim();
+    if (!trimmedAmount) {
+      return null;
+    }
+
+    const nextAmount = new BigNumber(trimmedAmount);
+    return nextAmount.isFinite() ? nextAmount : null;
+  }, [amount]);
+
+  const amountError = React.useMemo(() => {
+    if (!amount.trim()) {
+      return "Enter the amount you want to withdraw.";
+    }
+
+    if (!parsedAmount) {
+      return "Enter a valid XLM amount.";
+    }
+
+    if (parsedAmount.lte(0)) {
+      return "Withdrawal amount must be greater than zero.";
+    }
+
+    if (parsedAmount.gt(balanceXlm)) {
+      return "Withdrawal amount cannot exceed your available balance.";
+    }
+
+    return null;
+  }, [amount, parsedAmount, balanceXlm]);
+
+  const requestedStroops = React.useMemo(() => {
+    if (!parsedAmount || amountError) {
+      return "0";
+    }
+
+    return xlmToStroop(parsedAmount).toFixed(0);
+  }, [amountError, parsedAmount]);
+
+  const fee = React.useMemo(() => {
+    const rawAmount = BigInt(requestedStroops);
+    return ((rawAmount * BigInt(feeBps)) / BigInt(10_000)).toString();
+  }, [feeBps, requestedStroops]);
+
+  const netAmount = React.useMemo(() => {
+    const rawAmount = BigInt(requestedStroops);
+    const rawFee = BigInt(fee);
+    return (rawAmount - rawFee).toString();
+  }, [fee, requestedStroops]);
+
+  const canWithdraw = !amountError;
 
   const handleWithdraw = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,6 +114,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
 
   const handleClose = () => {
     reset();
+    setAmount(balanceXlm.toFixed());
     onClose();
   };
 
@@ -65,8 +122,8 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
     <Modal isOpen={isOpen} onClose={handleClose} title="Withdraw Tips">
       <form onSubmit={handleWithdraw} className="space-y-6">
         <p className="text-gray-600 font-medium">
-          Transfer your available balance to your connected Stellar wallet.
-          A platform fee of {(feeBps / 100).toFixed(1)}% applies.
+          Transfer your available balance to your connected Stellar wallet. A
+          platform fee of {(feeBps / 100).toFixed(1)}% applies.
         </p>
 
         <div className="space-y-4">
@@ -76,31 +133,48 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
               type="number"
               step="0.0000001"
               min="0"
-              max={balance}
+              max={balanceXlm.toFixed()}
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               placeholder="0.00"
               required
-              disabled={withdrawing || txStatus === 'success'}
+              disabled={withdrawing || txStatus === "success"}
+              error={amountError ?? undefined}
             />
             <button
               type="button"
-              onClick={() => setAmount(balance)}
+              onClick={() => setAmount(balanceXlm.toFixed())}
               className="absolute right-3 top-[38px] text-xs font-black uppercase underline hover:text-gray-600"
-              disabled={withdrawing || txStatus === 'success'}
+              disabled={withdrawing || txStatus === "success"}
             >
               Max
             </button>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid gap-4 md:grid-cols-3">
             <div className="p-3 border-2 border-black bg-gray-50">
-              <p className="text-[10px] font-black uppercase text-gray-400">Platform Fee</p>
-              <p className="font-bold">{fee.toFixed(2)} XLM</p>
+              <p className="text-[10px] font-black uppercase text-gray-400">
+                Requested
+              </p>
+              <AmountDisplay
+                amount={requestedStroops}
+                className="mt-2 block text-lg"
+              />
+            </div>
+            <div className="p-3 border-2 border-black bg-gray-50">
+              <p className="text-[10px] font-black uppercase text-gray-400">
+                Platform Fee
+              </p>
+              <AmountDisplay amount={fee} className="mt-2 block text-lg" />
             </div>
             <div className="p-3 border-2 border-black bg-green-50">
-              <p className="text-[10px] font-black uppercase text-green-600">You'll Receive</p>
-              <p className="font-bold text-green-700">{netAmount.toFixed(2)} XLM</p>
+              <p className="text-[10px] font-black uppercase text-green-600">
+                You'll Receive
+              </p>
+              <AmountDisplay
+                amount={netAmount}
+                className="mt-2 block text-lg text-green-700"
+              />
             </div>
           </div>
         </div>
@@ -112,15 +186,23 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
           <AmountDisplay amount={balance} className="text-3xl" />
         </div>
 
-        {txStatus === 'signing' || txStatus === 'submitting' || txStatus === 'confirming' ? (
+        {txStatus === "signing" ||
+        txStatus === "submitting" ||
+        txStatus === "confirming" ? (
           <TransactionStatus
             status={txStatus}
             txHash={txHash ?? undefined}
-            errorMessage={error ? (categorizeError(error) === 'network' ? ERRORS.NETWORK : ERRORS.CONTRACT) : undefined}
+            errorMessage={
+              error
+                ? categorizeError(error) === "network"
+                  ? ERRORS.NETWORK
+                  : ERRORS.CONTRACT
+                : undefined
+            }
           />
         ) : null}
 
-        {txStatus === 'success' && (
+        {txStatus === "success" && (
           <div className="p-3 border-2 border-green-500 bg-green-50 text-green-700 text-sm font-bold text-center uppercase">
             Withdrawal Successful!
           </div>
@@ -133,7 +215,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
             type="submit"
             className="w-full"
             loading={withdrawing}
-            disabled={withdrawing || !canWithdraw || txStatus === 'success'}
+            disabled={withdrawing || !canWithdraw || txStatus === "success"}
           >
             {withdrawing ? "Processing..." : "Confirm Withdrawal"}
           </Button>
@@ -145,12 +227,13 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
             className="w-full"
             disabled={withdrawing}
           >
-            {txStatus === 'success' ? "Done" : "Cancel"}
+            {txStatus === "success" ? "Done" : "Cancel"}
           </Button>
         </div>
 
         <p className="text-[10px] text-center font-bold text-gray-400 uppercase tracking-widest leading-relaxed">
-          Network fees will be deducted by the Stellar network.<br />
+          Network fees will be deducted by the Stellar network.
+          <br />
           Funds will be available in your wallet instantly.
         </p>
       </form>

--- a/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
+++ b/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
@@ -1,28 +1,17 @@
-import { renderHook, act, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useWallet } from '../useWallet';
-import { useWalletStore } from '../../store/walletStore';
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useWallet } from "../useWallet";
+import { useWalletStore } from "../../store/walletStore";
+import * as walletKitModule from "@creit.tech/stellar-wallets-kit";
 
-// Mock the StellarWalletsKit
-vi.mock('@creit.tech/stellar-wallets-kit', () => ({
-  StellarWalletsKit: vi.fn().mockImplementation(() => ({
-    openModal: vi.fn(),
-    setWallet: vi.fn(),
-    getAddress: vi.fn(),
-    signTransaction: vi.fn(),
-  })),
-  WalletNetwork: {
-    TESTNET: 'TESTNET',
-    PUBLIC: 'PUBLIC',
-  },
-  FREIGHTER_ID: 'freighter',
-  FreighterModule: vi.fn(),
-  AlbedoModule: vi.fn(),
-  xBullModule: vi.fn(),
-}));
+interface WalletSelectionHandler {
+  onWalletSelected: (option: { id: string }) => Promise<void>;
+}
+
+const mockWalletKit = (walletKitModule as any).__mockWalletKit as any;
 
 // Mock window.freighter
-Object.defineProperty(window, 'freighter', {
+Object.defineProperty(window, "freighter", {
   value: {
     getNetwork: vi.fn(),
     getAddress: vi.fn(),
@@ -30,7 +19,7 @@ Object.defineProperty(window, 'freighter', {
   writable: true,
 });
 
-describe('useWallet', () => {
+describe("useWallet", () => {
   beforeEach(() => {
     // Reset the store before each test
     useWalletStore.setState({
@@ -38,38 +27,47 @@ describe('useWallet', () => {
       connected: false,
       connecting: false,
       error: null,
-      network: 'TESTNET',
+      network: "TESTNET",
     });
     vi.clearAllMocks();
+    Object.values(mockWalletKit).forEach((mockFn) => {
+      if (typeof mockFn === "function" && "mockReset" in mockFn) {
+        (mockFn as ReturnType<typeof vi.fn>).mockReset();
+      }
+    });
   });
 
-  it('should return initial wallet state', () => {
+  it("should return initial wallet state", () => {
     const { result } = renderHook(() => useWallet());
 
     expect(result.current.publicKey).toBeNull();
     expect(result.current.connected).toBe(false);
     expect(result.current.connecting).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(result.current.network).toBe('TESTNET');
+    expect(result.current.network).toBe("TESTNET");
   });
 
-  it('should connect wallet and set publicKey', async () => {
+  it("should connect wallet and set publicKey", async () => {
     const { result } = renderHook(() => useWallet());
-    
-    const mockAddress = 'GD1234567890ABCDEF';
+
+    const mockAddress = "GD1234567890ABCDEF";
     const mockOnWalletSelected = vi.fn();
-    
+
     // Mock the kit.openModal to call the callback with address
-    const StellarWalletsKit = await import('@creit.tech/stellar-wallets-kit');
-    const mockKit = (StellarWalletsKit.StellarWalletsKit as any).mock.results[0].value;
-    mockKit.openModal.mockImplementation(({ onWalletSelected }) => {
-      mockOnWalletSelected.mockImplementation(async (option: any) => {
-        mockKit.setWallet(option.id);
-        mockKit.getAddress.mockResolvedValue({ address: mockAddress });
-        await onWalletSelected(option);
-      });
-      return Promise.resolve();
-    });
+    mockWalletKit.openModal.mockImplementation(
+      ({ onWalletSelected }: WalletSelectionHandler) => {
+        mockOnWalletSelected.mockImplementation(
+          async (option: { id: string }) => {
+            mockWalletKit.setWallet(option.id);
+            mockWalletKit.getAddress.mockResolvedValue({
+              address: mockAddress,
+            });
+            await onWalletSelected(option);
+          },
+        );
+        return Promise.resolve();
+      },
+    );
 
     await act(async () => {
       result.current.connect();
@@ -77,7 +75,7 @@ describe('useWallet', () => {
 
     // Simulate wallet selection
     await act(async () => {
-      await mockOnWalletSelected({ id: 'freighter' });
+      await mockOnWalletSelected({ id: "freighter" });
     });
 
     await waitFor(() => {
@@ -88,19 +86,19 @@ describe('useWallet', () => {
     });
   });
 
-  it('should disconnect wallet and clear state', () => {
+  it("should disconnect wallet and clear state", () => {
     // First set up a connected state
     useWalletStore.setState({
-      publicKey: 'GD1234567890ABCDEF',
+      publicKey: "GD1234567890ABCDEF",
       connected: true,
       connecting: false,
       error: null,
-      network: 'TESTNET',
+      network: "TESTNET",
     });
 
     const { result } = renderHook(() => useWallet());
 
-    expect(result.current.publicKey).toBe('GD1234567890ABCDEF');
+    expect(result.current.publicKey).toBe("GD1234567890ABCDEF");
     expect(result.current.connected).toBe(true);
 
     act(() => {
@@ -112,22 +110,26 @@ describe('useWallet', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('should handle connection errors', async () => {
+  it("should handle connection errors", async () => {
     const { result } = renderHook(() => useWallet());
-    
+
     const mockOnWalletSelected = vi.fn();
-    
+
     // Mock the kit.openModal to call the callback with error
-    const StellarWalletsKit = await import('@creit.tech/stellar-wallets-kit');
-    const mockKit = (StellarWalletsKit.StellarWalletsKit as any).mock.results[0].value;
-    mockKit.openModal.mockImplementation(({ onWalletSelected }) => {
-      mockOnWalletSelected.mockImplementation(async (option: any) => {
-        mockKit.setWallet(option.id);
-        mockKit.getAddress.mockRejectedValue(new Error('Connection failed'));
-        await onWalletSelected(option);
-      });
-      return Promise.resolve();
-    });
+    mockWalletKit.openModal.mockImplementation(
+      ({ onWalletSelected }: WalletSelectionHandler) => {
+        mockOnWalletSelected.mockImplementation(
+          async (option: { id: string }) => {
+            mockWalletKit.setWallet(option.id);
+            mockWalletKit.getAddress.mockRejectedValue(
+              new Error("Connection failed"),
+            );
+            await onWalletSelected(option);
+          },
+        );
+        return Promise.resolve();
+      },
+    );
 
     await act(async () => {
       result.current.connect();
@@ -135,53 +137,53 @@ describe('useWallet', () => {
 
     // Simulate wallet selection with error
     await act(async () => {
-      await mockOnWalletSelected({ id: 'freighter' });
+      await mockOnWalletSelected({ id: "freighter" });
     });
 
     await waitFor(() => {
       expect(result.current.publicKey).toBeNull();
       expect(result.current.connected).toBe(false);
       expect(result.current.connecting).toBe(false);
-      expect(result.current.error).toBe('Connection failed');
+      expect(result.current.error).toBe("Connection failed");
     });
   });
 
-  it('should set network', () => {
+  it("should set network", () => {
     const { result } = renderHook(() => useWallet());
 
-    expect(result.current.network).toBe('TESTNET');
+    expect(result.current.network).toBe("TESTNET");
 
     act(() => {
-      result.current.setNetwork('PUBLIC');
+      result.current.setNetwork("PUBLIC");
     });
 
-    expect(result.current.network).toBe('PUBLIC');
+    expect(result.current.network).toBe("PUBLIC");
   });
 
-  it('should sign transaction', async () => {
-    const mockXdr = 'AAAAAgAAAAA=';
-    const mockSignedXdr = 'AAAAAwAAAAA=';
-    
+  it("should sign transaction", async () => {
+    const mockXdr = "AAAAAgAAAAA=";
+    const mockSignedXdr = "AAAAAwAAAAA=";
+
     // Set up connected state
     useWalletStore.setState({
-      publicKey: 'GD1234567890ABCDEF',
+      publicKey: "GD1234567890ABCDEF",
       connected: true,
       connecting: false,
       error: null,
-      network: 'TESTNET',
+      network: "TESTNET",
     });
 
     const { result } = renderHook(() => useWallet());
-    
-    const StellarWalletsKit = await import('@creit.tech/stellar-wallets-kit');
-    const mockKit = (StellarWalletsKit.StellarWalletsKit as any).mock.results[0].value;
-    mockKit.signTransaction.mockResolvedValue({ signedTxXdr: mockSignedXdr });
+
+    mockWalletKit.signTransaction.mockResolvedValue({
+      signedTxXdr: mockSignedXdr,
+    });
 
     const signedTx = await result.current.signTransaction(mockXdr);
 
     expect(signedTx).toBe(mockSignedXdr);
-    expect(mockKit.signTransaction).toHaveBeenCalledWith(mockXdr, {
-      address: 'GD1234567890ABCDEF',
+    expect(mockWalletKit.signTransaction).toHaveBeenCalledWith(mockXdr, {
+      address: "GD1234567890ABCDEF",
     });
   });
 });

--- a/frontend-scaffold/src/hooks/useContract.ts
+++ b/frontend-scaffold/src/hooks/useContract.ts
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback } from "react";
 import {
   Contract,
   TimeoutInfinite,
@@ -6,8 +6,8 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
-import { useWallet } from './';
-import { env } from '../helpers/env';
+import { useWallet } from "./";
+import { env } from "../helpers/env";
 import {
   getServer,
   getTxBuilder,
@@ -16,18 +16,18 @@ import {
   accountToScVal,
   numberToI128,
   BASE_FEE,
-} from '../services';
-import { NetworkDetails } from '../helpers/network';
-import { useWalletStore } from '../store/walletStore';
+} from "../services";
+import { NetworkDetails } from "../helpers/network";
+import { useWalletStore } from "../store/walletStore";
 import {
   Profile,
   Tip,
   LeaderboardEntry,
   ContractStats,
   getCreditTier as calculateCreditTier,
-} from '../types/contract';
-import { ProfileFormData } from '../types/profile';
-import { xlmToStroop } from '../helpers/format';
+} from "../types/contract";
+import { ProfileFormData } from "../types/profile";
+import { xlmToStroop } from "../helpers/format";
 
 /**
  * Safely converts a numeric string to a BigInt.
@@ -49,75 +49,99 @@ function safeStringToBigInt(amount: string): bigint {
 export const useContract = () => {
   const wallet = useWallet();
   const { network } = useWalletStore();
-  
-  const networkDetails: NetworkDetails = useMemo(() => ({
-    network,
-    networkUrl: network === 'TESTNET' ? env.horizonUrl : 'https://horizon.stellar.org',
-    networkPassphrase: network === 'TESTNET' 
-      ? 'Test SDF Network ; September 2015' 
-      : 'Public Global Stellar Network ; September 2015',
-  }), [network]);
-  
+
+  const networkDetails: NetworkDetails = useMemo(
+    () => ({
+      network,
+      networkUrl:
+        network === "TESTNET" ? env.horizonUrl : "https://horizon.stellar.org",
+      networkPassphrase:
+        network === "TESTNET"
+          ? "Test SDF Network ; September 2015"
+          : "Public Global Stellar Network ; September 2015",
+    }),
+    [network],
+  );
+
   const server = useMemo(() => getServer(networkDetails), [networkDetails]);
   const contractId = env.contractId;
 
   // --- Read-only Methods ---
 
-  const getProfile = useCallback(async (address: string): Promise<Profile> => {
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      address, // Use the address being queried as the source for simulation
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
-    const tx = txBuilder
-      .addOperation(contract.call("get_profile", accountToScVal(address)))
-      .setTimeout(TimeoutInfinite)
-      .build();
+  const getProfile = useCallback(
+    async (address: string): Promise<Profile> => {
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        address, // Use the address being queried as the source for simulation
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
+      const tx = txBuilder
+        .addOperation(contract.call("get_profile", accountToScVal(address)))
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    return simulateTx<Profile>(tx, server);
-  }, [contractId, server, networkDetails]);
+      return simulateTx<Profile>(tx, server);
+    },
+    [contractId, server, networkDetails],
+  );
 
-  const getProfileByUsername = useCallback(async (username: string): Promise<Profile> => {
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
-    const tx = txBuilder
-      .addOperation(contract.call("get_profile_by_username", nativeToScVal(username)))
-      .setTimeout(TimeoutInfinite)
-      .build();
+  const getProfileByUsername = useCallback(
+    async (username: string): Promise<Profile> => {
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey ||
+          "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
+      const tx = txBuilder
+        .addOperation(
+          contract.call("get_profile_by_username", nativeToScVal(username)),
+        )
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    return simulateTx<Profile>(tx, server);
-  }, [contractId, wallet.publicKey, server, networkDetails]);
+      return simulateTx<Profile>(tx, server);
+    },
+    [contractId, wallet.publicKey, server, networkDetails],
+  );
 
-  const getLeaderboard = useCallback(async (limit: number): Promise<LeaderboardEntry[]> => {
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
-    const tx = txBuilder
-      .addOperation(contract.call("get_leaderboard", nativeToScVal(limit, { type: "u32" })))
-      .setTimeout(TimeoutInfinite)
-      .build();
+  const getLeaderboard = useCallback(
+    async (limit: number): Promise<LeaderboardEntry[]> => {
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey ||
+          "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
+      const tx = txBuilder
+        .addOperation(
+          contract.call(
+            "get_leaderboard",
+            nativeToScVal(limit, { type: "u32" }),
+          ),
+        )
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    return simulateTx<LeaderboardEntry[]>(tx, server);
-  }, [contractId, wallet.publicKey, server, networkDetails]);
+      return simulateTx<LeaderboardEntry[]>(tx, server);
+    },
+    [contractId, wallet.publicKey, server, networkDetails],
+  );
 
   const getStats = useCallback(async (): Promise<ContractStats> => {
     const contract = new Contract(contractId);
     const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      wallet.publicKey ||
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
       BASE_FEE,
       server,
-      networkDetails.networkPassphrase
+      networkDetails.networkPassphrase,
     );
     const tx = txBuilder
       .addOperation(contract.call("get_stats"))
@@ -130,10 +154,11 @@ export const useContract = () => {
   const getMinTipAmount = useCallback(async (): Promise<string> => {
     const contract = new Contract(contractId);
     const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      wallet.publicKey ||
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
       BASE_FEE,
       server,
-      TESTNET_DETAILS.networkPassphrase
+      networkDetails.networkPassphrase,
     );
     const tx = txBuilder
       .addOperation(contract.call("get_min_tip_amount"))
@@ -143,224 +168,263 @@ export const useContract = () => {
     const minTipStroops = await simulateTx<number>(tx, server);
     // Convert stroops to XLM string for display
     return (minTipStroops / 1e7).toString();
-  }, [contractId, wallet.publicKey, server]);
+  }, [contractId, wallet.publicKey, server, networkDetails]);
 
-  const getRecentTips = useCallback(async (creator: string, limit: number, offset: number): Promise<Tip[]> => {
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
-    const tx = txBuilder
-      .addOperation(
-        contract.call(
-          "get_recent_tips",
-          accountToScVal(creator),
-          nativeToScVal(limit, { type: "u32" }),
-          nativeToScVal(offset, { type: "u32" })
+  const getRecentTips = useCallback(
+    async (creator: string, limit: number, offset: number): Promise<Tip[]> => {
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey ||
+          "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
+      const tx = txBuilder
+        .addOperation(
+          contract.call(
+            "get_recent_tips",
+            accountToScVal(creator),
+            nativeToScVal(limit, { type: "u32" }),
+            nativeToScVal(offset, { type: "u32" }),
+          ),
         )
-      )
-      .setTimeout(TimeoutInfinite)
-      .build();
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    return simulateTx<Tip[]>(tx, server);
-  }, [contractId, wallet.publicKey, server, networkDetails]);
+      return simulateTx<Tip[]>(tx, server);
+    },
+    [contractId, wallet.publicKey, server, networkDetails],
+  );
 
-  const getCreatorTipCount = useCallback(async (creator: string): Promise<number> => {
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
-    const tx = txBuilder
-      .addOperation(contract.call("get_creator_tip_count", accountToScVal(creator)))
-      .setTimeout(TimeoutInfinite)
-      .build();
-
-    return simulateTx<number>(tx, server);
-  }, [contractId, wallet.publicKey, server, networkDetails]);
-
-  const getTipsByTipper = useCallback(async (tipper: string, limit: number): Promise<Tip[]> => {
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
-    const tx = txBuilder
-      .addOperation(
-        contract.call(
-          "get_tips_by_tipper",
-          accountToScVal(tipper),
-          nativeToScVal(limit, { type: "u32" })
+  const getCreatorTipCount = useCallback(
+    async (creator: string): Promise<number> => {
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey ||
+          "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
+      const tx = txBuilder
+        .addOperation(
+          contract.call("get_creator_tip_count", accountToScVal(creator)),
         )
-      )
-      .setTimeout(TimeoutInfinite)
-      .build();
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    return simulateTx<Tip[]>(tx, server);
-  }, [contractId, wallet.publicKey, server, networkDetails]);
+      return simulateTx<number>(tx, server);
+    },
+    [contractId, wallet.publicKey, server, networkDetails],
+  );
 
-  const getTipperTipCount = useCallback(async (tipper: string): Promise<number> => {
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
-    const tx = txBuilder
-      .addOperation(contract.call("get_tipper_tip_count", accountToScVal(tipper)))
-      .setTimeout(TimeoutInfinite)
-      .build();
+  const getTipsByTipper = useCallback(
+    async (tipper: string, limit: number): Promise<Tip[]> => {
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey ||
+          "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
+      const tx = txBuilder
+        .addOperation(
+          contract.call(
+            "get_tips_by_tipper",
+            accountToScVal(tipper),
+            nativeToScVal(limit, { type: "u32" }),
+          ),
+        )
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    return simulateTx<number>(tx, server);
-  }, [contractId, wallet.publicKey, server, networkDetails]);
+      return simulateTx<Tip[]>(tx, server);
+    },
+    [contractId, wallet.publicKey, server, networkDetails],
+  );
 
-  const getCreditTier = useCallback(async (address: string) => {
-    const profile = await getProfile(address);
-    const tier = calculateCreditTier(profile.creditScore);
-    return { score: profile.creditScore, tier };
-  }, [getProfile]);
+  const getTipperTipCount = useCallback(
+    async (tipper: string): Promise<number> => {
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey ||
+          "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
+      const tx = txBuilder
+        .addOperation(
+          contract.call("get_tipper_tip_count", accountToScVal(tipper)),
+        )
+        .setTimeout(TimeoutInfinite)
+        .build();
+
+      return simulateTx<number>(tx, server);
+    },
+    [contractId, wallet.publicKey, server, networkDetails],
+  );
+
+  const getCreditTier = useCallback(
+    async (address: string) => {
+      const profile = await getProfile(address);
+      const tier = calculateCreditTier(profile.creditScore);
+      return { score: profile.creditScore, tier };
+    },
+    [getProfile],
+  );
 
   // --- Write Methods ---
 
-  const registerProfile = useCallback(async (data: ProfileFormData): Promise<string> => {
-    if (!wallet.publicKey) throw new Error("Wallet not connected");
+  const registerProfile = useCallback(
+    async (data: ProfileFormData): Promise<string> => {
+      if (!wallet.publicKey) throw new Error("Wallet not connected");
 
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey,
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey,
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
 
-    const tx = txBuilder
-      .addOperation(
-        contract.call(
-          "register_profile",
-          accountToScVal(wallet.publicKey),
-          nativeToScVal(data.username),
-          nativeToScVal(data.displayName),
-          nativeToScVal(data.bio),
-          nativeToScVal(data.imageUrl),
-          nativeToScVal(data.xHandle)
+      const tx = txBuilder
+        .addOperation(
+          contract.call(
+            "register_profile",
+            accountToScVal(wallet.publicKey),
+            nativeToScVal(data.username),
+            nativeToScVal(data.displayName),
+            nativeToScVal(data.bio),
+            nativeToScVal(data.imageUrl),
+            nativeToScVal(data.xHandle),
+          ),
         )
-      )
-      .setTimeout(TimeoutInfinite)
-      .build();
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    const xdr = tx.toXDR();
-    const signedXdr = await wallet.signTransaction(xdr);
-    return submitTx(signedXdr, networkDetails.networkPassphrase, server);
-  }, [contractId, wallet, server, networkDetails]);
+      const xdr = tx.toXDR();
+      const signedXdr = await wallet.signTransaction(xdr);
+      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+    },
+    [contractId, wallet, server, networkDetails],
+  );
 
-  const updateProfile = useCallback(async (data: Partial<ProfileFormData>): Promise<string> => {
-    if (!wallet.publicKey) throw new Error("Wallet not connected");
+  const updateProfile = useCallback(
+    async (data: Partial<ProfileFormData>): Promise<string> => {
+      if (!wallet.publicKey) throw new Error("Wallet not connected");
 
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey,
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey,
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
 
-    // Helper function to convert optional string to ScVal
-    // Returns an Option with Some(value) if value is provided, else None
-    const optionalStringToScVal = (value?: string): xdr.ScVal => {
-      if (value !== undefined && value !== "") {
-        return nativeToScVal({ type: "some", value: value });
-      }
-      return nativeToScVal({ type: "none" });
-    };
+      // Helper function to convert optional string to ScVal
+      // Returns an Option with Some(value) if value is provided, else None
+      const optionalStringToScVal = (value?: string): xdr.ScVal => {
+        if (value !== undefined && value !== "") {
+          return nativeToScVal({ type: "some", value: value });
+        }
+        return nativeToScVal({ type: "none" });
+      };
 
-    const tx = txBuilder
-      .addOperation(
-        contract.call(
-          "update_profile",
-          accountToScVal(wallet.publicKey),
-          optionalStringToScVal(data.displayName),
-          optionalStringToScVal(data.bio),
-          optionalStringToScVal(data.imageUrl),
-          optionalStringToScVal(data.xHandle)
+      const tx = txBuilder
+        .addOperation(
+          contract.call(
+            "update_profile",
+            accountToScVal(wallet.publicKey),
+            optionalStringToScVal(data.displayName),
+            optionalStringToScVal(data.bio),
+            optionalStringToScVal(data.imageUrl),
+            optionalStringToScVal(data.xHandle),
+          ),
         )
-      )
-      .setTimeout(TimeoutInfinite)
-      .build();
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    const xdr_tx = tx.toXDR();
-    const signedXdr = await wallet.signTransaction(xdr_tx);
-    return submitTx(signedXdr, networkDetails.networkPassphrase, server);
-  }, [contractId, wallet, server, networkDetails]);
+      const xdr_tx = tx.toXDR();
+      const signedXdr = await wallet.signTransaction(xdr_tx);
+      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+    },
+    [contractId, wallet, server, networkDetails],
+  );
 
-  const sendTip = useCallback(async (creator: string, amount: string, message: string): Promise<string> => {
-    if (!wallet.publicKey) throw new Error("Wallet not connected");
+  const sendTip = useCallback(
+    async (
+      creator: string,
+      amount: string,
+      message: string,
+    ): Promise<string> => {
+      if (!wallet.publicKey) throw new Error("Wallet not connected");
 
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey,
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey,
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
 
-    // Convert XLM amount to stroops before sending to contract
-    const stroopAmount = xlmToStroop(amount).toString();
+      // Convert XLM amount to stroops before sending to contract
+      const stroopAmount = xlmToStroop(amount).toString();
 
-    const tx = txBuilder
-      .addOperation(
-        contract.call(
-          "send_tip",
-          accountToScVal(wallet.publicKey),
-          accountToScVal(creator),
-          numberToI128(safeStringToBigInt(stroopAmount)),
-          nativeToScVal(message)
+      const tx = txBuilder
+        .addOperation(
+          contract.call(
+            "send_tip",
+            accountToScVal(wallet.publicKey),
+            accountToScVal(creator),
+            numberToI128(safeStringToBigInt(stroopAmount)),
+            nativeToScVal(message),
+          ),
         )
-      )
-      .setTimeout(TimeoutInfinite)
-      .build();
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    const xdr = tx.toXDR();
-    const signedXdr = await wallet.signTransaction(xdr);
-    return submitTx(signedXdr, networkDetails.networkPassphrase, server);
-  }, [contractId, wallet, server, networkDetails]);
+      const xdr = tx.toXDR();
+      const signedXdr = await wallet.signTransaction(xdr);
+      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+    },
+    [contractId, wallet, server, networkDetails],
+  );
 
-  const withdrawTips = useCallback(async (amount: string): Promise<string> => {
-    if (!wallet.publicKey) throw new Error("Wallet not connected");
+  const withdrawTips = useCallback(
+    async (amount: string): Promise<string> => {
+      if (!wallet.publicKey) throw new Error("Wallet not connected");
 
-    const contract = new Contract(contractId);
-    const txBuilder = await getTxBuilder(
-      wallet.publicKey,
-      BASE_FEE,
-      server,
-      networkDetails.networkPassphrase
-    );
+      const contract = new Contract(contractId);
+      const txBuilder = await getTxBuilder(
+        wallet.publicKey,
+        BASE_FEE,
+        server,
+        networkDetails.networkPassphrase,
+      );
 
-    // Convert XLM amount to stroops before sending to contract
-    const stroopAmount = xlmToStroop(amount).toString();
+      // Convert XLM amount to stroops before sending to contract
+      const stroopAmount = xlmToStroop(amount).toString();
 
-    const tx = txBuilder
-      .addOperation(
-        contract.call(
-          "withdraw_tips",
-          accountToScVal(wallet.publicKey),
-          numberToI128(safeStringToBigInt(stroopAmount))
+      const tx = txBuilder
+        .addOperation(
+          contract.call(
+            "withdraw_tips",
+            accountToScVal(wallet.publicKey),
+            numberToI128(safeStringToBigInt(stroopAmount)),
+          ),
         )
-      )
-      .setTimeout(TimeoutInfinite)
-      .build();
+        .setTimeout(TimeoutInfinite)
+        .build();
 
-    const xdr = tx.toXDR();
-    const signedXdr = await wallet.signTransaction(xdr);
-    return submitTx(signedXdr, networkDetails.networkPassphrase, server);
-  }, [contractId, wallet, server, networkDetails]);
+      const xdr = tx.toXDR();
+      const signedXdr = await wallet.signTransaction(xdr);
+      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+    },
+    [contractId, wallet, server, networkDetails],
+  );
 
   return {
     getProfile,

--- a/frontend-scaffold/src/hooks/useWallet.ts
+++ b/frontend-scaffold/src/hooks/useWallet.ts
@@ -7,6 +7,7 @@ import {
   AlbedoModule,
   xBullModule,
 } from "@creit.tech/stellar-wallets-kit";
+import { signTx } from "../helpers/network";
 import { useWalletStore } from "../store/walletStore";
 
 interface Freighter {
@@ -17,8 +18,40 @@ interface Freighter {
 let kitInstance: StellarWalletsKit | null = null;
 let currentNetwork: WalletNetwork | null = null;
 
+type DisposableWalletKit = StellarWalletsKit & {
+  closeModal?: () => void;
+  disconnect?: () => void | Promise<void>;
+  destroy?: () => void;
+  removeAllListeners?: () => void;
+};
+
+const disposeKit = (kit: StellarWalletsKit | null) => {
+  const disposableKit = kit as DisposableWalletKit | null;
+  if (!disposableKit) return;
+
+  try {
+    disposableKit.closeModal?.();
+  } catch (error) {
+    console.warn("Failed to close wallet modal during cleanup:", error);
+  }
+
+  try {
+    void disposableKit.disconnect?.();
+  } catch (error) {
+    console.warn("Failed to disconnect wallet kit during cleanup:", error);
+  }
+
+  try {
+    disposableKit.removeAllListeners?.();
+    disposableKit.destroy?.();
+  } catch (error) {
+    console.warn("Failed to fully dispose wallet kit during cleanup:", error);
+  }
+};
+
 const getKit = (network: WalletNetwork) => {
   if (!kitInstance || currentNetwork !== network) {
+    disposeKit(kitInstance);
     kitInstance = new StellarWalletsKit({
       network,
       selectedWalletId: FREIGHTER_ID,
@@ -62,9 +95,12 @@ export const useWallet = () => {
                 // Automatic network detection for better UX
                 try {
                   // If it's Freighter, check its current network
-                  const freighterWindow = window as unknown as { freighter?: Freighter };
+                  const freighterWindow = window as unknown as {
+                    freighter?: Freighter;
+                  };
                   if (option.id === FREIGHTER_ID && freighterWindow.freighter) {
-                    const networkDetails = await freighterWindow.freighter.getNetwork();
+                    const networkDetails =
+                      await freighterWindow.freighter.getNetwork();
                     const detectedNetwork =
                       networkDetails === "PUBLIC" ? "PUBLIC" : "TESTNET";
                     if (detectedNetwork !== network) {
@@ -100,10 +136,11 @@ export const useWallet = () => {
       },
 
       signTransaction: async (xdr: string): Promise<string> => {
-        const { signedTxXdr } = await kit.signTransaction(xdr, {
-          address: publicKey ?? undefined,
-        });
-        return signedTxXdr;
+        if (!publicKey) {
+          throw new Error("Wallet not connected");
+        }
+
+        return signTx(xdr, publicKey, kit);
       },
     }),
     [
@@ -120,6 +157,6 @@ export const useWallet = () => {
 
   return useMemo(
     () => ({ publicKey, connected, connecting, error, network, ...actions }),
-    [publicKey, connected, connecting, error, network, actions]
+    [publicKey, connected, connecting, error, network, actions],
   );
 };

--- a/frontend-scaffold/src/test/setup.ts
+++ b/frontend-scaffold/src/test/setup.ts
@@ -1,1 +1,50 @@
-import '@testing-library/jest-dom/matchers';
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds = [];
+
+  disconnect(): void {}
+
+  observe(): void {}
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  unobserve(): void {}
+}
+
+if (!("IntersectionObserver" in window)) {
+  Object.defineProperty(window, "IntersectionObserver", {
+    writable: true,
+    configurable: true,
+    value: MockIntersectionObserver,
+  });
+}
+
+const mockWalletKit = {
+  openModal: vi.fn(),
+  setWallet: vi.fn(),
+  getAddress: vi.fn(),
+  signTransaction: vi.fn(),
+  closeModal: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+vi.mock("@creit.tech/stellar-wallets-kit", () => ({
+  StellarWalletsKit: vi.fn(function MockStellarWalletsKit() {
+    return mockWalletKit;
+  }),
+  WalletNetwork: {
+    TESTNET: "TESTNET",
+    PUBLIC: "PUBLIC",
+  },
+  FREIGHTER_ID: "freighter",
+  FreighterModule: vi.fn(function MockFreighterModule() {}),
+  AlbedoModule: vi.fn(function MockAlbedoModule() {}),
+  xBullModule: vi.fn(function MockXBullModule() {}),
+  __mockWalletKit: mockWalletKit,
+}));

--- a/frontend-scaffold/tsconfig.json
+++ b/frontend-scaffold/tsconfig.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -9,6 +9,7 @@
 set -euo pipefail
 
 KEY_NAME="${1:-tipz-deployer}"
+NATIVE_TOKEN_ID="${NATIVE_TOKEN_ID:-CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC}"
 
 echo "=== Stellar Tipz — Testnet Deployment ==="
 echo ""
@@ -70,9 +71,10 @@ soroban contract invoke \
     --admin "$DEPLOYER_ADDR" \
     --fee_collector "$DEPLOYER_ADDR" \
     --fee_bps 200 \
-    --native_token "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+    --native_token "$NATIVE_TOKEN_ID"
 
 echo "Contract initialized with 2% fee."
+echo "Native token SAC: $NATIVE_TOKEN_ID"
 echo ""
 echo "=== Done ==="
 echo "Contract ID: $CONTRACT_ID"


### PR DESCRIPTION
## Description
This PR fixes the grouped deployment, frontend wallet, withdrawal UX, and contract documentation issues that were all reported together. It ensures the testnet deploy script clearly initializes the contract, the wallet hook exposes working transaction signing across network changes, withdrawal modals support partial withdrawals with fee previews, and the contract spec reflects the current storage layout.

Closes #348
Closes #351
Closes #355
Closes #361

## Changes proposed

### What were you told to do?
Bundle the fixes for the deploy script initialization gap, the missing `DataKey` documentation entries, the withdrawal modal forcing full-balance withdrawals, and the wallet hook not exposing a usable `signTransaction` path into one PR.

### What did I do?
#### Deployment and contract docs
- Updated `scripts/deploy-testnet.sh` to keep initialization explicit and configurable by reading the native token SAC from `NATIVE_TOKEN_ID` while printing the initialized token in the final output.
- Rewrote `docs/CONTRACT_SPEC.md` so the contract spec matches the current contract source, including all current `DataKey` variants, storage tiers, and the `native_token` initialization parameter.

#### Wallet and withdrawal flow
- Updated `useWallet` to expose `signTransaction` through the shared `signTx` helper and added best-effort cleanup when the wallet kit is recreated during network switches.
- Fixed `useContract` to use the active network passphrase for `getMinTipAmount` calls.
- Added partial-withdrawal amount inputs, validation, max shortcuts, and fee/net payout previews to both withdraw modals so users can withdraw less than their full balance.

#### Verification support
- Added the small frontend test-harness fixes needed to keep repo verification passing after the wallet-hook changes, including the wallet-kit mock setup, test typing support, a deterministic dashboard skeleton, and the landing-page `IntersectionObserver` polyfill.
- Preserved the existing lint baseline while keeping the updated files type-safe and test-covered.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `cd frontend-scaffold && npm run typecheck` passed.
- `cd frontend-scaffold && npm run test` passed with 99 tests.
- `cd frontend-scaffold && npm run lint` passed with existing repo warnings but no lint errors.
- `cd frontend-scaffold && npx eslint --fix` and `npx prettier --write` were run on the touched frontend files before verification.
