### PR TITLE
fix: add edge case tests for leaderboard insertion sort (#335)

### DIFF
--- a/contracts/tipz/src/leaderboard.rs
+++ b/contracts/tipz/src/leaderboard.rs
@@ -617,6 +617,165 @@ mod tests {
         });
     }
 
+    /// Three entries all with equal totals must retain insertion order (stable sort).
+    #[test]
+    fn test_sort_leaderboard_all_equal_totals() {
+        let env = Env::default();
+        let addr_a = Address::generate(&env);
+        let addr_b = Address::generate(&env);
+        let addr_c = Address::generate(&env);
+        let mut list = Vec::new(&env);
+        list.push_back(LeaderboardEntry {
+            address: addr_a.clone(),
+            username: String::from_str(&env, "a"),
+            total_tips_received: 100,
+            credit_score: 50,
+        });
+        list.push_back(LeaderboardEntry {
+            address: addr_b.clone(),
+            username: String::from_str(&env, "b"),
+            total_tips_received: 100,
+            credit_score: 50,
+        });
+        list.push_back(LeaderboardEntry {
+            address: addr_c.clone(),
+            username: String::from_str(&env, "c"),
+            total_tips_received: 100,
+            credit_score: 50,
+        });
+        sort_leaderboard(&mut list);
+        assert_eq!(list.len(), 3);
+        // All totals equal — insertion order must be preserved.
+        assert_eq!(list.get(0).unwrap().address, addr_a);
+        assert_eq!(list.get(1).unwrap().address, addr_b);
+        assert_eq!(list.get(2).unwrap().address, addr_c);
+    }
+
+    /// An entry with the highest total placed last must bubble all the way to
+    /// index 0, exercising every decrement of j down to 0.
+    #[test]
+    fn test_sort_leaderboard_entry_bubbles_to_position_zero() {
+        let env = Env::default();
+        let mut list = Vec::new(&env);
+        // Insert in ascending order so the last element is the largest.
+        let addrs: soroban_sdk::Vec<Address> = {
+            let mut v = soroban_sdk::Vec::new(&env);
+            let mut k: u32 = 0;
+            while k < 4 {
+                v.push_back(Address::generate(&env));
+                k += 1;
+            }
+            v
+        };
+        let totals: [i128; 4] = [10, 20, 30, 100];
+        let mut k: u32 = 0;
+        while k < 4 {
+            list.push_back(LeaderboardEntry {
+                address: addrs.get(k).unwrap(),
+                username: String::from_str(&env, "u"),
+                total_tips_received: totals[k as usize],
+                credit_score: 50,
+            });
+            k += 1;
+        }
+        sort_leaderboard(&mut list);
+        // Highest (100) must be at position 0.
+        assert_eq!(list.get(0).unwrap().total_tips_received, 100);
+        // Remaining entries must be in descending order.
+        let mut idx: u32 = 0;
+        while idx < list.len() - 1 {
+            assert!(
+                list.get(idx).unwrap().total_tips_received
+                    >= list.get(idx + 1).unwrap().total_tips_received
+            );
+            idx += 1;
+        }
+    }
+
+    /// update_leaderboard: two entries where the second has a higher total must
+    /// end with the higher-total entry at rank 1.
+    #[test]
+    fn test_update_leaderboard_two_entries_need_swap() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, TipzContract);
+        env.as_contract(&contract_id, || {
+            let addr_low = Address::generate(&env);
+            let addr_high = Address::generate(&env);
+
+            // Insert lower total first, higher total second.
+            update_leaderboard(&env, &make_profile(&env, addr_low.clone(), "low", 50));
+            update_leaderboard(&env, &make_profile(&env, addr_high.clone(), "high", 200));
+
+            let entries = load_entries(&env);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(
+                entries.get(0).unwrap().address,
+                addr_high,
+                "higher-total entry must be rank 1"
+            );
+            assert_eq!(entries.get(1).unwrap().address, addr_low);
+        });
+    }
+
+    /// update_leaderboard: all entries with the same total preserve insertion order.
+    #[test]
+    fn test_update_leaderboard_all_equal_totals() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, TipzContract);
+        env.as_contract(&contract_id, || {
+            let addr_a = Address::generate(&env);
+            let addr_b = Address::generate(&env);
+            let addr_c = Address::generate(&env);
+
+            update_leaderboard(&env, &make_profile(&env, addr_a.clone(), "a", 100));
+            update_leaderboard(&env, &make_profile(&env, addr_b.clone(), "b", 100));
+            update_leaderboard(&env, &make_profile(&env, addr_c.clone(), "c", 100));
+
+            let entries = load_entries(&env);
+            assert_eq!(entries.len(), 3);
+            assert_eq!(entries.get(0).unwrap().address, addr_a, "first-in keeps rank 1");
+            assert_eq!(entries.get(1).unwrap().address, addr_b);
+            assert_eq!(entries.get(2).unwrap().address, addr_c);
+        });
+    }
+
+    /// update_leaderboard: a new entry with the highest total must reach rank 1
+    /// (position 0) even when the existing list has multiple entries.
+    #[test]
+    fn test_update_leaderboard_entry_sorts_to_position_zero() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, TipzContract);
+        env.as_contract(&contract_id, || {
+            let addr_top = Address::generate(&env);
+            let addr_a = Address::generate(&env);
+            let addr_b = Address::generate(&env);
+            let addr_c = Address::generate(&env);
+
+            // Build a list of three mid-range entries, then add the top scorer.
+            update_leaderboard(&env, &make_profile(&env, addr_a.clone(), "a", 10));
+            update_leaderboard(&env, &make_profile(&env, addr_b.clone(), "b", 20));
+            update_leaderboard(&env, &make_profile(&env, addr_c.clone(), "c", 30));
+            update_leaderboard(&env, &make_profile(&env, addr_top.clone(), "top", 999));
+
+            let entries = load_entries(&env);
+            assert_eq!(entries.len(), 4);
+            assert_eq!(
+                entries.get(0).unwrap().address,
+                addr_top,
+                "new highest-total entry must be at position 0"
+            );
+            // Remaining entries in descending order.
+            let mut idx: u32 = 0;
+            while idx < entries.len() - 1 {
+                assert!(
+                    entries.get(idx).unwrap().total_tips_received
+                        >= entries.get(idx + 1).unwrap().total_tips_received
+                );
+                idx += 1;
+            }
+        });
+    }
+
     /// Two creators with the same tip total must maintain their insertion order
     /// (first-to-arrive keeps the higher rank) after `update_leaderboard`.
     #[test]


### PR DESCRIPTION
<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>fix: add edge case tests for leaderboard insertion sort (#335)</strong></p><h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul style="padding-inline-start: 2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Added 5 new unit and integration tests covering the edge cases identified in #335</li><li>Verified the existing<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sort_leaderboard</code><span> </span>insertion sort handles all edge cases correctly — no logic change was needed</li><li>Tests cover: 2-entry swap, all-equal totals (stability), and an entry bubbling all the way to position 0 through multiple comparisons</li></ul><h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests Added</h2>
Test | Type | What it covers
-- | -- | --
test_sort_leaderboard_all_equal_totals | Unit | 3 entries with equal totals — stable insertion order preserved
test_sort_leaderboard_entry_bubbles_to_position_zero | Unit | Largest entry placed last must traverse all comparisons to reach index 0
test_update_leaderboard_two_entries_need_swap | Integration | Lower total inserted first, higher total must end at rank 1
test_update_leaderboard_all_equal_totals | Integration | Equal totals across 3 entries — first-to-arrive keeps highest rank
test_update_leaderboard_entry_sorts_to_position_zero | Integration | New top scorer added to an existing 3-entry list must land at position 0

<h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Notes</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The <code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">j &lt; i</code> loop guard and <code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">if j == 0 { break; }</code> ordering are correct — the u32 underflow path is fully guarded and index 0 is always compared before the inner loop exits.</p>

closes #335 