### PR TITLE
fix(frontend): pre-populate profile edit page with existing data (#400)

### DIFF
--- a/frontend-scaffold/src/features/profile/EditProfileForm.tsx
+++ b/frontend-scaffold/src/features/profile/EditProfileForm.tsx
@@ -1,16 +1,22 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Lock } from 'lucide-react';
-import Input from '@/components/ui/Input';
-import Textarea from '@/components/ui/Textarea';
-import Button from '@/components/ui/Button';
-import TransactionStatus from '@/components/shared/TransactionStatus';
-import { useContract } from '@/hooks';
-import { useToastStore } from '@/store/toastStore';
-import type { Profile } from '@/types/contract';
-import type { ProfileFormData } from '@/types/profile';
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Lock } from "lucide-react";
+import Input from "@/components/ui/Input";
+import Textarea from "@/components/ui/Textarea";
+import Button from "@/components/ui/Button";
+import TransactionStatus from "@/components/shared/TransactionStatus";
+import { useContract } from "@/hooks";
+import { useToastStore } from "@/store/toastStore";
+import type { Profile } from "@/types/contract";
+import type { ProfileFormData } from "@/types/profile";
 
-type TxStatus = 'idle' | 'signing' | 'submitting' | 'confirming' | 'success' | 'error';
+type TxStatus =
+  | "idle"
+  | "signing"
+  | "submitting"
+  | "confirming"
+  | "success"
+  | "error";
 
 interface FormErrors {
   displayName?: string;
@@ -23,15 +29,16 @@ function validate(data: ProfileFormData): FormErrors {
   const errors: FormErrors = {};
 
   if (!data.displayName.trim() || data.displayName.length > 64) {
-    errors.displayName = 'Display name is required and must be 1–64 characters.';
+    errors.displayName =
+      "Display name is required and must be 1–64 characters.";
   }
 
   if (data.bio && data.bio.length > 280) {
-    errors.bio = 'Bio must be 280 characters or fewer.';
+    errors.bio = "Bio must be 280 characters or fewer.";
   }
 
   if (data.imageUrl && !isValidUrl(data.imageUrl)) {
-    errors.imageUrl = 'Please enter a valid URL.';
+    errors.imageUrl = "Please enter a valid URL.";
   }
 
   return errors;
@@ -48,9 +55,13 @@ function isValidUrl(url: string): boolean {
 
 interface EditProfileFormProps {
   profile: Profile;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
-const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
+const EditProfileForm: React.FC<EditProfileFormProps> = ({
+  profile,
+  onDirtyChange,
+}) => {
   const [form, setForm] = useState<ProfileFormData>({
     username: profile.username,
     displayName: profile.displayName,
@@ -59,13 +70,23 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
     xHandle: profile.xHandle,
   });
   const [errors, setErrors] = useState<FormErrors>({});
-  const [txStatus, setTxStatus] = useState<TxStatus>('idle');
+  const [txStatus, setTxStatus] = useState<TxStatus>("idle");
   const [txHash, setTxHash] = useState<string | undefined>(undefined);
   const [txError, setTxError] = useState<string | undefined>(undefined);
 
   const { updateProfile } = useContract();
   const { addToast } = useToastStore();
   const navigate = useNavigate();
+
+  // Track whether any field differs from the original profile
+  useEffect(() => {
+    const isDirty =
+      form.displayName !== profile.displayName ||
+      form.bio !== profile.bio ||
+      form.imageUrl !== profile.imageUrl ||
+      form.xHandle !== profile.xHandle;
+    onDirtyChange?.(isDirty);
+  }, [form, profile, onDirtyChange]);
 
   const handleChange =
     (field: keyof ProfileFormData) =>
@@ -86,7 +107,7 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
     }
 
     try {
-      setTxStatus('signing');
+      setTxStatus("signing");
       setTxError(undefined);
       setTxHash(undefined);
 
@@ -102,39 +123,51 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
       if (form.imageUrl.trim() !== profile.imageUrl) {
         data.imageUrl = form.imageUrl.trim();
       }
-      const xHandleFormatted = form.xHandle.trim().replace(/^@/, '');
+      const xHandleFormatted = form.xHandle.trim().replace(/^@/, "");
       if (xHandleFormatted !== profile.xHandle) {
         data.xHandle = xHandleFormatted;
       }
 
       // If no fields changed, show a toast and return
       if (Object.keys(data).length === 0) {
-        addToast({ message: 'No changes to save.', type: 'info', duration: 3000 });
-        setTxStatus('idle');
+        addToast({
+          message: "No changes to save.",
+          type: "info",
+          duration: 3000,
+        });
+        setTxStatus("idle");
         return;
       }
 
-      setTxStatus('submitting');
+      setTxStatus("submitting");
       const hash = await updateProfile(data);
 
-      setTxStatus('confirming');
+      setTxStatus("confirming");
       setTxHash(hash);
 
-      setTxStatus('success');
-      addToast({ message: 'Profile updated successfully!', type: 'success', duration: 5000 });
+      setTxStatus("success");
+      addToast({
+        message: "Profile updated successfully!",
+        type: "success",
+        duration: 5000,
+      });
 
-      setTimeout(() => navigate('/profile'), 1500);
+      setTimeout(() => navigate("/profile"), 1500);
     } catch (err) {
-      setTxStatus('error');
-      setTxError(err instanceof Error ? err.message : 'Update failed. Please try again.');
+      setTxStatus("error");
+      setTxError(
+        err instanceof Error ? err.message : "Update failed. Please try again.",
+      );
     }
   };
 
   const handleCancel = () => {
-    navigate('/profile');
+    navigate("/profile");
   };
 
-  const isSubmitting = ['signing', 'submitting', 'confirming'].includes(txStatus);
+  const isSubmitting = ["signing", "submitting", "confirming"].includes(
+    txStatus,
+  );
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6 max-w-lg mx-auto">
@@ -163,7 +196,7 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
         label="Display Name"
         placeholder="Your Name"
         value={form.displayName}
-        onChange={handleChange('displayName')}
+        onChange={handleChange("displayName")}
         error={errors.displayName}
         disabled={isSubmitting}
         maxLength={64}
@@ -175,7 +208,7 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
         label="Bio"
         placeholder="Tell supporters about yourself…"
         value={form.bio}
-        onChange={handleChange('bio')}
+        onChange={handleChange("bio")}
         error={errors.bio}
         disabled={isSubmitting}
         maxLength={280}
@@ -187,7 +220,7 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
         label="X (Twitter) Handle (optional)"
         placeholder="@yourhandle"
         value={form.xHandle}
-        onChange={handleChange('xHandle')}
+        onChange={handleChange("xHandle")}
         error={errors.xHandle}
         disabled={isSubmitting}
       />
@@ -198,18 +231,18 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
         placeholder="https://example.com/avatar.png"
         type="url"
         value={form.imageUrl}
-        onChange={handleChange('imageUrl')}
+        onChange={handleChange("imageUrl")}
         error={errors.imageUrl}
         disabled={isSubmitting}
       />
 
       {/* Transaction status */}
-      {txStatus !== 'idle' && (
+      {txStatus !== "idle" && (
         <TransactionStatus
           status={txStatus}
           txHash={txHash}
           errorMessage={txError}
-          onRetry={() => setTxStatus('idle')}
+          onRetry={() => setTxStatus("idle")}
         />
       )}
 
@@ -228,10 +261,10 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ profile }) => {
           type="submit"
           variant="primary"
           size="lg"
-          disabled={isSubmitting || txStatus === 'success'}
+          disabled={isSubmitting || txStatus === "success"}
           className="flex-1"
         >
-          {isSubmitting ? 'Updating…' : 'Save Changes'}
+          {isSubmitting ? "Updating…" : "Save Changes"}
         </Button>
       </div>
     </form>

--- a/frontend-scaffold/src/features/profile/ProfileEditPage.tsx
+++ b/frontend-scaffold/src/features/profile/ProfileEditPage.tsx
@@ -1,20 +1,107 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import Button from '@/components/ui/Button';
-import ErrorBoundary from '@/components/shared/ErrorBoundary';
+import React, { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+
+import PageContainer from "../../components/layout/PageContainer";
+import Button from "../../components/ui/Button";
+import Card from "../../components/ui/Card";
+import Loader from "../../components/ui/Loader";
+import ErrorBoundary from "../../components/shared/ErrorBoundary";
+import ErrorState from "../../components/shared/ErrorState";
+import { useProfile } from "../../hooks/useProfile";
+import { usePageTitle } from "../../hooks/usePageTitle";
+import { categorizeError } from "../../helpers/error";
+import EditProfileForm from "./EditProfileForm";
 
 const ProfileEditPage: React.FC = () => {
   const navigate = useNavigate();
+  const { profile, loading, error, isRegistered, refetch } = useProfile();
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  usePageTitle(
+    loading
+      ? "Loading Profile..."
+      : profile
+      ? `Edit ${profile.displayName}`
+      : "Edit Profile",
+  );
+
+  // Redirect to register if no profile exists after loading completes
+  useEffect(() => {
+    if (!loading && !isRegistered) {
+      navigate("/register", { replace: true });
+    }
+  }, [loading, isRegistered, navigate]);
+
+  // Warn user about unsaved changes when navigating away
+  const handleBeforeUnload = useCallback(
+    (e: BeforeUnloadEvent) => {
+      if (hasUnsavedChanges) {
+        e.preventDefault();
+      }
+    },
+    [hasUnsavedChanges],
+  );
+
+  useEffect(() => {
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [handleBeforeUnload]);
+
+  if (loading) {
+    return (
+      <PageContainer maxWidth="md" className="py-20">
+        <div
+          data-testid="profile-skeleton"
+          className="flex flex-col items-center justify-center gap-4"
+        >
+          <Loader size="lg" text="Loading profile data..." />
+        </div>
+      </PageContainer>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageContainer maxWidth="md" className="py-20">
+        <ErrorState category={categorizeError(error)} onRetry={refetch} />
+      </PageContainer>
+    );
+  }
+
+  if (!profile) {
+    return null;
+  }
 
   return (
     <ErrorBoundary>
-      <div className="py-16 px-4 text-center">
-        <h1 className="text-4xl font-black mb-4">Edit Profile</h1>
-        <p className="text-gray-600 mb-8">Profile editing — coming soon.</p>
-        <Button variant="outline" onClick={() => navigate('/profile')}>
-          Back to Profile
-        </Button>
-      </div>
+      <PageContainer maxWidth="md" className="space-y-6 py-10">
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate("/profile")}
+            icon={<ArrowLeft size={18} />}
+          >
+            Back to Profile
+          </Button>
+        </div>
+
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-black uppercase">Edit Profile</h1>
+          <p className="text-sm font-bold text-gray-600">
+            Update your creator profile details below.
+          </p>
+        </div>
+
+        <Card padding="lg" className="border-4 shadow-brutalist">
+          <EditProfileForm
+            profile={profile}
+            onDirtyChange={setHasUnsavedChanges}
+          />
+        </Card>
+      </PageContainer>
     </ErrorBoundary>
   );
 };

--- a/frontend-scaffold/src/hooks/useWallet.ts
+++ b/frontend-scaffold/src/hooks/useWallet.ts
@@ -114,7 +114,10 @@ export const useWallet = () => {
           connect(address, walletType);
         }
       } catch (err) {
-        console.warn("Auto-reconnect failed — wallet extension may be unavailable:", err);
+        console.warn(
+          "Auto-reconnect failed — wallet extension may be unavailable:",
+          err,
+        );
         if (!cancelled) {
           // Clear persisted state so we don't retry on next load
           disconnect();
@@ -191,7 +194,9 @@ export const useWallet = () => {
 
       signTransaction: async (xdr: string): Promise<string> => {
         if (!publicKey) {
-          throw new Error("Please connect your wallet before signing transactions");
+          throw new Error(
+            "Please connect your wallet before signing transactions",
+          );
         }
 
         setSigningStatus("signing");
@@ -201,11 +206,10 @@ export const useWallet = () => {
           return signed;
         } catch (err) {
           setSigningStatus("error");
-          const message =
-            err instanceof Error ? err.message : String(err);
+          const message = err instanceof Error ? err.message : String(err);
           // Normalise rejection/cancellation messages
           if (/cancel|reject|denied|declined|closed/i.test(message)) {
-            throw new Error("Transaction rejected by user");
+            throw new Error("Transaction rejected by user", { cause: err });
           }
           throw err;
         } finally {
@@ -239,6 +243,16 @@ export const useWallet = () => {
       signingStatus,
       ...actions,
     }),
-    [publicKey, connected, connecting, isReconnecting, error, network, walletType, signingStatus, actions],
+    [
+      publicKey,
+      connected,
+      connecting,
+      isReconnecting,
+      error,
+      network,
+      walletType,
+      signingStatus,
+      actions,
+    ],
   );
 };


### PR DESCRIPTION
## Description

Rewrites [ProfileEditPage](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/profile/ProfileEditPage.tsx:15:0-106:2) from a "coming soon" stub into a fully functional edit page that fetches the current profile on mount and pre-populates all form fields. Users no longer need to re-enter all information for minor changes.

Closes #400

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)

## Changes Made

- **[ProfileEditPage.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/profile/ProfileEditPage.tsx:0:0-0:0)**: Rewritten to fetch profile via [useProfile](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/hooks/useProfile.ts:20:0-73:2) hook, show loading state, redirect to `/register` if unregistered, show [ErrorState](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/components/shared/ErrorState.tsx:19:0-93:2) on failure, and render [EditProfileForm](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/profile/EditProfileForm.tsx:60:0-271:2) pre-populated with current data. Includes `beforeunload` warning for unsaved changes.
- **[EditProfileForm.tsx](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/profile/EditProfileForm.tsx:0:0-0:0)**: Added optional `onDirtyChange` callback prop that fires whenever form values differ from the original profile, enabling the parent to track unsaved changes.
- **[useWallet.ts](cci:7://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/hooks/useWallet.ts:0:0-0:0)**: Fixed pre-existing `preserve-caught-error` lint error by attaching `{ cause: err }` to the re-thrown error.

## How to Test

1. Connect wallet with a registered profile and navigate to `/profile/edit` — all fields (display name, bio, image URL, X handle) should be pre-filled
2. Verify a loading spinner appears briefly while profile data is fetched
3. Edit a field then try closing the browser tab — a "leave site?" warning should appear
4. Use an unregistered wallet and navigate to `/profile/edit` — should redirect to `/register`
5. Disconnect network and navigate to `/profile/edit` — should show an error state with a retry button

## Checklist

### Contract Changes
- [x] `cargo fmt -- --check` passes
- [x] N/A — no contract logic changes

### Frontend Changes
- [x] `npx tsc --noEmit` passes (no new errors)
- [x] `npm run lint` passes (0 errors)
- [ ] Tested in browser with Freighter wallet
- [x] Responsive design verified

### General
- [x] Code follows project conventions
- [x] Self-reviewed my own code
- [x] No `console.log` or debug code left in
- [x] Branch is up to date with `main`

## Screenshots (if applicable)

N/A — uses existing [EditProfileForm](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/features/profile/EditProfileForm.tsx:60:0-271:2), `Loader`, and [ErrorState](cci:1://file:///home/dsotec/Documents/Stellar-Tipz/frontend-scaffold/src/components/shared/ErrorState.tsx:19:0-93:2) components with no new visual elements.