### PR TITLE
fix: resolve correct Wasm filename and add --build/--dry-run flags

### DIFF
--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -2,14 +2,37 @@
 # Deploy the Tipz contract to Stellar Testnet.
 #
 # Usage:
-#   ./scripts/deploy-testnet.sh [KEY_NAME]
+#   ./scripts/deploy-testnet.sh [options] [KEY_NAME]
+#
+# Options:
+#   --build       Build the contract before deploying
+#   --optimized   Use soroban contract optimize output (optimized.wasm)
+#   --dry-run     Validate inputs and wasm path without deploying
 #
 # KEY_NAME defaults to "tipz-deployer"
 
 set -euo pipefail
 
-KEY_NAME="${1:-tipz-deployer}"
+BUILD=false
+OPTIMIZED=false
+DRY_RUN=false
+KEY_NAME="tipz-deployer"
 NATIVE_TOKEN_ID="${NATIVE_TOKEN_ID:-CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC}"
+
+# Parse args
+for arg in "$@"; do
+    case "$arg" in
+        --build)     BUILD=true ;;
+        --optimized) OPTIMIZED=true ;;
+        --dry-run)   DRY_RUN=true ;;
+        --*)
+            echo "Error: Unknown option '$arg'"
+            echo "Usage: $0 [--build] [--optimized] [--dry-run] [KEY_NAME]"
+            exit 1
+            ;;
+        *)           KEY_NAME="$arg" ;;
+    esac
+done
 
 echo "=== Stellar Tipz — Testnet Deployment ==="
 echo ""
@@ -19,6 +42,58 @@ if ! command -v soroban &> /dev/null; then
     echo "Error: soroban CLI not found. Install it with:"
     echo "  cargo install --locked soroban-cli"
     exit 1
+fi
+
+# Optionally build first
+if [ "$BUILD" = true ]; then
+    echo "Building contract..."
+    (cd contracts && cargo build --target wasm32-unknown-unknown --release)
+    echo "Build complete."
+    echo ""
+fi
+
+# Resolve Wasm path — auto-detect from build output
+RELEASE_DIR="contracts/target/wasm32-unknown-unknown/release"
+
+if [ "$OPTIMIZED" = true ]; then
+    WASM_PATH="$RELEASE_DIR/tipz_contract.optimized.wasm"
+else
+    # Auto-detect: prefer the known name, fall back to any .wasm in release dir
+    KNOWN_WASM="$RELEASE_DIR/tipz_contract.wasm"
+    if [ -f "$KNOWN_WASM" ]; then
+        WASM_PATH="$KNOWN_WASM"
+    else
+        # Try to find any compiled wasm (handles unexpected name changes)
+        DETECTED=$(find "$RELEASE_DIR" -maxdepth 1 -name "*.wasm" ! -name "*.optimized.wasm" 2>/dev/null | head -1)
+        if [ -n "$DETECTED" ]; then
+            WASM_PATH="$DETECTED"
+            echo "Warning: expected tipz_contract.wasm not found; using detected file."
+        else
+            WASM_PATH="$KNOWN_WASM"  # set for the error message below
+        fi
+    fi
+fi
+
+# Validate Wasm exists
+if [ ! -f "$WASM_PATH" ]; then
+    echo "Error: Wasm file not found at $WASM_PATH"
+    echo ""
+    echo "Build the contract first with:"
+    echo "  cd contracts && cargo build --target wasm32-unknown-unknown --release"
+    echo ""
+    echo "Or re-run this script with the --build flag:"
+    echo "  $0 --build $KEY_NAME"
+    exit 1
+fi
+
+echo "Using Wasm: $WASM_PATH"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo "[dry-run] Wasm file found. Skipping deploy."
+    echo "[dry-run] Key: $KEY_NAME"
+    echo "[dry-run] Native token: $NATIVE_TOKEN_ID"
+    exit 0
 fi
 
 # Check if key exists, create if not
@@ -34,19 +109,7 @@ echo "Deployer address: $DEPLOYER_ADDR"
 echo "Funding account via Friendbot..."
 curl -s "https://friendbot.stellar.org?addr=$DEPLOYER_ADDR" > /dev/null
 echo "Account funded."
-
-# Build the contract
-echo "Building contract..."
-cd contracts
-cargo build --target wasm32-unknown-unknown --release
-cd ..
-
-WASM_PATH="contracts/target/wasm32-unknown-unknown/release/tipz_contract.wasm"
-
-if [ ! -f "$WASM_PATH" ]; then
-    echo "Error: Wasm file not found at $WASM_PATH"
-    exit 1
-fi
+echo ""
 
 # Deploy
 echo "Deploying to testnet..."
@@ -73,6 +136,7 @@ soroban contract invoke \
     --fee_bps 200 \
     --native_token "$NATIVE_TOKEN_ID"
 
+echo ""
 echo "Contract initialized with 2% fee."
 echo "Native token SAC: $NATIVE_TOKEN_ID"
 echo ""


### PR DESCRIPTION
---

PR title: `fix: resolve correct Wasm filename and add --build/--dry-run flags`

Body:
```
Closes #398

## What changed
- Wasm filename corrected to `tipz_contract.wasm` (derived from package
  name `tipz-contract` in `contracts/tipz/Cargo.toml`)
- Auto-detection fallback using `find` in case the name ever drifts
- Clear error message with exact build command when Wasm is missing
- `--build` flag: runs `cargo build` before deploying
- `--optimized` flag: targets the `.optimized.wasm` from `soroban contract optimize`
- `--dry-run` flag: validates Wasm path and config without deploying
- Prints the resolved Wasm path so it's always visible in CI/CD logs

## Testing
# Verify correct filename
ls contracts/target/wasm32-unknown-unknown/release/*.wasm

# Dry-run (no deploy)
bash scripts/deploy-testnet.sh --dry-run

# Error message when Wasm missing
rm -f contracts/target/wasm32-unknown-unknown/release/*.wasm
bash scripts/deploy-testnet.sh 2>&1 | grep -i "build"

# Build + deploy in one step
bash scripts/deploy-testnet.sh --build
```