### PR TITLE
feat: implement favorites feature with UI and state management

### DIFF
--- a/frontend-scaffold/src/components/shared/ProfileCard.tsx
+++ b/frontend-scaffold/src/components/shared/ProfileCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { User, Copy, ExternalLink, Trophy } from 'lucide-react';
+import { User, Copy, ExternalLink, Trophy, Heart } from 'lucide-react';
 import Avatar from '../ui/Avatar';
 import Card from '../ui/Card';
 import CreditBadge from './CreditBadge';
 import AmountDisplay from './AmountDisplay';
 import Skeleton from '../ui/Skeleton';
+import { useFavorites } from '../../hooks/useFavorites';
 
 interface ProfileCardProps {
   handle: string;
@@ -25,6 +26,9 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
   creditScore,
   totalTips
 }) => {
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const favorite = isFavorite(publicKey);
+
   const shortKey = `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`;
 
   const copyToClipboard = () => {
@@ -38,9 +42,23 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
         <div data-testid="profile-card" className="contents">
           <div className="flex items-center justify-between gap-2">
             <Avatar address={publicKey} alt={handle} size="md" />
-            {creditScore !== undefined && (
-              <CreditBadge score={creditScore} showScore={false} />
-            )}
+            <div className="flex items-center gap-2">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleFavorite({ address: publicKey, username: handle });
+                }}
+                className={`p-1.5 rounded-full transition-colors ${
+                  favorite ? 'text-red-500 bg-red-50' : 'text-gray-400 hover:text-red-500 hover:bg-gray-100'
+                }`}
+                aria-label={favorite ? "Remove from favorites" : "Add to favorites"}
+              >
+                <Heart size={18} fill={favorite ? "currentColor" : "none"} />
+              </button>
+              {creditScore !== undefined && (
+                <CreditBadge score={creditScore} showScore={false} />
+              )}
+            </div>
           </div>
 
           <div className="min-w-0">
@@ -66,7 +84,20 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
 
   return (
     <div className="w-full max-w-sm bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden hover:shadow-md transition-shadow duration-300">
-      <div className="h-24 bg-gradient-to-r from-blue-500 to-indigo-600" />
+      <div className="h-24 bg-gradient-to-r from-blue-500 to-indigo-600 relative">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleFavorite({ address: publicKey, username: handle });
+          }}
+          className={`absolute top-4 right-4 p-2 rounded-full bg-white/20 backdrop-blur-md transition-colors ${
+            favorite ? 'text-red-500' : 'text-white hover:text-red-500 hover:bg-white/40'
+          }`}
+          aria-label={favorite ? "Remove from favorites" : "Add to favorites"}
+        >
+          <Heart size={20} fill={favorite ? "currentColor" : "none"} />
+        </button>
+      </div>
       <div className="px-6 pb-6 text-center">
         <div className="relative -mt-12 mb-4">
           <div className="inline-flex items-center justify-center h-24 w-24 rounded-full border-4 border-white bg-gray-100 overflow-hidden shadow-sm">

--- a/frontend-scaffold/src/components/shared/__tests__/ProfileCard.test.tsx
+++ b/frontend-scaffold/src/components/shared/__tests__/ProfileCard.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ProfileCard from "../ProfileCard";
+import { useFavorites } from "../../../hooks/useFavorites";
+
+// Mock useFavorites
+vi.mock("../../../hooks/useFavorites", () => ({
+  useFavorites: vi.fn(),
+}));
+
+describe("ProfileCard", () => {
+  const mockToggleFavorite = vi.fn();
+  const mockIsFavorite = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useFavorites as any).mockReturnValue({
+      isFavorite: mockIsFavorite,
+      toggleFavorite: mockToggleFavorite,
+    });
+  });
+
+  it("calls toggleFavorite when heart button is clicked", () => {
+    mockIsFavorite.mockReturnValue(false);
+    render(
+      <ProfileCard 
+        handle="alice" 
+        publicKey="G123" 
+      />
+    );
+
+    const favoriteButton = screen.getByLabelText(/Add to favorites/i);
+    fireEvent.click(favoriteButton);
+
+    expect(mockToggleFavorite).toHaveBeenCalledWith({ address: "G123", username: "alice" });
+  });
+
+  it("shows filled heart when is favorite", () => {
+    mockIsFavorite.mockReturnValue(true);
+    render(
+      <ProfileCard 
+        handle="alice" 
+        publicKey="G123" 
+      />
+    );
+
+    const favoriteButton = screen.getByLabelText(/Remove from favorites/i);
+    expect(favoriteButton).toBeInTheDocument();
+    
+    // Check for filled heart (the icon has fill prop set to currentColor when favorite)
+    const heartIcon = favoriteButton.querySelector('svg');
+    expect(heartIcon).toHaveAttribute('fill', 'currentColor');
+  });
+});

--- a/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
+++ b/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
@@ -23,12 +23,13 @@ import EarningsTab from "./EarningsTab";
 import OverviewTab from "./OverviewTab";
 import SettingsTab from "./SettingsTab";
 import TipsTab from "./TipsTab";
+import FavoritesList from "./FavoritesList";
 
 const DashboardPage: React.FC = () => {
   usePageTitle("Dashboard");
 
   const { connected } = useWalletStore();
-  const { profile, loading, error, refetch } = useDashboard();
+  const { profile, tips, loading, error, refetch } = useDashboard();
   const { latestTip, markSeen, unseenCount } = useTipNotifications(
     profile?.owner,
   );
@@ -129,15 +130,14 @@ const DashboardPage: React.FC = () => {
       id: "overview",
       label: "Overview",
       content: (
-        <div className="pt-6">
-          <div className="space-y-8">
-            <OverviewTab />
-            <div className="border-4 border-black bg-white p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-              <EarningsChart tips={tips} />
-            </div>
+        <div className="pt-6 space-y-8">
           <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
             <OverviewTab />
             <TipQRCode username={creator.username} />
+          </div>
+          <div className="border-4 border-black bg-white p-6 shadow-brutalist">
+            <h3 className="text-xl font-black uppercase mb-4">Earnings History</h3>
+            <EarningsChart tips={tips} />
           </div>
         </div>
       ),
@@ -155,6 +155,15 @@ const DashboardPage: React.FC = () => {
       id: "earnings",
       label: "Earnings",
       content: <EarningsTab />,
+    },
+    {
+      id: "favorites",
+      label: "Favorites",
+      content: (
+        <div className="pt-6">
+          <FavoritesList />
+        </div>
+      ),
     },
     {
       id: "settings",

--- a/frontend-scaffold/src/features/dashboard/FavoritesList.tsx
+++ b/frontend-scaffold/src/features/dashboard/FavoritesList.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Heart, Send, Trash2, ArrowUpDown, Users } from 'lucide-react';
+
+import Avatar from '../../components/ui/Avatar';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import { useFavorites } from '../../hooks/useFavorites';
+
+const FavoritesList: React.FC = () => {
+  const { favorites, sortedFavorites, removeFavorite, recordTip } = useFavorites();
+  const [sortBy, setSortBy] = useState<'recent' | 'most_tipped' | 'alphabetical'>('recent');
+  const navigate = useNavigate();
+
+  const sortedList = sortedFavorites(sortBy);
+
+  if (favorites.length === 0) {
+    return (
+      <Card className="p-8 text-center border-4 border-dashed border-gray-200 bg-gray-50/50 shadow-none">
+        <div className="mx-auto w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+          <Users className="h-8 w-8 text-gray-400" />
+        </div>
+        <h3 className="text-lg font-black uppercase text-gray-900 mb-2">No favorites yet</h3>
+        <p className="text-gray-500 font-bold max-w-xs mx-auto text-sm">
+          Add creators to your favorites for quick access and faster tipping.
+        </p>
+        <Button 
+          variant="outline" 
+          className="mt-6 bg-white border-2 border-black shadow-brutalist hover:shadow-none transition-all"
+          onClick={() => navigate('/leaderboard')}
+        >
+          Explore Creators
+        </Button>
+      </Card>
+    );
+  }
+
+  const handleRemove = (address: string, username: string) => {
+    if (window.confirm(`Are you sure you want to remove @${username} from your favorites?`)) {
+      removeFavorite(address);
+    }
+  };
+
+  const handleQuickTip = (address: string, username: string) => {
+    recordTip(address);
+    navigate(`/@${username}`);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-black uppercase flex items-center gap-2 tracking-tight">
+          <Heart className="text-red-500 fill-red-500" size={24} />
+          Favorites
+        </h2>
+        <div className="flex items-center gap-2 border-2 border-black bg-white px-3 py-1.5 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
+           <ArrowUpDown size={14} className="text-black" />
+           <select 
+             value={sortBy}
+             onChange={(e) => setSortBy(e.target.value as any)}
+             className="bg-transparent border-none text-xs font-black uppercase focus:ring-0 cursor-pointer p-0 pr-6"
+           >
+             <option value="recent">Recently Added</option>
+             <option value="most_tipped">Most Tipped</option>
+             <option value="alphabetical">Alphabetical</option>
+           </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {sortedList.map((creator) => (
+          <Card 
+            key={creator.address} 
+            padding="sm" 
+            className="flex items-center justify-between gap-4 border-2 border-black hover:shadow-brutalist transition-all"
+          >
+            <div 
+              className="flex items-center gap-3 min-w-0 cursor-pointer group"
+              onClick={() => navigate(`/@${creator.username}`)}
+            >
+               <Avatar 
+                 address={creator.address} 
+                 alt={creator.username}
+                 size="md" 
+                 className="border-2 border-black"
+               />
+               <div className="truncate">
+                 <p className="font-black uppercase truncate group-hover:underline">@{creator.username}</p>
+                 <p className="text-[10px] font-black uppercase text-gray-500">
+                   {creator.tipCount} tips sent
+                 </p>
+               </div>
+            </div>
+            <div className="flex items-center gap-1">
+               <button
+                 onClick={() => handleQuickTip(creator.address, creator.username)}
+                 className="p-2 text-black hover:bg-yellow-200 border-2 border-transparent hover:border-black transition-all rounded"
+                 title="Quick Tip"
+               >
+                 <Send size={18} />
+               </button>
+               <button
+                 onClick={() => handleRemove(creator.address, creator.username)}
+                 className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors rounded"
+                 title="Remove"
+               >
+                 <Trash2 size={18} />
+               </button>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default FavoritesList;

--- a/frontend-scaffold/src/features/dashboard/__tests__/FavoritesList.test.tsx
+++ b/frontend-scaffold/src/features/dashboard/__tests__/FavoritesList.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import FavoritesList from "../FavoritesList";
+import { useFavorites } from "../../../hooks/useFavorites";
+
+// Mock useFavorites
+vi.mock("../../../hooks/useFavorites", () => ({
+  useFavorites: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("FavoritesList", () => {
+  const mockRemoveFavorite = vi.fn();
+  const mockRecordTip = vi.fn();
+  const mockFavorites = [
+    { address: "G1", username: "alice", addedAt: 1000, tipCount: 2 },
+    { address: "G2", username: "bob", addedAt: 2000, tipCount: 5 },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useFavorites as any).mockReturnValue({
+      favorites: mockFavorites,
+      sortedFavorites: (sortBy: string) => {
+        if (sortBy === 'alphabetical') return [...mockFavorites].sort((a, b) => a.username.localeCompare(b.username));
+        if (sortBy === 'most_tipped') return [...mockFavorites].sort((a, b) => b.tipCount - a.tipCount);
+        return [...mockFavorites].sort((a, b) => b.addedAt - a.addedAt);
+      },
+      removeFavorite: mockRemoveFavorite,
+      recordTip: mockRecordTip,
+    });
+    
+    // Mock window.confirm
+    window.confirm = vi.fn(() => true);
+  });
+
+  const renderComponent = () =>
+    render(
+      <BrowserRouter>
+        <FavoritesList />
+      </BrowserRouter>,
+    );
+
+  it("renders empty state when no favorites", () => {
+    (useFavorites as any).mockReturnValue({
+      favorites: [],
+      sortedFavorites: () => [],
+      removeFavorite: mockRemoveFavorite,
+      recordTip: mockRecordTip,
+    });
+    renderComponent();
+
+    expect(screen.getByText(/No favorites yet/i)).toBeInTheDocument();
+  });
+
+  it("renders list of favorites", () => {
+    renderComponent();
+
+    expect(screen.getByText(/@alice/i)).toBeInTheDocument();
+    expect(screen.getByText(/@bob/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 tips sent/i)).toBeInTheDocument();
+    expect(screen.getByText(/5 tips sent/i)).toBeInTheDocument();
+  });
+
+  it("calls removeFavorite when remove button is clicked and confirmed", () => {
+    renderComponent();
+
+    const removeButtons = screen.getAllByTitle(/Remove/i);
+    fireEvent.click(removeButtons[0]);
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(mockRemoveFavorite).toHaveBeenCalledWith("G2"); // G2 is Bob, who is first in 'recent' sort (addedAt 2000)
+  });
+
+  it("navigates to tip page when quick tip button is clicked", () => {
+    renderComponent();
+
+    const tipButtons = screen.getAllByTitle(/Quick Tip/i);
+    fireEvent.click(tipButtons[0]);
+
+    expect(mockRecordTip).toHaveBeenCalledWith("G2");
+    expect(mockNavigate).toHaveBeenCalledWith("/@bob");
+  });
+});

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardRow.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardRow.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { Heart } from "lucide-react";
 
 import AmountDisplay from "../../components/shared/AmountDisplay";
 import CreditBadge from "../../components/shared/CreditBadge";
@@ -7,6 +8,7 @@ import Avatar from "../../components/ui/Avatar";
 import Skeleton from "../../components/ui/Skeleton";
 import { useWalletStore } from "../../store";
 import type { LeaderboardEntry } from "../../types/contract";
+import { useFavorites } from "../../hooks/useFavorites";
 
 export interface LeaderboardRowProps {
   entry: LeaderboardEntry;
@@ -16,6 +18,8 @@ export interface LeaderboardRowProps {
 const LeaderboardRow: React.FC<LeaderboardRowProps> = ({ entry, rank }) => {
   const navigate = useNavigate();
   const { connected, publicKey } = useWalletStore();
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const favorite = isFavorite(entry.address);
 
   const isOwnProfile =
     connected && Boolean(publicKey) && publicKey?.toLowerCase() === entry.address.toLowerCase();
@@ -52,7 +56,23 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({ entry, rank }) => {
             fallback={entry.username}
             size="md"
           />
-          <span className="font-black uppercase">{entry.username}</span>
+          <div className="flex items-center gap-2">
+            <span className="font-black uppercase">{entry.username}</span>
+            {!isOwnProfile && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleFavorite({ address: entry.address, username: entry.username });
+                }}
+                className={`p-1 rounded-full transition-colors ${
+                  favorite ? 'text-red-500 bg-red-50' : 'text-gray-400 hover:text-red-500 hover:bg-gray-100'
+                }`}
+                aria-label={favorite ? "Remove from favorites" : "Add to favorites"}
+              >
+                <Heart size={16} fill={favorite ? "currentColor" : "none"} />
+              </button>
+            )}
+          </div>
           {isOwnProfile && (
             <span className="border-2 border-black bg-black px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-white">
               You

--- a/frontend-scaffold/src/hooks/__tests__/useFavorites.test.ts
+++ b/frontend-scaffold/src/hooks/__tests__/useFavorites.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useFavorites } from "../useFavorites";
+import { useWalletStore } from "../../store/walletStore";
+import { useFavoritesStore } from "../../store/favoritesStore";
+
+describe("useFavorites", () => {
+  const mockWallet = "GD1234567890ABCDEF";
+  const mockCreator = { address: "GABC123", username: "alice" };
+
+  beforeEach(() => {
+    // Reset stores
+    useWalletStore.setState({
+      publicKey: mockWallet,
+      connected: true,
+    });
+    useFavoritesStore.setState({
+      favoritesByWallet: {},
+    });
+  });
+
+  it("should add a creator to favorites", () => {
+    const { result } = renderHook(() => useFavorites());
+
+    act(() => {
+      result.current.toggleFavorite(mockCreator);
+    });
+
+    expect(result.current.favorites).toHaveLength(1);
+    expect(result.current.favorites[0].address).toBe(mockCreator.address);
+    expect(result.current.isFavorite(mockCreator.address)).toBe(true);
+  });
+
+  it("should remove a creator from favorites", () => {
+    const { result } = renderHook(() => useFavorites());
+
+    act(() => {
+      result.current.toggleFavorite(mockCreator);
+    });
+    expect(result.current.favorites).toHaveLength(1);
+
+    act(() => {
+      result.current.toggleFavorite(mockCreator);
+    });
+    expect(result.current.favorites).toHaveLength(0);
+    expect(result.current.isFavorite(mockCreator.address)).toBe(false);
+  });
+
+  it("should sort favorites", () => {
+    const { result } = renderHook(() => useFavorites());
+
+    act(() => {
+      result.current.toggleFavorite({ address: "ADDR1", username: "Charlie" });
+      result.current.toggleFavorite({ address: "ADDR2", username: "Alice" });
+      result.current.toggleFavorite({ address: "ADDR3", username: "Bob" });
+    });
+
+    // Alphabetical
+    const alpha = result.current.sortedFavorites("alphabetical");
+    expect(alpha[0].username).toBe("Alice");
+    expect(alpha[1].username).toBe("Bob");
+    expect(alpha[2].username).toBe("Charlie");
+
+    // Most tipped (record some tips)
+    act(() => {
+        result.current.recordTip("ADDR3"); // Bob
+        result.current.recordTip("ADDR3");
+        result.current.recordTip("ADDR1"); // Charlie
+    });
+
+    const mostTipped = result.current.sortedFavorites("most_tipped");
+    expect(mostTipped[0].username).toBe("Bob"); // 2 tips
+    expect(mostTipped[1].username).toBe("Charlie"); // 1 tip
+    expect(mostTipped[2].username).toBe("Alice"); // 0 tips
+  });
+
+  it("should be wallet-specific", () => {
+    const { result, rerender } = renderHook(() => useFavorites());
+
+    act(() => {
+      result.current.toggleFavorite(mockCreator);
+    });
+    expect(result.current.favorites).toHaveLength(1);
+
+    // Switch wallet
+    act(() => {
+      useWalletStore.setState({ publicKey: "GOTH888", connected: true });
+    });
+    
+    // We need to wait for the hook to react to store change if it uses selectors
+    // renderHook with zustand usually reacts immediately if it's using the store
+    
+    expect(result.current.favorites).toHaveLength(0);
+
+    act(() => {
+        result.current.toggleFavorite({ address: "GXYZ", username: "bob" });
+    });
+    expect(result.current.favorites).toHaveLength(1);
+    expect(result.current.favorites[0].username).toBe("bob");
+
+    // Switch back
+    act(() => {
+        useWalletStore.setState({ publicKey: mockWallet, connected: true });
+    });
+    expect(result.current.favorites).toHaveLength(1);
+    expect(result.current.favorites[0].username).toBe("alice");
+  });
+});

--- a/frontend-scaffold/src/hooks/useFavorites.ts
+++ b/frontend-scaffold/src/hooks/useFavorites.ts
@@ -1,0 +1,67 @@
+import { useMemo, useCallback } from 'react';
+import { useWalletStore } from '../store/walletStore';
+import { useFavoritesStore } from '../store/favoritesStore';
+import { FavoriteCreator } from '../types';
+
+export const useFavorites = () => {
+  const { publicKey } = useWalletStore();
+  const { favoritesByWallet, addFavorite, removeFavorite, incrementTipCount } = useFavoritesStore();
+
+  const favorites = useMemo(() => {
+    if (!publicKey) return [];
+    return favoritesByWallet[publicKey] || [];
+  }, [favoritesByWallet, publicKey]);
+
+  const isFavorite = useCallback(
+    (address: string) => {
+      return favorites.some((f) => f.address === address);
+    },
+    [favorites]
+  );
+
+  const toggleFavorite = useCallback(
+    (creator: { address: string; username: string }) => {
+      if (!publicKey) return;
+      if (isFavorite(creator.address)) {
+        removeFavorite(publicKey, creator.address);
+      } else {
+        addFavorite(publicKey, creator);
+      }
+    },
+    [publicKey, isFavorite, removeFavorite, addFavorite]
+  );
+
+  const recordTip = useCallback(
+    (address: string) => {
+      if (!publicKey) return;
+      incrementTipCount(publicKey, address);
+    },
+    [publicKey, incrementTipCount]
+  );
+
+  const sortedFavorites = useCallback(
+    (sortBy: 'recent' | 'most_tipped' | 'alphabetical' = 'recent') => {
+      const result = [...favorites];
+      switch (sortBy) {
+        case 'recent':
+          return result.sort((a, b) => b.addedAt - a.addedAt);
+        case 'most_tipped':
+          return result.sort((a, b) => b.tipCount - a.tipCount);
+        case 'alphabetical':
+          return result.sort((a, b) => a.username.localeCompare(b.username));
+        default:
+          return result;
+      }
+    },
+    [favorites]
+  );
+
+  return {
+    favorites,
+    isFavorite,
+    toggleFavorite,
+    recordTip,
+    sortedFavorites,
+    removeFavorite: (address: string) => publicKey && removeFavorite(publicKey, address),
+  };
+};

--- a/frontend-scaffold/src/store/favoritesStore.ts
+++ b/frontend-scaffold/src/store/favoritesStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { FavoriteCreator } from '../types';
+
+interface FavoritesState {
+  favoritesByWallet: { [publicKey: string]: FavoriteCreator[] };
+  addFavorite: (walletAddress: string, creator: Omit<FavoriteCreator, 'addedAt' | 'tipCount'>) => void;
+  removeFavorite: (walletAddress: string, creatorAddress: string) => void;
+  incrementTipCount: (walletAddress: string, creatorAddress: string) => void;
+}
+
+export const useFavoritesStore = create<FavoritesState>()(
+  persist(
+    (set) => ({
+      favoritesByWallet: {},
+
+      addFavorite: (walletAddress, creator) =>
+        set((state) => {
+          const walletFavorites = state.favoritesByWallet[walletAddress] || [];
+          if (walletFavorites.some((f) => f.address === creator.address)) {
+            return state;
+          }
+          return {
+            favoritesByWallet: {
+              ...state.favoritesByWallet,
+              [walletAddress]: [
+                ...walletFavorites,
+                { ...creator, addedAt: Date.now(), tipCount: 0 },
+              ],
+            },
+          };
+        }),
+
+      removeFavorite: (walletAddress, creatorAddress) =>
+        set((state) => ({
+          favoritesByWallet: {
+            ...state.favoritesByWallet,
+            [walletAddress]: (state.favoritesByWallet[walletAddress] || []).filter(
+              (f) => f.address !== creatorAddress
+            ),
+          },
+        })),
+
+      incrementTipCount: (walletAddress, creatorAddress) =>
+        set((state) => ({
+          favoritesByWallet: {
+            ...state.favoritesByWallet,
+            [walletAddress]: (state.favoritesByWallet[walletAddress] || []).map((f) =>
+              f.address === creatorAddress ? { ...f, tipCount: f.tipCount + 1 } : f
+            ),
+          },
+        })),
+    }),
+    {
+      name: 'tipz_favorites',
+    }
+  )
+);

--- a/frontend-scaffold/src/types/favorites.ts
+++ b/frontend-scaffold/src/types/favorites.ts
@@ -1,0 +1,6 @@
+export interface FavoriteCreator {
+  address: string;
+  username: string;
+  addedAt: number;
+  tipCount: number;
+}

--- a/frontend-scaffold/src/types/index.ts
+++ b/frontend-scaffold/src/types/index.ts
@@ -9,6 +9,8 @@ export { getCreditTier } from "./contract";
 
 export type { ProfileFormData } from "./profile";
 
+export type { FavoriteCreator } from "./favorites";
+
 export type { WalletState } from "./wallet";
 
 export type { ErrorCategory, CategorizedError } from "../helpers/error";


### PR DESCRIPTION
## Description

Allow users to save favorite creators for quick access.

Closes #564 

## Changes

   - State Management: Created favoritesStore.ts using Zustand with persistence,
     allowing favorites to be saved in localStorage and scoped to specific
     wallet addresses.
   - Hook: Developed a useFavorites hook that provides an easy-to-use API for
     toggling favorites, recording tips for sorting, and retrieving sorted lists
     (recent, most tipped, alphabetical).
   - Components:
       - ProfileCard: Added a heart button to both default and compact variants
         to allow favoriting creators directly from their profiles or search
         results.
       - LeaderboardRow: Added a heart button next to creators' usernames on the
         leaderboard.
       - FavoritesList: Created a new component for the dashboard that displays
         favorite creators, supports sorting, and offers "Quick Tip" and removal
         actions.
   - Dashboard Integration: Added a "Favorites" tab to the main Dashboard page
     and fixed an existing layout issue in the "Overview" tab while ensuring
     tips data is correctly passed to the earnings chart.
   - Verification: 
       - Implemented unit tests for the useFavorites hook.
       - Added component tests for FavoritesList and ProfileCard.
       - Verified all tests pass using Vitest.

  Users can now heart creators across the app and access them quickly from their
  dashboard for one-click tipping.


