### PR TITLE
perf: Add caching layer for contract queries

### DIFF
--- a/frontend-scaffold/src/hooks/useContract.ts
+++ b/frontend-scaffold/src/hooks/useContract.ts
@@ -29,6 +29,7 @@ import {
 } from "../types/contract";
 import { ProfileFormData } from "../types/profile";
 import { xlmToStroop } from "../helpers/format";
+import { contractQueryCache, buildContractCacheKey } from "../services/cache";
 
 /**
  * Valid Stellar placeholder address used as the source account for
@@ -37,6 +38,10 @@ import { xlmToStroop } from "../helpers/format";
  */
 const READ_ONLY_SOURCE =
   "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+const PROFILE_TTL_MS = 30_000;
+const LEADERBOARD_TTL_MS = 60_000;
+const PLATFORM_STATS_TTL_MS = 120_000;
 
 /**
  * Safely converts a numeric string to a BigInt.
@@ -84,18 +89,31 @@ export const useContract = () => {
 
   const getProfile = useCallback(
     async (address: string): Promise<Profile> => {
-      const contract = new Contract(contractId);
-      const txBuilder = getSimulationTxBuilder(
+      const key = buildContractCacheKey(
+        "get_profile",
+        networkDetails.network,
+        contractId,
         address,
-        BASE_FEE,
-        networkDetails.networkPassphrase,
       );
-      const tx = txBuilder
-        .addOperation(contract.call("get_profile", accountToScVal(address)))
-        .setTimeout(TimeoutInfinite)
-        .build();
 
-      return simulateTx<Profile>(tx, server);
+      return contractQueryCache.getOrFetch<Profile>(
+        key,
+        PROFILE_TTL_MS,
+        async () => {
+          const contract = new Contract(contractId);
+          const txBuilder = getSimulationTxBuilder(
+            address,
+            BASE_FEE,
+            networkDetails.networkPassphrase,
+          );
+          const tx = txBuilder
+            .addOperation(contract.call("get_profile", accountToScVal(address)))
+            .setTimeout(TimeoutInfinite)
+            .build();
+
+          return simulateTx<Profile>(tx, server);
+        },
+      );
     },
     [contractId, server, networkDetails],
   );
@@ -129,30 +147,43 @@ export const useContract = () => {
 
   const getLeaderboard = useCallback(
     async (limit: number): Promise<LeaderboardEntry[]> => {
-      const contract = new Contract(contractId);
-      const txBuilder = wallet.publicKey
-        ? await getTxBuilder(
-            wallet.publicKey,
-            BASE_FEE,
-            server,
-            networkDetails.networkPassphrase,
-          )
-        : getSimulationTxBuilder(
-            READ_ONLY_SOURCE,
-            BASE_FEE,
-            networkDetails.networkPassphrase,
-          );
-      const tx = txBuilder
-        .addOperation(
-          contract.call(
-            "get_leaderboard",
-            nativeToScVal(limit, { type: "u32" }),
-          ),
-        )
-        .setTimeout(TimeoutInfinite)
-        .build();
+      const key = buildContractCacheKey(
+        "get_leaderboard",
+        networkDetails.network,
+        contractId,
+        limit,
+      );
 
-      return simulateTx<LeaderboardEntry[]>(tx, server);
+      return contractQueryCache.getOrFetch<LeaderboardEntry[]>(
+        key,
+        LEADERBOARD_TTL_MS,
+        async () => {
+          const contract = new Contract(contractId);
+          const txBuilder = wallet.publicKey
+            ? await getTxBuilder(
+                wallet.publicKey,
+                BASE_FEE,
+                server,
+                networkDetails.networkPassphrase,
+              )
+            : getSimulationTxBuilder(
+                READ_ONLY_SOURCE,
+                BASE_FEE,
+                networkDetails.networkPassphrase,
+              );
+          const tx = txBuilder
+            .addOperation(
+              contract.call(
+                "get_leaderboard",
+                nativeToScVal(limit, { type: "u32" }),
+              ),
+            )
+            .setTimeout(TimeoutInfinite)
+            .build();
+
+          return simulateTx<LeaderboardEntry[]>(tx, server);
+        },
+      );
     },
     [contractId, wallet.publicKey, server, networkDetails],
   );
@@ -161,25 +192,37 @@ export const useContract = () => {
     if (!contractId) {
       throw new Error("Contract ID is not configured");
     }
-    const contract = new Contract(contractId);
-    const txBuilder = wallet.publicKey
-      ? await getTxBuilder(
-          wallet.publicKey,
-          BASE_FEE,
-          server,
-          networkDetails.networkPassphrase,
-        )
-      : getSimulationTxBuilder(
-          READ_ONLY_SOURCE,
-          BASE_FEE,
-          networkDetails.networkPassphrase,
-        );
-    const tx = txBuilder
-      .addOperation(contract.call("get_stats"))
-      .setTimeout(TimeoutInfinite)
-      .build();
+    const key = buildContractCacheKey(
+      "get_stats",
+      networkDetails.network,
+      contractId,
+    );
 
-    return simulateTx<ContractStats>(tx, server);
+    return contractQueryCache.getOrFetch<ContractStats>(
+      key,
+      PLATFORM_STATS_TTL_MS,
+      async () => {
+        const contract = new Contract(contractId);
+        const txBuilder = wallet.publicKey
+          ? await getTxBuilder(
+              wallet.publicKey,
+              BASE_FEE,
+              server,
+              networkDetails.networkPassphrase,
+            )
+          : getSimulationTxBuilder(
+              READ_ONLY_SOURCE,
+              BASE_FEE,
+              networkDetails.networkPassphrase,
+            );
+        const tx = txBuilder
+          .addOperation(contract.call("get_stats"))
+          .setTimeout(TimeoutInfinite)
+          .build();
+
+        return simulateTx<ContractStats>(tx, server);
+      },
+    );
   }, [contractId, wallet.publicKey, server, networkDetails]);
 
   const getMinTipAmount = useCallback(async (): Promise<string> => {
@@ -374,7 +417,13 @@ export const useContract = () => {
 
       const xdr = tx.toXDR();
       const signedXdr = await wallet.signTransaction(xdr);
-      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+      const txHash = await submitTx(
+        signedXdr,
+        networkDetails.networkPassphrase,
+        server,
+      );
+      contractQueryCache.invalidateAll();
+      return txHash;
     },
     [contractId, wallet, server, networkDetails],
   );
@@ -416,7 +465,13 @@ export const useContract = () => {
 
       const xdr_tx = tx.toXDR();
       const signedXdr = await wallet.signTransaction(xdr_tx);
-      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+      const txHash = await submitTx(
+        signedXdr,
+        networkDetails.networkPassphrase,
+        server,
+      );
+      contractQueryCache.invalidateAll();
+      return txHash;
     },
     [contractId, wallet, server, networkDetails],
   );
@@ -455,7 +510,13 @@ export const useContract = () => {
 
       const xdr = tx.toXDR();
       const signedXdr = await wallet.signTransaction(xdr);
-      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+      const txHash = await submitTx(
+        signedXdr,
+        networkDetails.networkPassphrase,
+        server,
+      );
+      contractQueryCache.invalidateAll();
+      return txHash;
     },
     [contractId, wallet, server, networkDetails],
   );
@@ -488,7 +549,13 @@ export const useContract = () => {
 
       const xdr = tx.toXDR();
       const signedXdr = await wallet.signTransaction(xdr);
-      return submitTx(signedXdr, networkDetails.networkPassphrase, server);
+      const txHash = await submitTx(
+        signedXdr,
+        networkDetails.networkPassphrase,
+        server,
+      );
+      contractQueryCache.invalidateAll();
+      return txHash;
     },
     [contractId, wallet, server, networkDetails],
   );

--- a/frontend-scaffold/src/services/__tests__/cache.test.ts
+++ b/frontend-scaffold/src/services/__tests__/cache.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildContractCacheKey, ContractQueryCache } from '../cache';
+
+describe('Contract query cache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns cached result on repeated query', async () => {
+    const cache = new ContractQueryCache();
+    const fetcher = vi.fn(async () => ({ username: 'alice' }));
+    const key = buildContractCacheKey('get_profile', 'TESTNET', 'contract-1', 'GA...');
+
+    await cache.getOrFetch(key, 30_000, fetcher);
+    await cache.getOrFetch(key, 30_000, fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates on write', async () => {
+    const cache = new ContractQueryCache();
+    const fetcher = vi.fn(async () => ({ username: 'alice' }));
+    const key = buildContractCacheKey('get_profile', 'TESTNET', 'contract-1', 'GA...');
+
+    await cache.getOrFetch(key, 30_000, fetcher);
+    cache.invalidateAll();
+    await cache.getOrFetch(key, 30_000, fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes stale entries in background', async () => {
+    const cache = new ContractQueryCache();
+    const fetcher = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('v1')
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve('v2'), 50);
+          }),
+      );
+    const key = buildContractCacheKey('get_profile', 'TESTNET', 'contract-1', 'GA...');
+
+    const initial = await cache.getOrFetch(key, 30_000, fetcher);
+    expect(initial).toBe('v1');
+
+    vi.advanceTimersByTime(31_000);
+
+    const staleResult = await cache.getOrFetch(key, 30_000, fetcher);
+    expect(staleResult).toBe('v1');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(50);
+    await vi.runAllTimersAsync();
+
+    const refreshed = await cache.getOrFetch(key, 30_000, fetcher);
+    expect(refreshed).toBe('v2');
+  });
+
+  it('enforces max cache size', async () => {
+    const cache = new ContractQueryCache(2);
+
+    await cache.getOrFetch(buildContractCacheKey('get_profile', 'a'), 30_000, async () => 'a');
+    vi.advanceTimersByTime(1);
+    await cache.getOrFetch(buildContractCacheKey('get_profile', 'b'), 30_000, async () => 'b');
+    vi.advanceTimersByTime(1);
+    await cache.getOrFetch(buildContractCacheKey('get_profile', 'c'), 30_000, async () => 'c');
+
+    expect(cache.size()).toBe(2);
+  });
+});

--- a/frontend-scaffold/src/services/cache.ts
+++ b/frontend-scaffold/src/services/cache.ts
@@ -1,0 +1,114 @@
+export type CacheKeyPart = string | number | boolean | null | undefined;
+
+export type CacheEntry<T> = {
+  data: T;
+  expiresAt: number;
+  inFlightRefresh?: Promise<T>;
+  lastUpdatedAt: number;
+};
+
+const DEFAULT_MAX_CACHE_SIZE = 200;
+
+export class ContractQueryCache {
+  private readonly cache = new Map<string, CacheEntry<unknown>>();
+
+  constructor(private readonly maxSize: number = DEFAULT_MAX_CACHE_SIZE) {}
+
+  async getOrFetch<T>(
+    key: string,
+    ttlMs: number,
+    fetcher: () => Promise<T>,
+  ): Promise<T> {
+    const now = Date.now();
+    const cached = this.cache.get(key) as CacheEntry<T> | undefined;
+
+    if (cached) {
+      if (cached.expiresAt > now) {
+        return cached.data;
+      }
+
+      // Stale-while-revalidate:
+      // return stale data instantly and refresh in the background.
+      if (!cached.inFlightRefresh) {
+        cached.inFlightRefresh = this.refreshEntry(key, ttlMs, fetcher, cached);
+      }
+
+      return cached.data;
+    }
+
+    const freshValue = await fetcher();
+    this.set(key, {
+      data: freshValue,
+      expiresAt: now + ttlMs,
+      lastUpdatedAt: now,
+    });
+    return freshValue;
+  }
+
+  invalidateAll(): void {
+    this.cache.clear();
+  }
+
+  size(): number {
+    return this.cache.size;
+  }
+
+  private async refreshEntry<T>(
+    key: string,
+    ttlMs: number,
+    fetcher: () => Promise<T>,
+    staleEntry: CacheEntry<T>,
+  ): Promise<T> {
+    try {
+      const refreshed = await fetcher();
+      const now = Date.now();
+      this.set(key, {
+        data: refreshed,
+        expiresAt: now + ttlMs,
+        lastUpdatedAt: now,
+      });
+      return refreshed;
+    } catch (error) {
+      // Keep stale value if background refresh fails.
+      staleEntry.inFlightRefresh = undefined;
+      throw error;
+    } finally {
+      const latest = this.cache.get(key) as CacheEntry<T> | undefined;
+      if (latest) {
+        latest.inFlightRefresh = undefined;
+      }
+    }
+  }
+
+  private set<T>(key: string, entry: CacheEntry<T>): void {
+    this.cache.set(key, entry as CacheEntry<unknown>);
+    this.enforceMaxSize();
+  }
+
+  private enforceMaxSize(): void {
+    if (this.cache.size <= this.maxSize) {
+      return;
+    }
+
+    const sortedByOldest = [...this.cache.entries()].sort(
+      (a, b) => a[1].lastUpdatedAt - b[1].lastUpdatedAt,
+    );
+
+    while (this.cache.size > this.maxSize && sortedByOldest.length > 0) {
+      const oldest = sortedByOldest.shift();
+      if (!oldest) {
+        break;
+      }
+      this.cache.delete(oldest[0]);
+    }
+  }
+}
+
+export const buildContractCacheKey = (
+  method: string,
+  ...params: CacheKeyPart[]
+): string => {
+  return JSON.stringify([method, ...params]);
+};
+
+export const contractQueryCache = new ContractQueryCache();

--- a/frontend-scaffold/src/services/index.ts
+++ b/frontend-scaffold/src/services/index.ts
@@ -2,4 +2,5 @@ export * from './soroban';
 export * from './stellar';
 export * from './logger';
 export * from './eventStream';
+export * from './cache';
 export * as serviceWorker from './serviceWorker';


### PR DESCRIPTION
## Description
Description
Add frontend-scaffold/src/services/cache.ts which implements ContractQueryCache with per-key TTLs, stale-while-revalidate background refresh, max-size eviction, invalidateAll(), and buildContractCacheKey for deterministic keys.

Wire the cache into useContract to cache getProfile (30s), getLeaderboard (60s), and getStats (120s) with cache keys that include method, network, contract id, and parameters.

Invalidate the contract query cache after successful write operations by calling contractQueryCache.invalidateAll() from registerProfile, updateProfile, sendTip, and withdrawTips to prevent stale reads.

Export the cache from services/index.ts and add focused unit tests at frontend-scaffold/src/services/__tests__/cache.test.ts covering hits, invalidation, SWR refresh, and max-size enforcement.

<!-- Brief description of what this PR does -->

Closes #503 <!-- issue number -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)

## Changes Made

<!-- List the specific changes -->

- 
- 
- 

## How to Test
Ran npm test -- src/services/__tests__/cache.test.ts and the new test file passed (4 tests run and passed).

Ran npm run typecheck which failed due to pre-existing unrelated TypeScript errors in the repository and not caused by these changes.

Unit tests exercise cached read hits, background refresh of stale entries, explicit invalidation behavior, and eviction when max cache size is exceeded.

<!-- Steps to verify the changes -->

1. 
2. 
3. 

## Checklist

### Contract Changes
- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (all tests)
- [ ] New tests written for new functionality
- [ ] No hardcoded values that should be configurable

### Frontend Changes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] Tested in browser with Freighter wallet
- [ ] Responsive design verified

### General
- [ ] Code follows project conventions
- [ ] Self-reviewed my own code
- [ ] No `console.log` or debug code left in
- [ ] Branch is up to date with `main`

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
