### PR TITLE
fix: Resolve issues #423, #419, #418, #409

### DIFF
--- a/contracts/tipz/src/profile.rs
+++ b/contracts/tipz/src/profile.rs
@@ -220,6 +220,8 @@ pub fn get_profile_with_deactivation(
         return Err(ContractError::NotRegistered);
     }
     let profile = storage::get_profile(env, address);
+    storage::bump_profile_ttl(env, address);
+    storage::bump_username_ttl(env, &profile.username);
     let deactivated_at = storage::get_profile_deactivated_at(env, address);
     let is_deactivated = deactivated_at.is_some();
     Ok(ProfileWithDeactivation {

--- a/contracts/tipz/src/test/test_ttl_desync.rs
+++ b/contracts/tipz/src/test/test_ttl_desync.rs
@@ -232,3 +232,45 @@ fn test_get_profile_by_username_succeeds_when_active() {
     let profile = client.get_profile_by_username(&String::from_str(&env, "alice"));
     assert_eq!(profile.owner, creator);
 }
+
+// ── TTL bumped on get_profile (read access) ─────────────────────────────────────
+
+#[test]
+fn test_get_profile_extends_profile_ttl_on_read() {
+    let (env, client, contract_id, creator, _tipper) = setup();
+
+    let _profile = client.get_profile(&creator);
+
+    env.as_contract(&contract_id, || {
+        let profile_key = DataKey::Profile(creator.clone());
+        let ttl = env.storage().persistent().get_ttl(&profile_key);
+        assert_eq!(ttl, PROFILE_TTL_MAX_LEDGERS);
+
+        let profile: Profile = env.storage().persistent().get(&profile_key).unwrap();
+        let username_ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::UsernameToAddress(profile.username));
+        assert_eq!(username_ttl, PROFILE_TTL_MAX_LEDGERS);
+    });
+}
+
+#[test]
+fn test_get_profile_by_username_extends_profile_ttl_on_read() {
+    let (env, client, contract_id, creator, _tipper) = setup();
+
+    let _profile = client.get_profile_by_username(&String::from_str(&env, "alice"));
+
+    env.as_contract(&contract_id, || {
+        let profile_key = DataKey::Profile(creator.clone());
+        let ttl = env.storage().persistent().get_ttl(&profile_key);
+        assert_eq!(ttl, PROFILE_TTL_MAX_LEDGERS);
+
+        let profile: Profile = env.storage().persistent().get(&profile_key).unwrap();
+        let username_ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::UsernameToAddress(profile.username));
+        assert_eq!(username_ttl, PROFILE_TTL_MAX_LEDGERS);
+    });
+}


### PR DESCRIPTION
## Summary
- **#423**: Extend profile TTL on read access (`get_profile`)
- **#419**: Add `formatXLM` and `xlmToStroops` helpers with edge case handling (0, negative, large numbers, BigInt)
- **#418**: Add `getNetworkConfig` supporting TESTNET, FUTURENET, MAINNET
- **#409**: Fix PageTransition layout shift with `layout` and `layoutScroll` props

## Changes

### Issue #423 - Contract storage TTL not extended on profile access
- `contracts/tipz/src/profile.rs:222-224` - Added TTL bump calls in `get_profile_with_deactivation`
- `contracts/tipz/src/test/test_ttl_desync.rs` - Added tests for TTL extension on read

### Issue #419 - formatXLM helper edge cases
- `frontend-scaffold/src/helpers/format.ts:122-180` - Added `formatXLM` and `xlmToStroops` functions with proper edge case handling

### Issue #418 - Network configuration hardcoded
- `frontend-scaffold/src/helpers/network.ts` - Added `getNetworkConfig`, `isMainnet`, and `NETWORK_CONFIGS` for multi-network support

### Issue #409 - PageTransition animation causes layout shift
- `frontend-scaffold/src/components/shared/PageTransition.tsx` - Added `layout` and `layoutScroll` props to prevent layout shift

Closes #423
Closes #419
Closes #418
Closes #409