### PR TITLE
test: comprehensive coverage for credit, lifecycle, UI, and useWallet

### DIFF
--- a/contracts/tipz/src/test/mod.rs
+++ b/contracts/tipz/src/test/mod.rs
@@ -4,6 +4,8 @@ mod test_admin;
 mod test_credit;
 mod test_events;
 mod test_init;
+mod test_integration;
+mod test_integration_advanced;
 mod test_leaderboard;
 mod test_profile_query;
 mod test_profiles;

--- a/contracts/tipz/src/test/test_credit.rs
+++ b/contracts/tipz/src/test/test_credit.rs
@@ -469,3 +469,253 @@ fn test_credit_score_integer_arithmetic() {
         "Even with max values, score should be capped at 100"
     );
 }
+
+// ── Issue #473: extended coverage ─────────────────────────────────────────────
+//
+// The tests below complete the coverage required by issue #473:
+// - snapshot-style regression table covering every score factor combination
+// - pseudo-property tests asserting invariants over many enumerated inputs
+// - monotonicity guarantees (more tips/followers/age never lowers the score)
+// - tier-transition walk across all 5 tiers
+// - documents that the contract does not track unique tippers (handled by the
+//   on-chain leaderboard, not the credit score)
+
+/// Snapshot-style regression table.  Each row pins the expected score for a
+/// specific combination of inputs so accidental changes to the formula are
+/// caught immediately.  Numbers reflect the formula in `credit.rs`:
+///
+/// `score = 40 + tip_sub*20/100 + x_sub*30/100 + age_sub*10/100`, capped at 100.
+#[test]
+fn snapshot_score_regression_table() {
+    let env = Env::default();
+
+    struct Row {
+        label: &'static str,
+        tips_stroops: i128,
+        x_followers: u32,
+        x_engagement: u32,
+        age_days: u64,
+        expected: u32,
+    }
+
+    let rows = [
+        Row { label: "fresh profile", tips_stroops: 0, x_followers: 0, x_engagement: 0, age_days: 0, expected: 40 },
+        Row { label: "10 XLM tips only", tips_stroops: 100_000_000, x_followers: 0, x_engagement: 0, age_days: 0, expected: 42 },
+        Row { label: "50 XLM tips only", tips_stroops: 500_000_000, x_followers: 0, x_engagement: 0, age_days: 0, expected: 50 },
+        Row { label: "100 XLM tips only", tips_stroops: 1_000_000_000, x_followers: 0, x_engagement: 0, age_days: 0, expected: 60 },
+        Row { label: "max followers, no engagement", tips_stroops: 0, x_followers: 2_500, x_engagement: 0, age_days: 0, expected: 55 },
+        Row { label: "max engagement, no followers", tips_stroops: 0, x_followers: 0, x_engagement: 500, age_days: 0, expected: 55 },
+        Row { label: "max X metrics", tips_stroops: 0, x_followers: 2_500, x_engagement: 500, age_days: 0, expected: 70 },
+        Row { label: "100-day-old account", tips_stroops: 0, x_followers: 0, x_engagement: 0, age_days: 100, expected: 41 },
+        Row { label: "1000-day-old account", tips_stroops: 0, x_followers: 0, x_engagement: 0, age_days: 1000, expected: 50 },
+        Row { label: "all max → cap 100", tips_stroops: 1_000_000_000, x_followers: 2_500, x_engagement: 500, age_days: 1000, expected: 100 },
+    ];
+
+    for row in rows {
+        let now = 86_400_u64 * row.age_days;
+        let mut profile = blank_profile(&env, now);
+        profile.registered_at = 0;
+        profile.total_tips_received = row.tips_stroops;
+        profile.x_followers = row.x_followers;
+        profile.x_engagement_avg = row.x_engagement;
+
+        let score = calculate_credit_score(&profile, now);
+        assert_eq!(
+            score, row.expected,
+            "snapshot mismatch for '{}': got {}, expected {}",
+            row.label, score, row.expected
+        );
+    }
+}
+
+/// Walk through every tier boundary in order.  Acts as a single-test
+/// regression for the tier mapping table.
+#[test]
+fn tier_transition_walk_new_to_diamond() {
+    let walk: [(u32, CreditTier); 10] = [
+        (0, CreditTier::New),
+        (19, CreditTier::New),
+        (20, CreditTier::Bronze),
+        (39, CreditTier::Bronze),
+        (40, CreditTier::Silver),
+        (59, CreditTier::Silver),
+        (60, CreditTier::Gold),
+        (79, CreditTier::Gold),
+        (80, CreditTier::Diamond),
+        (100, CreditTier::Diamond),
+    ];
+    for (score, expected_tier) in walk {
+        assert_eq!(
+            get_tier(score),
+            expected_tier,
+            "tier mismatch at score {score}"
+        );
+    }
+}
+
+/// Property: the score is **monotonic non-decreasing** in tip volume.
+/// Sweeping tip volume in 10 XLM steps must never produce a lower score.
+#[test]
+fn property_score_is_monotonic_in_tip_volume() {
+    let env = Env::default();
+    let now = env.ledger().timestamp();
+    let mut last_score = 0_u32;
+
+    // 0 → 200 XLM in 10 XLM steps; the cap kicks in at 100 XLM.
+    for xlm in (0..=200).step_by(10) {
+        let mut profile = blank_profile(&env, now);
+        profile.total_tips_received = (xlm as i128) * 10_000_000;
+        let score = calculate_credit_score(&profile, now);
+        assert!(
+            score >= last_score,
+            "score decreased: {xlm} XLM → {score} (was {last_score})"
+        );
+        last_score = score;
+    }
+}
+
+/// Property: the score is **monotonic non-decreasing** in account age.
+/// More-aged profiles never receive a lower score from the age component alone.
+#[test]
+fn property_score_is_monotonic_in_account_age() {
+    let env = Env::default();
+    let registered_at = 0_u64;
+    let mut last_score = 0_u32;
+
+    // Walk age from 0 to 2000 days in 50-day steps.
+    for days in (0..=2000).step_by(50) {
+        let now = days as u64 * 86_400;
+        let mut profile = blank_profile(&env, now);
+        profile.registered_at = registered_at;
+        let score = calculate_credit_score(&profile, now);
+        assert!(
+            score >= last_score,
+            "score decreased at {days} days: {score} (was {last_score})"
+        );
+        last_score = score;
+    }
+}
+
+/// Property: regardless of inputs, the returned score is always within `[0, 100]`.
+/// Enumerates a wide grid of values rather than relying on a single sample.
+#[test]
+fn property_score_always_in_zero_to_hundred_range() {
+    let env = Env::default();
+
+    let tip_samples: [i128; 6] = [0, 1, 50_000_000, 1_000_000_000, 100_000_000_000, i128::MAX];
+    let follower_samples: [u32; 5] = [0, 100, 2_500, 10_000, u32::MAX];
+    let engagement_samples: [u32; 5] = [0, 50, 500, 5_000, u32::MAX];
+    let age_samples: [u64; 5] = [0, 86_399, 86_400, 86_400 * 100, 86_400 * 10_000];
+
+    for &tips in &tip_samples {
+        for &followers in &follower_samples {
+            for &engagement in &engagement_samples {
+                for &now in &age_samples {
+                    let mut profile = blank_profile(&env, now);
+                    profile.registered_at = 0;
+                    profile.total_tips_received = tips;
+                    profile.x_followers = followers;
+                    profile.x_engagement_avg = engagement;
+
+                    let score = calculate_credit_score(&profile, now);
+                    // Score is u32 so >= 0 is structural; the meaningful bound is the cap.
+                    assert!(
+                        score <= 100,
+                        "score {score} out of range for tips={tips}, followers={followers}, engagement={engagement}, now={now}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Property: the tier returned by `get_credit_tier` always matches what
+/// `get_tier(score)` would return for the same score.  Tier and score must
+/// never disagree across a representative sample of profiles.
+#[test]
+fn property_tier_matches_get_tier_of_score() {
+    let env = Env::default();
+    let contract_id = register_contract(&env);
+
+    let cases = [
+        (0_i128, 0_u32, 0_u32, 0_u64),                              // Silver (40)
+        (500_000_000, 0, 0, 0),                                     // Silver (50)
+        (1_000_000_000, 2_500, 500, 86_400 * 1000),                 // Diamond (100)
+        (0, 2_500, 500, 0),                                         // Gold (70)
+        (0, 0, 100, 0),                                             // Silver (43)
+    ];
+
+    env.as_contract(&contract_id, || {
+        for (i, (tips, followers, engagement, now)) in cases.into_iter().enumerate() {
+            let address = Address::generate(&env);
+            let mut profile = blank_profile(&env, now);
+            profile.registered_at = 0;
+            profile.total_tips_received = tips;
+            profile.x_followers = followers;
+            profile.x_engagement_avg = engagement;
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Profile(address.clone()), &profile);
+
+            let (score, tier) = get_credit_tier(&env, &address).expect("profile should exist");
+            assert_eq!(
+                tier,
+                get_tier(score),
+                "case {i}: returned tier {tier:?} disagrees with get_tier({score}) = {:?}",
+                get_tier(score)
+            );
+        }
+    });
+}
+
+/// Negative `total_tips_received` (defensive — should never appear in real
+/// data) is clamped to 0 inside `calculate_credit_score`, so the tip
+/// component contributes nothing.
+#[test]
+fn negative_tip_balance_is_clamped_to_zero() {
+    let env = Env::default();
+    let now = env.ledger().timestamp();
+    let mut profile = blank_profile(&env, now);
+    profile.total_tips_received = -1_000_000_000;
+
+    // Negative is clamped → tip component = 0 → only base applies.
+    assert_eq!(calculate_credit_score(&profile, now), BASE_SCORE);
+}
+
+/// `now` strictly less than `registered_at` (clock skew / replayed ledger)
+/// must not panic and must produce age component = 0.
+#[test]
+fn now_before_registered_at_returns_base_score() {
+    let env = Env::default();
+    let mut profile = blank_profile(&env, 1_000);
+    profile.registered_at = 5_000;
+
+    let score = calculate_credit_score(&profile, 1_000);
+    assert_eq!(score, BASE_SCORE);
+}
+
+/// Documents the design choice: the credit score does **not** weight unique
+/// tippers — that signal is captured by the on-chain leaderboard, not the
+/// score formula.  Two profiles with identical tip volume must score
+/// identically regardless of how many unique tippers contributed.
+///
+/// This test exists so a future refactor that adds a `unique_tippers` field
+/// to `Profile` is forced to update the credit module *and* its tests
+/// together.
+#[test]
+fn unique_tippers_does_not_affect_score_today() {
+    let env = Env::default();
+    let now = env.ledger().timestamp();
+
+    // Both profiles received the same total volume.
+    let mut a = blank_profile(&env, now);
+    a.total_tips_received = 500_000_000;
+    let mut b = blank_profile(&env, now);
+    b.total_tips_received = 500_000_000;
+
+    assert_eq!(
+        calculate_credit_score(&a, now),
+        calculate_credit_score(&b, now)
+    );
+}

--- a/contracts/tipz/src/test/test_integration.rs
+++ b/contracts/tipz/src/test/test_integration.rs
@@ -1,0 +1,335 @@
+//! End-to-end integration tests (issue #474).
+//!
+//! Exercises the complete creator lifecycle as it would unfold in production:
+//!
+//!   register_profile → send_tip → calculate_credit_score → leaderboard
+//!     → withdraw_tips → balance assertions
+//!
+//! Tests in this file go through the *public* contract entrypoints and the
+//! Stellar Asset Contract (SAC) for native XLM.  They intentionally avoid
+//! reaching into storage directly so a regression in any single layer is
+//! caught even if the rest of the chain still produces plausible results.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
+
+use crate::storage::{self, DataKey};
+use crate::types::{Profile, Tip};
+use crate::TipzContract;
+use crate::TipzContractClient;
+
+// ── shared setup ──────────────────────────────────────────────────────────────
+
+struct LifecycleCtx<'a> {
+    env: Env,
+    client: TipzContractClient<'a>,
+    contract_id: Address,
+    fee_collector: Address,
+    sac: Address,
+    token_admin_client: token::StellarAssetClient<'a>,
+}
+
+/// Initialise the contract with a 2 % withdrawal fee and a Stellar Asset
+/// Contract for native XLM.  Returns the context shared by every test.
+fn ctx(fee_bps: u32) -> LifecycleCtx<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipzContract);
+    let client = TipzContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+    let sac = token_contract.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &sac);
+
+    let admin = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+    client.initialize(&admin, &fee_collector, &fee_bps, &sac);
+
+    LifecycleCtx {
+        env,
+        client,
+        contract_id,
+        fee_collector,
+        sac,
+        token_admin_client,
+    }
+}
+
+/// Register a creator through the *public* `register_profile` entrypoint
+/// (not direct storage writes) so the registration path is exercised.
+fn register_creator(c: &LifecycleCtx, username: &str) -> Address {
+    let creator = Address::generate(&c.env);
+    c.client.register_profile(
+        &creator,
+        &String::from_str(&c.env, username),
+        &String::from_str(&c.env, "Display Name"),
+        &String::from_str(&c.env, ""),
+        &String::from_str(&c.env, ""),
+        &String::from_str(&c.env, ""),
+    );
+    creator
+}
+
+/// Mint XLM to a fresh address and return it (a tipper with funds).
+fn fund_tipper(c: &LifecycleCtx, balance_stroops: i128) -> Address {
+    let tipper = Address::generate(&c.env);
+    c.token_admin_client.mint(&tipper, &balance_stroops);
+    tipper
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// The headline scenario from the issue: a creator registers, receives a tip,
+/// has their credit score recomputed, appears on the leaderboard, withdraws
+/// their balance, and ends up with the expected XLM in their wallet.
+#[test]
+fn lifecycle_register_tip_score_leaderboard_withdraw() {
+    let c = ctx(200); // 2 % fee
+    let creator = register_creator(&c, "alice");
+    let tipper = fund_tipper(&c, 100_000_000_000);
+
+    let token_client = token::TokenClient::new(&c.env, &c.sac);
+
+    // ── 1. baseline ────────────────────────────────────────────────────────
+    let creator_xlm_before = token_client.balance(&creator);
+    let collector_xlm_before = token_client.balance(&c.fee_collector);
+    assert_eq!(creator_xlm_before, 0, "creator wallet starts empty");
+
+    // ── 2. tip 50 XLM ──────────────────────────────────────────────────────
+    let tip_amount: i128 = 500_000_000;
+    c.client
+        .send_tip(&tipper, &creator, &tip_amount, &String::from_str(&c.env, "great"));
+
+    // Creator's profile balance updates.
+    let profile = c.client.get_profile(&creator);
+    assert_eq!(profile.balance, tip_amount);
+    assert_eq!(profile.total_tips_received, tip_amount);
+    assert_eq!(profile.total_tips_count, 1);
+
+    // ── 3. credit score recomputed ────────────────────────────────────────
+    // 50 XLM → tip_sub=50 → tip_pts=10 → score = BASE(40) + 10 = 50.
+    let score = c.client.calculate_credit_score(&creator);
+    assert_eq!(score, 50, "credit score must reflect tip volume");
+
+    // ── 4. leaderboard contains the creator ────────────────────────────────
+    let board = c.client.get_leaderboard(&10);
+    assert_eq!(board.len(), 1, "single tipped creator → 1-entry leaderboard");
+    assert_eq!(board.get(0).unwrap().address, creator);
+    assert_eq!(board.get(0).unwrap().total_tips_received, tip_amount);
+
+    let rank = c.client.get_leaderboard_rank(&creator);
+    assert_eq!(rank, Some(1), "only creator → rank 1");
+
+    // ── 5. withdraw the entire balance ─────────────────────────────────────
+    c.client.withdraw_tips(&creator, &tip_amount);
+
+    // 2 % fee = 10_000_000, net = 490_000_000.
+    let expected_fee = tip_amount * 200 / 10_000;
+    let expected_net = tip_amount - expected_fee;
+    assert_eq!(token_client.balance(&creator), creator_xlm_before + expected_net);
+    assert_eq!(
+        token_client.balance(&c.fee_collector),
+        collector_xlm_before + expected_fee
+    );
+
+    // ── 6. balance zeroed; credit score & lifetime totals preserved ───────
+    let profile_after = c.client.get_profile(&creator);
+    assert_eq!(profile_after.balance, 0, "balance zeroed after full withdraw");
+    assert_eq!(
+        profile_after.total_tips_received, tip_amount,
+        "lifetime total preserved across withdraws"
+    );
+    assert_eq!(profile_after.credit_score, 50, "credit score preserved");
+
+    // Re-querying the score after withdraw returns the same value — proves
+    // that withdrawals do not depress the credit signal.
+    assert_eq!(c.client.calculate_credit_score(&creator), 50);
+}
+
+/// A tip record is created in temporary storage and surfaces through the
+/// `get_tip` and `get_recent_tips` query endpoints.  Verifies the tip
+/// pipeline end-to-end.
+#[test]
+fn tip_records_are_queryable_after_send() {
+    let c = ctx(200);
+    let creator = register_creator(&c, "alice");
+    let tipper = fund_tipper(&c, 1_000_000_000);
+
+    c.client.send_tip(
+        &tipper,
+        &creator,
+        &10_000_000,
+        &String::from_str(&c.env, "first"),
+    );
+    c.client.send_tip(
+        &tipper,
+        &creator,
+        &20_000_000,
+        &String::from_str(&c.env, "second"),
+    );
+
+    let recent = c.client.get_recent_tips(&creator, &10);
+    assert_eq!(recent.len(), 2, "both tips returned");
+
+    // Direct lookup by ID still works.
+    let tip0 = c.client.get_tip(&0);
+    assert_eq!(tip0.tipper, tipper);
+    assert_eq!(tip0.creator, creator);
+    assert_eq!(tip0.amount, 10_000_000);
+
+    // Sanity check raw storage matches the public query.
+    c.env.as_contract(&c.contract_id, || {
+        let tip: Tip = c
+            .env
+            .storage()
+            .temporary()
+            .get(&DataKey::Tip(0))
+            .expect("tip stored");
+        assert_eq!(tip.message, String::from_str(&c.env, "first"));
+    });
+}
+
+/// Global stats reflect the full lifecycle: tip count and total volume
+/// increase on every tip, fee total grows on every withdrawal.
+#[test]
+fn global_stats_track_full_lifecycle() {
+    let c = ctx(200);
+    let creator = register_creator(&c, "alice");
+    let tipper = fund_tipper(&c, 10_000_000_000);
+
+    let stats0 = c.client.get_stats();
+    assert_eq!(stats0.total_tips_count, 0);
+    assert_eq!(stats0.total_tips_volume, 0);
+    assert_eq!(stats0.total_fees_collected, 0);
+    assert_eq!(stats0.total_creators, 1, "register_creator added one");
+
+    // Two tips totalling 30 XLM.
+    c.client
+        .send_tip(&tipper, &creator, &100_000_000, &String::from_str(&c.env, ""));
+    c.client
+        .send_tip(&tipper, &creator, &200_000_000, &String::from_str(&c.env, ""));
+
+    let stats1 = c.client.get_stats();
+    assert_eq!(stats1.total_tips_count, 2);
+    assert_eq!(stats1.total_tips_volume, 300_000_000);
+    assert_eq!(stats1.total_fees_collected, 0, "fees only on withdraw");
+
+    // Withdraw 30 XLM (300_000_000 stroops) at 2 % → fee = 6_000_000 stroops.
+    c.client.withdraw_tips(&creator, &300_000_000);
+    let stats2 = c.client.get_stats();
+    assert_eq!(stats2.total_fees_collected, 6_000_000);
+}
+
+/// After withdrawing, the credit score recomputed from the persisted profile
+/// stays the same — the tipping signal is *cumulative* and not sensitive to
+/// the wallet's current balance.
+#[test]
+fn credit_score_survives_full_withdraw() {
+    let c = ctx(0); // zero fee → simpler assertions
+    let creator = register_creator(&c, "alice");
+    let tipper = fund_tipper(&c, 10_000_000_000);
+
+    c.client.send_tip(
+        &tipper,
+        &creator,
+        &500_000_000,
+        &String::from_str(&c.env, ""),
+    );
+    let score_before = c.client.calculate_credit_score(&creator);
+
+    c.client.withdraw_tips(&creator, &500_000_000);
+
+    let score_after = c.client.calculate_credit_score(&creator);
+    assert_eq!(score_after, score_before);
+}
+
+/// The leaderboard correctly mirrors the lifetime total, not the current
+/// balance: a creator who has fully withdrawn must still appear with their
+/// full historical volume.
+#[test]
+fn leaderboard_uses_lifetime_total_after_withdraw() {
+    let c = ctx(200);
+    let creator = register_creator(&c, "alice");
+    let tipper = fund_tipper(&c, 10_000_000_000);
+
+    c.client
+        .send_tip(&tipper, &creator, &500_000_000, &String::from_str(&c.env, ""));
+    c.client.withdraw_tips(&creator, &500_000_000);
+
+    let board = c.client.get_leaderboard(&10);
+    assert_eq!(board.len(), 1);
+    assert_eq!(board.get(0).unwrap().total_tips_received, 500_000_000);
+}
+
+/// Insufficient balance during withdraw leaves the profile and global stats
+/// untouched — failed withdrawals do not partially mutate state.
+#[test]
+fn failed_withdraw_does_not_mutate_state() {
+    let c = ctx(200);
+    let creator = register_creator(&c, "alice");
+    let tipper = fund_tipper(&c, 10_000_000_000);
+
+    c.client
+        .send_tip(&tipper, &creator, &10_000_000, &String::from_str(&c.env, ""));
+    let stats_before = c.client.get_stats();
+    let profile_before = c.client.get_profile(&creator);
+
+    // Try to withdraw 100 XLM when balance is 1 XLM.
+    let result = c.client.try_withdraw_tips(&creator, &1_000_000_000);
+    assert!(result.is_err());
+
+    let stats_after = c.client.get_stats();
+    let profile_after = c.client.get_profile(&creator);
+    assert_eq!(stats_after.total_fees_collected, stats_before.total_fees_collected);
+    assert_eq!(profile_after.balance, profile_before.balance);
+}
+
+/// Two registered creators can independently complete the full lifecycle
+/// without their state interfering with each other (storage isolation).
+#[test]
+fn two_creators_lifecycles_are_independent() {
+    let c = ctx(200);
+    let alice = register_creator(&c, "alice");
+    let bob = register_creator(&c, "bob");
+    let tipper = fund_tipper(&c, 10_000_000_000);
+
+    // Alice receives 30 XLM, Bob receives 70 XLM.
+    c.client
+        .send_tip(&tipper, &alice, &300_000_000, &String::from_str(&c.env, ""));
+    c.client
+        .send_tip(&tipper, &bob, &700_000_000, &String::from_str(&c.env, ""));
+
+    // Alice withdraws everything; Bob does not.
+    c.client.withdraw_tips(&alice, &300_000_000);
+
+    let alice_p = c.client.get_profile(&alice);
+    let bob_p = c.client.get_profile(&bob);
+
+    assert_eq!(alice_p.balance, 0, "alice withdrew all");
+    assert_eq!(bob_p.balance, 700_000_000, "bob's balance untouched");
+    assert_eq!(alice_p.total_tips_received, 300_000_000);
+    assert_eq!(bob_p.total_tips_received, 700_000_000);
+
+    // Leaderboard reflects lifetime totals: Bob > Alice.
+    let board = c.client.get_leaderboard(&10);
+    assert_eq!(board.len(), 2);
+    assert_eq!(board.get(0).unwrap().address, bob);
+    assert_eq!(board.get(1).unwrap().address, alice);
+}
+
+/// Sanity check that `storage::has_profile` agrees with the public
+/// `get_profile` entrypoint after a successful registration.
+#[test]
+fn registration_visible_through_storage_and_public_api() {
+    let c = ctx(200);
+    let alice = register_creator(&c, "alice");
+
+    assert!(c.client.get_profile(&alice).owner == alice);
+
+    c.env.as_contract(&c.contract_id, || {
+        assert!(storage::has_profile(&c.env, &alice));
+    });
+}

--- a/contracts/tipz/src/test/test_integration_advanced.rs
+++ b/contracts/tipz/src/test/test_integration_advanced.rs
@@ -1,0 +1,284 @@
+//! Advanced multi-actor integration tests (issue #474).
+//!
+//! Stress scenarios that exercise the contract with many creators and tippers
+//! at once.  These tests do not exercise pause/deregister flows because those
+//! features are not implemented in the contract today — see issue #474 for
+//! the broader test plan.
+//!
+//! Coverage:
+//! - 5 creators × 10 tippers — verifies leaderboard ordering, per-profile
+//!   balances, and aggregate stats remain consistent under load.
+//! - Sequential tips from the same tipper to the same creator (the closest
+//!   approximation of "concurrent operations" in a deterministic Soroban
+//!   test environment, which executes transactions sequentially).
+//! - Admin-driven fee changes mid-lifecycle apply to subsequent withdrawals.
+//! - Fee collector address change splits collected fees correctly.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
+
+use crate::TipzContract;
+use crate::TipzContractClient;
+
+// ── shared setup ──────────────────────────────────────────────────────────────
+
+struct Ctx<'a> {
+    env: Env,
+    client: TipzContractClient<'a>,
+    admin: Address,
+    fee_collector: Address,
+    sac: Address,
+    token_admin_client: token::StellarAssetClient<'a>,
+}
+
+fn ctx(fee_bps: u32) -> Ctx<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipzContract);
+    let client = TipzContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+    let sac = token_contract.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &sac);
+
+    let admin = Address::generate(&env);
+    let fee_collector = Address::generate(&env);
+    client.initialize(&admin, &fee_collector, &fee_bps, &sac);
+
+    Ctx {
+        env,
+        client,
+        admin,
+        fee_collector,
+        sac,
+        token_admin_client,
+    }
+}
+
+fn register(c: &Ctx, username: &str) -> Address {
+    let creator = Address::generate(&c.env);
+    c.client.register_profile(
+        &creator,
+        &String::from_str(&c.env, username),
+        &String::from_str(&c.env, "Display"),
+        &String::from_str(&c.env, ""),
+        &String::from_str(&c.env, ""),
+        &String::from_str(&c.env, ""),
+    );
+    creator
+}
+
+fn fund(c: &Ctx, balance: i128) -> Address {
+    let tipper = Address::generate(&c.env);
+    c.token_admin_client.mint(&tipper, &balance);
+    tipper
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// Five creators receiving deterministic amounts from ten tippers each.
+/// Verifies aggregate stats and leaderboard ordering after the cross-product
+/// of tips has been sent.
+#[test]
+fn multi_creator_multi_tipper_consistency() {
+    let c = ctx(0); // zero fee → cleaner balance math
+    let usernames = ["alpha", "bravo", "delta", "echo", "foxtrot"];
+    let mut creators = soroban_sdk::Vec::<Address>::new(&c.env);
+    for u in usernames {
+        creators.push_back(register(&c, u));
+    }
+
+    // Build 10 tippers each funded with 1 000 XLM.
+    let mut tippers = soroban_sdk::Vec::<Address>::new(&c.env);
+    for _ in 0..10u32 {
+        tippers.push_back(fund(&c, 10_000_000_000));
+    }
+
+    // Each tipper sends `(creator_idx + 1) XLM` to each creator.
+    // Per-creator total = 10 * (idx+1) XLM = (idx+1) * 100_000_000 stroops.
+    let msg = String::from_str(&c.env, "");
+    for ci in 0..creators.len() {
+        let creator = creators.get(ci).unwrap();
+        let amount: i128 = (ci as i128 + 1) * 10_000_000;
+        for ti in 0..tippers.len() {
+            let tipper = tippers.get(ti).unwrap();
+            c.client.send_tip(&tipper, &creator, &amount, &msg);
+        }
+    }
+
+    // Per-creator profile totals and counts match expectations.
+    for ci in 0..creators.len() {
+        let creator = creators.get(ci).unwrap();
+        let p = c.client.get_profile(&creator);
+        let expected_total: i128 = (ci as i128 + 1) * 10_000_000 * 10;
+        assert_eq!(p.total_tips_received, expected_total, "creator {ci} total");
+        assert_eq!(p.balance, expected_total, "creator {ci} balance");
+        assert_eq!(p.total_tips_count, 10, "creator {ci} count");
+    }
+
+    // Global stats: 5 creators × 10 tippers = 50 tips.
+    let stats = c.client.get_stats();
+    assert_eq!(stats.total_tips_count, 50);
+    assert_eq!(stats.total_creators, 5);
+
+    // Sum of geometric-style totals: 1+2+3+4+5 = 15 → 15 * 10 XLM = 150 XLM.
+    let expected_volume: i128 = (1 + 2 + 3 + 4 + 5) * 10 * 10_000_000;
+    assert_eq!(stats.total_tips_volume, expected_volume);
+
+    // Leaderboard descending by lifetime total → foxtrot first.
+    let board = c.client.get_leaderboard(&10);
+    assert_eq!(board.len(), 5);
+    assert_eq!(board.get(0).unwrap().address, creators.get(4).unwrap());
+    assert_eq!(board.get(4).unwrap().address, creators.get(0).unwrap());
+}
+
+/// Soroban tests are sequential by nature, but we can still exercise the
+/// "many ops on the same profile back-to-back" code path.  Twenty tips from
+/// the same tipper must aggregate exactly with no off-by-one in counts.
+#[test]
+fn many_sequential_tips_aggregate_exactly() {
+    let c = ctx(0);
+    let creator = register(&c, "alice");
+    let tipper = fund(&c, 10_000_000_000);
+
+    let amount: i128 = 1_000_000;
+    for _ in 0..20u32 {
+        c.client
+            .send_tip(&tipper, &creator, &amount, &String::from_str(&c.env, ""));
+    }
+
+    let p = c.client.get_profile(&creator);
+    assert_eq!(p.total_tips_count, 20);
+    assert_eq!(p.total_tips_received, amount * 20);
+    assert_eq!(p.balance, amount * 20);
+}
+
+/// Admin updates the withdrawal fee partway through the lifecycle.  Earlier
+/// withdrawals use the old rate, later ones the new rate — total fees
+/// collected reflect both.
+#[test]
+fn fee_change_mid_lifecycle_applies_to_later_withdraws() {
+    let c = ctx(200); // start at 2 %
+    let creator = register(&c, "alice");
+    let tipper = fund(&c, 10_000_000_000);
+
+    // Receive 1 XLM, withdraw at 2 %.
+    c.client
+        .send_tip(&tipper, &creator, &10_000_000, &String::from_str(&c.env, ""));
+    c.client.withdraw_tips(&creator, &10_000_000);
+    let stats1 = c.client.get_stats();
+    assert_eq!(stats1.total_fees_collected, 200_000); // 2 % of 10_000_000
+
+    // Admin bumps fee to 5 %.
+    c.client.set_fee(&c.admin, &500);
+
+    // Receive another 1 XLM, withdraw at 5 %.
+    c.client
+        .send_tip(&tipper, &creator, &10_000_000, &String::from_str(&c.env, ""));
+    c.client.withdraw_tips(&creator, &10_000_000);
+
+    let stats2 = c.client.get_stats();
+    // 200_000 (2 %) + 500_000 (5 %) = 700_000.
+    assert_eq!(stats2.total_fees_collected, 700_000);
+}
+
+/// Changing the fee collector address mid-flight: pre-change fees go to the
+/// original collector, post-change fees to the new collector.  Funds already
+/// paid out cannot move retroactively.
+#[test]
+fn fee_collector_change_splits_payouts() {
+    let c = ctx(200);
+    let creator = register(&c, "alice");
+    let tipper = fund(&c, 10_000_000_000);
+    let token_client = token::TokenClient::new(&c.env, &c.sac);
+
+    // First cycle → fees to original collector.
+    c.client
+        .send_tip(&tipper, &creator, &50_000_000, &String::from_str(&c.env, ""));
+    c.client.withdraw_tips(&creator, &50_000_000);
+    let original_collector_balance = token_client.balance(&c.fee_collector);
+    assert_eq!(original_collector_balance, 1_000_000); // 2 % of 50_000_000
+
+    // Switch collector.
+    let new_collector = Address::generate(&c.env);
+    c.client.set_fee_collector(&c.admin, &new_collector);
+
+    // Second cycle → fees to the new collector.
+    c.client
+        .send_tip(&tipper, &creator, &50_000_000, &String::from_str(&c.env, ""));
+    c.client.withdraw_tips(&creator, &50_000_000);
+    assert_eq!(token_client.balance(&new_collector), 1_000_000);
+    // Original collector balance unchanged.
+    assert_eq!(token_client.balance(&c.fee_collector), original_collector_balance);
+}
+
+/// A creator can interleave tips and partial withdrawals: lifetime total
+/// tracks every tip, current balance only what hasn't been withdrawn yet.
+#[test]
+fn interleaved_tips_and_partial_withdraws() {
+    let c = ctx(0); // zero fee for clean math
+    let creator = register(&c, "alice");
+    let tipper = fund(&c, 10_000_000_000);
+    let msg = String::from_str(&c.env, "");
+
+    c.client.send_tip(&tipper, &creator, &100_000_000, &msg); // bal=100
+    c.client.withdraw_tips(&creator, &30_000_000); //                bal=70
+    c.client.send_tip(&tipper, &creator, &50_000_000, &msg); //  bal=120
+    c.client.withdraw_tips(&creator, &100_000_000); //               bal=20
+    c.client.send_tip(&tipper, &creator, &10_000_000, &msg); //  bal=30
+
+    let p = c.client.get_profile(&creator);
+    assert_eq!(p.balance, 30_000_000, "running balance");
+    assert_eq!(p.total_tips_received, 160_000_000, "lifetime total");
+    assert_eq!(p.total_tips_count, 3);
+}
+
+/// `get_profile_by_username` must return the same data as `get_profile` by
+/// address after registration — the username → address index is consistent
+/// with the address → profile index.
+#[test]
+fn username_lookup_matches_address_lookup_after_registration() {
+    let c = ctx(200);
+    let alice = register(&c, "alice");
+
+    let by_addr = c.client.get_profile(&alice);
+    let by_username = c
+        .client
+        .get_profile_by_username(&String::from_str(&c.env, "alice"));
+
+    assert_eq!(by_addr.owner, by_username.owner);
+    assert_eq!(by_addr.username, by_username.username);
+    assert_eq!(by_addr.registered_at, by_username.registered_at);
+}
+
+/// After many tips the leaderboard rank function still returns positions
+/// that agree with the leaderboard listing order.
+#[test]
+fn leaderboard_rank_agrees_with_listing_order() {
+    let c = ctx(0);
+    let usernames = ["one", "two", "three"];
+    let mut creators = soroban_sdk::Vec::<Address>::new(&c.env);
+    for u in usernames {
+        creators.push_back(register(&c, u));
+    }
+    let tipper = fund(&c, 10_000_000_000);
+    let msg = String::from_str(&c.env, "");
+
+    // Distinct totals so the order is deterministic.
+    c.client
+        .send_tip(&tipper, &creators.get(0).unwrap(), &100_000_000, &msg);
+    c.client
+        .send_tip(&tipper, &creators.get(1).unwrap(), &300_000_000, &msg);
+    c.client
+        .send_tip(&tipper, &creators.get(2).unwrap(), &200_000_000, &msg);
+
+    let board = c.client.get_leaderboard(&10);
+    for i in 0..board.len() {
+        let entry = board.get(i).unwrap();
+        let rank = c.client.get_leaderboard_rank(&entry.address);
+        assert_eq!(rank, Some(i + 1), "rank for entry {i} agrees with listing");
+    }
+}

--- a/frontend-scaffold/package-lock.json
+++ b/frontend-scaffold/package-lock.json
@@ -25,14 +25,20 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@stellar/prettier-config": "^1.0.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/ui": "^4.1.5",
         "autoprefixer": "^10.4.21",
         "eslint": "^10.1.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "husky": "^9.1.7",
+        "jsdom": "^29.0.2",
         "lint-staged": "^16.4.0",
         "postcss": "^8.5.6",
         "prettier": "^2.8.8",
@@ -42,8 +48,16 @@
         "typescript-eslint": "^8.57.2",
         "vite": "^6.3.0",
         "vite-plugin-node-polyfills": "^0.22.0",
-        "vite-tsconfig-paths": "^5.1.4"
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@albedo-link/intent": {
       "version": "0.12.0",
@@ -63,6 +77,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -375,6 +440,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@creit.tech/stellar-wallets-kit": {
       "version": "1.9.5",
       "resolved": "https://registry.npmmirror.com/@creit.tech/stellar-wallets-kit/-/stellar-wallets-kit-1.9.5.tgz",
@@ -441,6 +519,146 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -1144,6 +1362,24 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fivebinaries/coin-selection": {
@@ -1962,6 +2198,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3440,6 +3683,13 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stellar/design-system": {
       "version": "1.1.3",
       "resolved": "https://registry.npmmirror.com/@stellar/design-system/-/design-system-1.1.3.tgz",
@@ -3521,6 +3771,105 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@trezor/analytics": {
@@ -4160,6 +4509,13 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmmirror.com/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4205,6 +4561,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmmirror.com/@types/connect/-/connect-3.4.38.tgz",
@@ -4213,6 +4580,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -4551,6 +4925,151 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.5"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@wallet-standard/base": {
@@ -5165,6 +5684,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmmirror.com/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -5196,6 +5725,16 @@
         "object-is": "^1.1.5",
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -5412,6 +5951,16 @@
       "resolved": "https://registry.npmmirror.com/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/big-integer": {
       "version": "1.6.36",
@@ -5901,6 +6450,16 @@
         "big-integer": "1.6.36"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-5.6.2.tgz",
@@ -6277,6 +6836,27 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/cssesc/-/cssesc-3.0.0.tgz",
@@ -6296,6 +6876,68 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -6322,6 +6964,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -6408,6 +7057,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/des.js": {
@@ -6500,6 +7159,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmmirror.com/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6600,6 +7266,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -6630,6 +7309,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -6962,6 +7648,16 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmmirror.com/eyes/-/eyes-0.1.8.tgz",
@@ -7071,6 +7767,13 @@
       "dependencies": {
         "is-retry-allowed": "^3.0.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -7547,6 +8250,19 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -7630,6 +8346,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -7798,6 +8524,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -7981,6 +8714,105 @@
       "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -8468,6 +9300,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
@@ -8497,6 +9339,13 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8590,6 +9439,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -8646,6 +9505,16 @@
       "resolved": "https://registry.npmmirror.com/motion-utils/-/motion-utils-12.36.0.tgz",
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8924,6 +9793,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmmirror.com/ofetch/-/ofetch-1.5.1.tgz",
@@ -9056,6 +9936,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -9086,6 +9979,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmmirror.com/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -9404,6 +10304,41 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -9780,6 +10715,20 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-addon": {
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/require-addon/-/require-addon-1.2.0.tgz",
@@ -9797,6 +10746,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10109,6 +11068,19 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.23.2.tgz",
@@ -10319,6 +11291,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10330,6 +11309,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/slice-ansi": {
@@ -10463,6 +11457,20 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -10561,6 +11569,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmmirror.com/sucrase/-/sucrase-3.35.1.tgz",
@@ -10615,6 +11636,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -10791,6 +11819,13 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -10817,6 +11852,36 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -10856,6 +11921,29 @@
       "resolved": "https://registry.npmmirror.com/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -11086,6 +12174,16 @@
       "resolved": "https://registry.npmmirror.com/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.24.5",
@@ -11531,6 +12629,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmmirror.com/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -11538,11 +12726,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -11595,6 +12806,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wif": {
@@ -11656,6 +12884,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xrpl": {
       "version": "4.6.0",

--- a/frontend-scaffold/package.json
+++ b/frontend-scaffold/package.json
@@ -11,6 +11,9 @@
     "start": "vite",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -29,14 +32,20 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@stellar/prettier-config": "^1.0.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/ui": "^4.1.5",
     "autoprefixer": "^10.4.21",
     "eslint": "^10.1.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "husky": "^9.1.7",
+    "jsdom": "^29.0.2",
     "lint-staged": "^16.4.0",
     "postcss": "^8.5.6",
     "prettier": "^2.8.8",
@@ -46,7 +55,8 @@
     "typescript-eslint": "^8.57.2",
     "vite": "^6.3.0",
     "vite-plugin-node-polyfills": "^0.22.0",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^4.1.5"
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^1.9.5",

--- a/frontend-scaffold/src/components/ui/__tests__/Badge.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Badge.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Badge, { getTierFromScore } from "../Badge";
+
+describe("Badge", () => {
+  it.each([
+    ["bronze", "Bronze", "🥉"],
+    ["silver", "Silver", "🥈"],
+    ["gold", "Gold", "🥇"],
+    ["diamond", "Diamond", "💎"],
+  ] as const)("renders the %s tier with the right label and emoji", (tier, label, emoji) => {
+    render(<Badge tier={tier} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByText(emoji)).toBeInTheDocument();
+  });
+
+  it("does not render the score parens when score is omitted", () => {
+    render(<Badge tier="gold" />);
+    // No element matching "(<number>)" pattern.
+    expect(screen.queryByText(/^\(\d+\)$/)).toBeNull();
+  });
+
+  it("renders the score in parentheses when provided", () => {
+    render(<Badge tier="gold" score={750} />);
+    expect(screen.getByText("(750)")).toBeInTheDocument();
+  });
+
+  it("renders score=0 (zero is a valid value, not falsy)", () => {
+    render(<Badge tier="bronze" score={0} />);
+    expect(screen.getByText("(0)")).toBeInTheDocument();
+  });
+
+  it("merges a custom className onto the wrapper span", () => {
+    const { container } = render(<Badge tier="silver" className="ml-4" />);
+    expect(container.firstChild).toHaveClass("ml-4");
+  });
+});
+
+describe("getTierFromScore", () => {
+  it.each([
+    [0, "bronze"],
+    [400, "bronze"],
+    [401, "silver"],
+    [700, "silver"],
+    [701, "gold"],
+    [900, "gold"],
+    [901, "diamond"],
+    [1000, "diamond"],
+  ] as const)("score %i → %s", (score, expected) => {
+    expect(getTierFromScore(score)).toBe(expected);
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Button.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Button from "../Button";
+
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Send tip</Button>);
+    expect(screen.getByRole("button", { name: /send tip/i })).toBeInTheDocument();
+  });
+
+  it("renders the primary variant by default", () => {
+    render(<Button>Tip</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-black/);
+    expect(btn.className).toMatch(/text-white/);
+  });
+
+  it("renders the outline variant", () => {
+    render(<Button variant="outline">Tip</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-white/);
+    expect(btn.className).toMatch(/text-black/);
+  });
+
+  it("renders the ghost variant without a shadow", () => {
+    render(<Button variant="ghost">Tip</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-transparent/);
+    expect(btn.style.boxShadow).toBe("none");
+  });
+
+  it("applies the requested size", () => {
+    render(<Button size="lg">Big</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/text-lg/);
+  });
+
+  it("calls onClick when clicked", async () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Click me</Button>);
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onClick when disabled", async () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        Off
+      </Button>,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("disables itself and shows the loader spinner when loading", () => {
+    render(<Button loading>Submitting</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    // The loader is the spinning div inside the button.
+    expect(btn.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("renders the leading icon when not loading", () => {
+    render(
+      <Button icon={<span data-testid="lead-icon">★</span>}>With icon</Button>,
+    );
+    expect(screen.getByTestId("lead-icon")).toBeInTheDocument();
+  });
+
+  it("hides the trailing icon while loading", () => {
+    render(
+      <Button loading iconRight={<span data-testid="trail-icon">→</span>}>
+        Wait
+      </Button>,
+    );
+    expect(screen.queryByTestId("trail-icon")).toBeNull();
+  });
+
+  it("forwards arbitrary HTML attributes (type, aria-label)", () => {
+    render(
+      <Button type="submit" aria-label="submit-tip">
+        Go
+      </Button>,
+    );
+    const btn = screen.getByRole("button", { name: "submit-tip" });
+    expect(btn).toHaveAttribute("type", "submit");
+  });
+
+  it("merges a custom className with the built-in classes", () => {
+    render(<Button className="my-extra-class">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/my-extra-class/);
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Card.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Card from "../Card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(
+      <Card>
+        <span data-testid="content">Hello</span>
+      </Card>,
+    );
+    expect(screen.getByTestId("content")).toHaveTextContent("Hello");
+  });
+
+  it("uses medium padding by default", () => {
+    const { container } = render(<Card>x</Card>);
+    expect(container.firstChild).toHaveClass("p-6");
+  });
+
+  it("applies the requested padding", () => {
+    const { container } = render(<Card padding="lg">x</Card>);
+    expect(container.firstChild).toHaveClass("p-8");
+  });
+
+  it("does not include the hover transform classes by default", () => {
+    const { container } = render(<Card>x</Card>);
+    expect(container.firstChild).not.toHaveClass("hover:-translate-x-1");
+  });
+
+  it("opts in to the hover transform when hover=true", () => {
+    const { container } = render(<Card hover>x</Card>);
+    expect(container.firstChild).toHaveClass("hover:-translate-x-1");
+  });
+
+  it("merges a custom className", () => {
+    const { container } = render(<Card className="border-purple-500">x</Card>);
+    expect(container.firstChild).toHaveClass("border-purple-500");
+  });
+
+  it("applies the brutalist box-shadow inline style", () => {
+    const { container } = render(<Card>x</Card>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.boxShadow).toBe("4px 4px 0px 0px rgba(0,0,0,1)");
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Input.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Input.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Input from "../Input";
+
+describe("Input", () => {
+  it("renders without a label", () => {
+    render(<Input placeholder="Search" />);
+    expect(screen.getByPlaceholderText("Search")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("renders the label and links it to the input via htmlFor", () => {
+    render(<Input label="Username" />);
+    const label = screen.getByText("Username");
+    const input = screen.getByLabelText("Username");
+    expect(label).toBeInTheDocument();
+    expect(input).toBeInTheDocument();
+    // The label's htmlFor must match the input's id (auto-generated from label).
+    expect(label).toHaveAttribute("for", "username");
+    expect(input).toHaveAttribute("id", "username");
+  });
+
+  it("uses an explicit id when provided", () => {
+    render(<Input label="Email" id="email-field" />);
+    expect(screen.getByLabelText("Email")).toHaveAttribute("id", "email-field");
+  });
+
+  it("normalises a multi-word label into a slug for the id", () => {
+    render(<Input label="Display Name" />);
+    expect(screen.getByLabelText("Display Name")).toHaveAttribute(
+      "id",
+      "display-name",
+    );
+  });
+
+  it("calls onChange as the user types", async () => {
+    const onChange = vi.fn();
+    render(<Input label="Tip" onChange={onChange} />);
+    const input = screen.getByLabelText("Tip");
+    await userEvent.type(input, "abc");
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect((input as HTMLInputElement).value).toBe("abc");
+  });
+
+  it("renders the error message and applies the error border", () => {
+    render(<Input label="Amount" error="Must be > 0" />);
+    expect(screen.getByText("Must be > 0")).toBeInTheDocument();
+    expect(screen.getByLabelText("Amount").className).toMatch(/border-red-600/);
+  });
+
+  it("does not render the error paragraph when error is undefined", () => {
+    const { container } = render(<Input label="Bio" />);
+    // No <p> child should exist for the error.
+    expect(container.querySelector("p.text-red-600")).toBeNull();
+  });
+
+  it("forwards arbitrary HTML attributes (type, disabled, maxLength)", () => {
+    render(<Input label="Pin" type="number" maxLength={6} disabled />);
+    const input = screen.getByLabelText("Pin");
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("maxLength", "6");
+    expect(input).toBeDisabled();
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Loader.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Loader.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Loader from "../Loader";
+
+describe("Loader", () => {
+  it("renders the spinner element", () => {
+    const { container } = render(<Loader />);
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).not.toBeNull();
+  });
+
+  it("uses medium size by default", () => {
+    const { container } = render(<Loader />);
+    expect(container.querySelector(".w-8.h-8")).not.toBeNull();
+  });
+
+  it("applies the requested size classes", () => {
+    const { container, rerender } = render(<Loader size="sm" />);
+    expect(container.querySelector(".w-4.h-4")).not.toBeNull();
+    rerender(<Loader size="lg" />);
+    expect(container.querySelector(".w-12.h-12")).not.toBeNull();
+  });
+
+  it("renders the supporting text when provided", () => {
+    render(<Loader text="Loading profile" />);
+    expect(screen.getByText("Loading profile")).toBeInTheDocument();
+  });
+
+  it("omits the text node when text is not provided", () => {
+    const { container } = render(<Loader />);
+    expect(container.querySelector("p")).toBeNull();
+  });
+});

--- a/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Modal from "../Modal";
+
+describe("Modal", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <Modal isOpen={false} onClose={() => {}}>
+        <p>Hidden</p>
+      </Modal>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders children when isOpen is true", () => {
+    render(
+      <Modal isOpen onClose={() => {}}>
+        <p data-testid="modal-body">Content</p>
+      </Modal>,
+    );
+    expect(screen.getByTestId("modal-body")).toBeInTheDocument();
+  });
+
+  it("renders the title and a close button when title is provided", () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Send a tip">
+        <p>x</p>
+      </Modal>,
+    );
+    expect(screen.getByRole("heading", { name: "Send a tip" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /close modal/i })).toBeInTheDocument();
+  });
+
+  it("omits the close button when no title is provided", () => {
+    render(
+      <Modal isOpen onClose={() => {}}>
+        <p>x</p>
+      </Modal>,
+    );
+    expect(screen.queryByRole("button", { name: /close modal/i })).toBeNull();
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <Modal isOpen onClose={onClose} title="Hi">
+        <p>x</p>
+      </Modal>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /close modal/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <Modal isOpen onClose={onClose}>
+        <p>x</p>
+      </Modal>,
+    );
+    // Backdrop has role="presentation".
+    await userEvent.click(screen.getByRole("presentation"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses dialog ARIA semantics with aria-modal=true", () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Confirm">
+        <p>x</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-label", "Confirm");
+  });
+});

--- a/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
+++ b/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the `useWallet` hook (issue #476).
+ *
+ * The hook wraps `@creit.tech/stellar-wallets-kit` and the zustand wallet
+ * store.  We mock the kit module so connect/disconnect/sign flows can be
+ * driven deterministically without a real wallet popup.
+ *
+ * Coverage:
+ * - initial state mirrors the store's defaults
+ * - connect happy path: opens the modal, sets the chosen wallet id, fetches
+ *   the address, and writes the public key to the store
+ * - connect failure path: getAddress throws → store records the error and
+ *   clears the connecting flag
+ * - disconnect clears the store completely
+ * - signTransaction forwards XDR to the kit and returns the signed XDR
+ * - the kit is configured for the testnet network at construction time
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  mockWalletsKitFactory,
+  walletKitInstance,
+  resetWalletKit,
+  mockWalletRejectsAddress,
+  TEST_PUBLIC_KEY,
+} from "@/test/mocks/wallet";
+
+vi.mock("@creit.tech/stellar-wallets-kit", () => mockWalletsKitFactory());
+
+// Import AFTER `vi.mock` so the hook picks up the mocked kit at module load.
+import { useWallet } from "../useWallet";
+import { useWalletStore } from "../../store/walletStore";
+
+beforeEach(() => {
+  // Reset both the kit mock and the zustand store before every test so state
+  // does not leak between cases.
+  resetWalletKit();
+  useWalletStore.setState({
+    publicKey: null,
+    connected: false,
+    connecting: false,
+    error: null,
+    network: "TESTNET",
+  });
+});
+
+describe("useWallet — initial state", () => {
+  it("mirrors the store defaults", () => {
+    const { result } = renderHook(() => useWallet());
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.network).toBe("TESTNET");
+  });
+});
+
+describe("useWallet — connect", () => {
+  it("opens the modal, picks a wallet, and stores the public key", async () => {
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      result.current.connect();
+    });
+
+    const kit = walletKitInstance();
+    expect(kit.openModal).toHaveBeenCalledTimes(1);
+
+    // Simulate the user picking Freighter from the modal.
+    await act(async () => {
+      await kit.pickWallet("freighter");
+    });
+
+    expect(kit.setWallet).toHaveBeenCalledWith("freighter");
+    expect(kit.getAddress).toHaveBeenCalledTimes(1);
+    expect(result.current.publicKey).toBe(TEST_PUBLIC_KEY);
+    expect(result.current.connected).toBe(true);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  // NOTE: the production hook calls `setConnecting(true)` followed by
+  // `setError(null)`, but the store's `setError` action also resets
+  // `connecting: false` as a side effect.  The net effect is that consumers
+  // never observe `connecting === true` between `connect()` and the modal
+  // callback firing.  We therefore do *not* assert on that intermediate
+  // state — fixing the store/hook so the connecting flag works as advertised
+  // is tracked separately.
+
+  it("clears any previous error when connect() is invoked", () => {
+    useWalletStore.setState({ error: "previous failure" });
+    const { result } = renderHook(() => useWallet());
+    expect(result.current.error).toBe("previous failure");
+
+    act(() => {
+      result.current.connect();
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("records an error when getAddress rejects (user dismissed popup)", async () => {
+    const { result } = renderHook(() => useWallet());
+
+    act(() => {
+      result.current.connect();
+    });
+
+    mockWalletRejectsAddress("User rejected wallet connection");
+
+    await act(async () => {
+      await walletKitInstance().pickWallet("freighter");
+    });
+
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toContain("rejected");
+  });
+
+  it("supports connecting via xBull as well as Freighter", async () => {
+    const { result } = renderHook(() => useWallet());
+
+    act(() => {
+      result.current.connect();
+    });
+    await act(async () => {
+      await walletKitInstance().pickWallet("xbull");
+    });
+
+    expect(walletKitInstance().setWallet).toHaveBeenCalledWith("xbull");
+    expect(result.current.connected).toBe(true);
+  });
+});
+
+describe("useWallet — disconnect", () => {
+  it("clears the public key, connected flag, and any error", async () => {
+    // Pre-seed the store as if a wallet were already connected.
+    useWalletStore.setState({
+      publicKey: TEST_PUBLIC_KEY,
+      connected: true,
+      error: "stale error",
+    });
+
+    const { result } = renderHook(() => useWallet());
+    expect(result.current.connected).toBe(true);
+
+    act(() => {
+      result.current.disconnect();
+    });
+
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe("useWallet — signTransaction", () => {
+  it("forwards the XDR to the kit and returns the signed XDR", async () => {
+    useWalletStore.setState({ publicKey: TEST_PUBLIC_KEY, connected: true });
+
+    const { result } = renderHook(() => useWallet());
+
+    let signed: string | undefined;
+    await act(async () => {
+      signed = await result.current.signTransaction("xdr-payload");
+    });
+
+    expect(signed).toBe("signed:xdr-payload");
+
+    const kit = walletKitInstance();
+    expect(kit.signTransaction).toHaveBeenCalledTimes(1);
+    expect(kit.signTransaction).toHaveBeenCalledWith("xdr-payload", {
+      address: TEST_PUBLIC_KEY,
+    });
+  });
+
+  it("passes address=undefined to the kit when no wallet is connected", async () => {
+    const { result } = renderHook(() => useWallet());
+    await act(async () => {
+      await result.current.signTransaction("anon");
+    });
+    expect(walletKitInstance().signTransaction).toHaveBeenCalledWith("anon", {
+      address: undefined,
+    });
+  });
+});
+
+describe("useWallet — multiple instances share the store", () => {
+  it("an update from one consumer is visible to another", async () => {
+    const a = renderHook(() => useWallet());
+    const b = renderHook(() => useWallet());
+
+    act(() => {
+      a.result.current.connect();
+    });
+    await act(async () => {
+      await walletKitInstance().pickWallet("freighter");
+    });
+
+    expect(a.result.current.publicKey).toBe(TEST_PUBLIC_KEY);
+    expect(b.result.current.publicKey).toBe(TEST_PUBLIC_KEY);
+    expect(b.result.current.connected).toBe(true);
+  });
+});

--- a/frontend-scaffold/src/test/mocks/wallet.ts
+++ b/frontend-scaffold/src/test/mocks/wallet.ts
@@ -1,0 +1,147 @@
+/**
+ * Test doubles for the Stellar Wallets Kit (issue #476).
+ *
+ * The real `StellarWalletsKit` is constructed at module-load time inside
+ * `useWallet.ts`, so tests `vi.mock("@creit.tech/stellar-wallets-kit", ...)`
+ * with the factory below.  The mock exposes a single shared instance whose
+ * mocks can be reset between tests via `resetWalletKit()`.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { vi, beforeEach } from "vitest";
+ * import {
+ *   mockWalletsKitFactory,
+ *   walletKitInstance,
+ *   resetWalletKit,
+ * } from "@/test/mocks/wallet";
+ *
+ * vi.mock("@creit.tech/stellar-wallets-kit", () => mockWalletsKitFactory());
+ *
+ * beforeEach(() => resetWalletKit());
+ * ```
+ */
+import { vi, type Mock } from "vitest";
+
+const FREIGHTER = "freighter";
+const ALBEDO = "albedo";
+const XBULL = "xbull";
+
+/** A representative testnet public key (Stellar G-prefix, 56 chars). */
+export const TEST_PUBLIC_KEY =
+  "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX";
+
+/** Shared mock instance produced by the StellarWalletsKit constructor. */
+export interface MockWalletsKitInstance {
+  openModal: Mock;
+  setWallet: Mock;
+  getAddress: Mock;
+  signTransaction: Mock;
+  /** Records the last wallet id passed to `setWallet`. */
+  selectedWalletId: string | null;
+  /**
+   * Triggers the `onWalletSelected` callback that the production hook passes
+   * to `kit.openModal`.  Tests call this to simulate the user picking a
+   * wallet from the modal.
+   */
+  pickWallet: (id?: string) => Promise<void>;
+}
+
+// A single, mutable instance.  The hook constructs the kit once at module
+// load, so we never replace this object — we only reset its internals.
+const sharedInstance = bootstrapInstance();
+
+/** Returns the shared kit instance used by the production hook. */
+export function walletKitInstance(): MockWalletsKitInstance {
+  return sharedInstance;
+}
+
+/**
+ * Resets the shared instance back to the default success behaviour.  Call
+ * this from `beforeEach` so state does not leak between tests.
+ */
+export function resetWalletKit() {
+  configureInstance(sharedInstance);
+}
+
+function bootstrapInstance(): MockWalletsKitInstance {
+  const inst = {
+    selectedWalletId: null,
+    openModal: vi.fn(),
+    setWallet: vi.fn(),
+    getAddress: vi.fn(),
+    signTransaction: vi.fn(),
+    pickWallet: async () => {
+      /* re-installed by configureInstance */
+    },
+  } as MockWalletsKitInstance;
+  configureInstance(inst);
+  return inst;
+}
+
+function configureInstance(inst: MockWalletsKitInstance) {
+  let onSelected: ((opt: { id: string }) => void | Promise<void>) | null = null;
+
+  inst.selectedWalletId = null;
+  inst.openModal.mockReset();
+  inst.setWallet.mockReset();
+  inst.getAddress.mockReset();
+  inst.signTransaction.mockReset();
+
+  inst.openModal.mockImplementation(({ onWalletSelected }) => {
+    onSelected = onWalletSelected;
+  });
+  inst.setWallet.mockImplementation((id: string) => {
+    inst.selectedWalletId = id;
+  });
+  inst.getAddress.mockResolvedValue({ address: TEST_PUBLIC_KEY });
+  inst.signTransaction.mockImplementation(async (xdr: string) => ({
+    signedTxXdr: `signed:${xdr}`,
+  }));
+
+  inst.pickWallet = async (id = FREIGHTER) => {
+    if (!onSelected) {
+      throw new Error(
+        "pickWallet() called before the production hook invoked openModal",
+      );
+    }
+    await onSelected({ id });
+  };
+}
+
+/**
+ * Returns a `vi.mock` factory that replaces the entire
+ * `@creit.tech/stellar-wallets-kit` module.  The constructor returns the
+ * shared mock instance so the hook and the test code see the same object.
+ */
+export function mockWalletsKitFactory() {
+  class StellarWalletsKit {
+    constructor(_opts: unknown) {
+      // Returning an object from a constructor makes `new` evaluate to that
+      // object, so the production hook ends up holding a direct reference to
+      // `sharedInstance` and sees `resetWalletKit()` mutations live.
+      return sharedInstance as unknown as StellarWalletsKit;
+    }
+  }
+
+  return {
+    StellarWalletsKit,
+    WalletNetwork: { TESTNET: "TESTNET", PUBLIC: "PUBLIC" },
+    FREIGHTER_ID: FREIGHTER,
+    ALBEDO_ID: ALBEDO,
+    XBULL_ID: XBULL,
+    FreighterModule: class {},
+    AlbedoModule: class {},
+    xBullModule: class {},
+  };
+}
+
+/**
+ * Convenience: configures the shared mock to reject on the *next* call to
+ * `getAddress`, simulating a user dismissing the wallet popup.
+ */
+export function mockWalletRejectsAddress(
+  message = "User rejected wallet connection",
+) {
+  walletKitInstance().getAddress.mockRejectedValueOnce(new Error(message));
+}

--- a/frontend-scaffold/src/test/setup.ts
+++ b/frontend-scaffold/src/test/setup.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});

--- a/frontend-scaffold/vite.config.ts
+++ b/frontend-scaffold/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -30,5 +31,11 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {},
     },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    css: false,
   },
 });


### PR DESCRIPTION
## Summary

Closes #473, 
Closes #474, 
Closes #475, 
Closes #476.

This PR adds four independent test suites that share no source files, so the changes are conflict-free and can be reviewed in any order.

### Issue #473 — Credit score unit tests
- Append snapshot regression table covering every score factor combination
- Pseudo-property tests asserting score is monotonic in tip volume and account age, and always within `[0, 100]`
- Tier-transition walk across all 5 tiers
- Edge cases: clock skew (`now < registered_at`), negative balance clamp, unique-tippers documentation test
- Result: **41/41 credit tests pass** (was 26)

### Issue #474 — End-to-end integration tests
Two new files in `contracts/tipz/src/test/`:
- `test_integration.rs` — register → tip → score → leaderboard → withdraw lifecycle, tip queryability, global stats, balance preservation, multi-creator isolation
- `test_integration_advanced.rs` — 5×10 multi-creator/multi-tipper consistency, sequential tip aggregation, mid-lifecycle fee changes, fee collector switches, interleaved tips/withdraws
- Result: **15/15 integration tests pass** (258/258 contract tests overall)
- Pause/deregister scenarios from the issue are noted but skipped because those features are not implemented in the contract.

### Issue #475 — UI component tests
- Wired up Vitest + jsdom + React Testing Library (no test runner existed before)
- New tests for Button, Card, Input, Badge, Modal, Loader — 55 cases covering variants, ARIA attributes, click/disable behavior, and prop forwarding
- Added `npm test`, `npm run test:watch`, and `npm run test:ui` scripts

### Issue #476 — useWallet hook tests
- New `src/test/mocks/wallet.ts` with a reusable `StellarWalletsKit` test double (constructor returns the shared mock instance so `resetWalletKit()` mutations are visible to consumers)
- Tests cover: initial state, connect happy path with Freighter and xBull, connect failure (user-rejected popup), disconnect cleanup, signTransaction forwarding, and store sharing across multiple `useWallet()` consumers
- Documents the existing store quirk where `setError(null)` resets the `connecting` flag (worth a separate fix)

## Test plan
- [x] `cd contracts && cargo test --package tipz-contract --lib` → 258 passed, 0 failed
- [x] `cd frontend-scaffold && npm test` → 64 passed across 7 files
- [x] `cd frontend-scaffold && npm run typecheck` → no errors
- [ ] Reviewer: optionally `npm run test:ui` to inspect UI test snapshots interactively