### PR TITLE
fix(frontend): support hash-aware smooth scrolling in ScrollToTop

### DIFF
--- a/frontend-scaffold/src/components/shared/ScrollToTop.tsx
+++ b/frontend-scaffold/src/components/shared/ScrollToTop.tsx
@@ -2,11 +2,22 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ScrollToTop: React.FC = () => {
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
+    if (hash) {
+      const targetId = decodeURIComponent(hash.replace('#', ''));
+      const target = document.getElementById(targetId);
+
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+
+      return;
+    }
+
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  }, [pathname, hash]);
 
   return null;
 };

--- a/frontend-scaffold/src/components/shared/__tests__/ScrollToTop.test.tsx
+++ b/frontend-scaffold/src/components/shared/__tests__/ScrollToTop.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import ScrollToTop from '../ScrollToTop';
+
+const NavigationButtons = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button onClick={() => navigate('/leaderboard')}>Go leaderboard</button>
+      <button onClick={() => navigate('/#features')}>Go features</button>
+      <button onClick={() => navigate('/#nonexistent')}>Go missing hash</button>
+    </>
+  );
+};
+
+describe('ScrollToTop', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollTo', {
+      writable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it('scrolls to top on route change', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ScrollToTop />
+        <NavigationButtons />
+        <Routes>
+          <Route
+            path="/"
+            element={<section id="features">Features Section</section>}
+          />
+          <Route path="/leaderboard" element={<div>Leaderboard</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.scrollTo).mockClear();
+    await user.click(screen.getByRole('button', { name: /go leaderboard/i }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  it('scrolls to element on hash navigation', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ScrollToTop />
+        <NavigationButtons />
+        <Routes>
+          <Route
+            path="/"
+            element={<section id="features">Features Section</section>}
+          />
+          <Route path="/leaderboard" element={<div>Leaderboard</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const featuresEl = document.getElementById('features');
+    expect(featuresEl).toBeTruthy();
+
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(featuresEl as HTMLElement, 'scrollIntoView', {
+      writable: true,
+      value: scrollIntoView,
+    });
+
+    vi.mocked(window.scrollTo).mockClear();
+    await user.click(screen.getByRole('button', { name: /go features/i }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-existent hash targets', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ScrollToTop />
+        <NavigationButtons />
+        <Routes>
+          <Route
+            path="/"
+            element={<section id="features">Features Section</section>}
+          />
+          <Route path="/leaderboard" element={<div>Leaderboard</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.scrollTo).mockClear();
+
+    await user.click(screen.getByRole('button', { name: /go missing hash/i }));
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Scroll to top only on pathname changes, and scroll to hash targets smoothly when present. Gracefully no-op when hash target does not exist, and add tests for route change, hash navigation, and missing-target behavior.

Closes #411

## Description

<!-- Brief description of what this PR does -->

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)

## Changes Made

<!-- List the specific changes -->

- 
- 
- 

## How to Test

<!-- Steps to verify the changes -->

1. 
2. 
3. 

## Checklist

### Contract Changes
- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (all tests)
- [ ] New tests written for new functionality
- [ ] No hardcoded values that should be configurable

### Frontend Changes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] Tested in browser with Freighter wallet
- [ ] Responsive design verified

### General
- [ ] Code follows project conventions
- [ ] Self-reviewed my own code
- [ ] No `console.log` or debug code left in
- [ ] Branch is up to date with `main`

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
