### PR TITLE
fix(frontend): make Modal fully accessible with focus trap and keyboard support

### DIFF
--- a/frontend-scaffold/src/components/shared/ScrollToTop.tsx
+++ b/frontend-scaffold/src/components/shared/ScrollToTop.tsx
@@ -2,11 +2,22 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ScrollToTop: React.FC = () => {
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
+    if (hash) {
+      const targetId = decodeURIComponent(hash.replace('#', ''));
+      const target = document.getElementById(targetId);
+
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+
+      return;
+    }
+
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  }, [pathname, hash]);
 
   return null;
 };

--- a/frontend-scaffold/src/components/shared/__tests__/ScrollToTop.test.tsx
+++ b/frontend-scaffold/src/components/shared/__tests__/ScrollToTop.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import ScrollToTop from '../ScrollToTop';
+
+const NavigationButtons = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button onClick={() => navigate('/leaderboard')}>Go leaderboard</button>
+      <button onClick={() => navigate('/#features')}>Go features</button>
+      <button onClick={() => navigate('/#nonexistent')}>Go missing hash</button>
+    </>
+  );
+};
+
+describe('ScrollToTop', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollTo', {
+      writable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it('scrolls to top on route change', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ScrollToTop />
+        <NavigationButtons />
+        <Routes>
+          <Route
+            path="/"
+            element={<section id="features">Features Section</section>}
+          />
+          <Route path="/leaderboard" element={<div>Leaderboard</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.scrollTo).mockClear();
+    await user.click(screen.getByRole('button', { name: /go leaderboard/i }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  it('scrolls to element on hash navigation', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ScrollToTop />
+        <NavigationButtons />
+        <Routes>
+          <Route
+            path="/"
+            element={<section id="features">Features Section</section>}
+          />
+          <Route path="/leaderboard" element={<div>Leaderboard</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const featuresEl = document.getElementById('features');
+    expect(featuresEl).toBeTruthy();
+
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(featuresEl as HTMLElement, 'scrollIntoView', {
+      writable: true,
+      value: scrollIntoView,
+    });
+
+    vi.mocked(window.scrollTo).mockClear();
+    await user.click(screen.getByRole('button', { name: /go features/i }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-existent hash targets', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ScrollToTop />
+        <NavigationButtons />
+        <Routes>
+          <Route
+            path="/"
+            element={<section id="features">Features Section</section>}
+          />
+          <Route path="/leaderboard" element={<div>Leaderboard</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.scrollTo).mockClear();
+
+    await user.click(screen.getByRole('button', { name: /go missing hash/i }));
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend-scaffold/src/components/ui/Modal.tsx
+++ b/frontend-scaffold/src/components/ui/Modal.tsx
@@ -1,68 +1,94 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   title?: string;
+  closeOnBackdropClick?: boolean;
+  ariaLabelledBy?: string;
+  ariaDescribedBy?: string;
   children: React.ReactNode;
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  closeOnBackdropClick = true,
+  ariaLabelledBy,
+  ariaDescribedBy,
+  children,
+}) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const previousBodyOverflowRef = useRef<string>('');
+  const generatedTitleId = useId();
+
+  const effectiveLabelledBy = ariaLabelledBy ?? (title ? generatedTitleId : undefined);
 
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+    if (!isOpen) {
+      return;
+    }
 
-      if (e.key === 'Tab' && modalRef.current) {
-        const focusableElements = modalRef.current.querySelectorAll(
-          'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select, [tabindex]:not([tabindex="-1"])'
-        );
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!modalRef.current) {
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab') {
+        const focusableElements = Array.from(modalRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+
+        if (focusableElements.length === 0) {
+          modalRef.current.focus();
+          e.preventDefault();
+          return;
+        }
+
         const firstElement = focusableElements[0] as HTMLElement;
         const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
 
         if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            lastElement?.focus();
+          if (document.activeElement === firstElement || document.activeElement === modalRef.current) {
+            lastElement.focus();
             e.preventDefault();
           }
         } else {
           if (document.activeElement === lastElement) {
-            firstElement?.focus();
+            firstElement.focus();
             e.preventDefault();
           }
         }
       }
     };
 
-    if (isOpen) {
-      previousFocusRef.current = document.activeElement as HTMLElement;
-      document.addEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = 'hidden';
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    previousBodyOverflowRef.current = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleKeyDown);
 
-      const timer = setTimeout(() => {
-        if (modalRef.current) {
-          const focusableElements = modalRef.current.querySelectorAll(
-            'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select, [tabindex]:not([tabindex="-1"])'
-          );
-          if (focusableElements.length) {
-            (focusableElements[0] as HTMLElement).focus();
-          } else {
-            modalRef.current.focus();
-          }
-        }
-      }, 10);
-
-      return () => {
-        clearTimeout(timer);
-        document.removeEventListener('keydown', handleKeyDown);
-        document.body.style.overflow = 'unset';
-        if (previousFocusRef.current) {
-          previousFocusRef.current.focus();
-        }
-      };
+    if (modalRef.current) {
+      const focusableElements = Array.from(modalRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus();
+      } else {
+        modalRef.current.focus();
+      }
     }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousBodyOverflowRef.current;
+      previousFocusRef.current?.focus();
+    };
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
@@ -72,21 +98,28 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black bg-opacity-50"
-        onClick={onClose}
+        onClick={() => {
+          if (closeOnBackdropClick) {
+            onClose();
+          }
+        }}
         role="presentation"
       />
 
       {/* Modal content */}
       <div
+        ref={modalRef}
+        tabIndex={-1}
         className="relative z-10 w-full border-3 border-black bg-white p-6 sm:mx-4 sm:max-w-lg sm:p-8 max-sm:h-full max-sm:max-w-none max-sm:rounded-none"
         style={{ boxShadow: '6px 6px 0px 0px rgba(0,0,0,1)' }}
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-labelledby={effectiveLabelledBy}
+        aria-describedby={ariaDescribedBy}
       >
         {title && (
           <div className="flex items-center justify-between mb-6">
-            <h2 id="modal-title" className="text-2xl font-black uppercase">{title}</h2>
+            <h2 id={effectiveLabelledBy} className="text-2xl font-black uppercase">{title}</h2>
             <button
               onClick={onClose}
               className="text-2xl font-black hover:opacity-60 transition-opacity focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"

--- a/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Modal from '../Modal';
 
 describe('Modal Component', () => {
@@ -9,9 +10,9 @@ describe('Modal Component', () => {
         <div data-testid="modal-content">Modal Content</div>
       </Modal>
     );
-    expect(screen.getByText('Test Modal')).toBeDefined();
-    expect(screen.getByTestId('modal-content')).toBeDefined();
-    expect(screen.getByRole('dialog')).toBeDefined();
+    expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('does not render modal content when isOpen is false', () => {
@@ -65,6 +66,97 @@ describe('Modal Component', () => {
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
 
+  it('traps focus within modal', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal isOpen={true} onClose={() => {}} title="Focus Test">
+        <input aria-label="Name" />
+        <button>OK</button>
+      </Modal>
+    );
+
+    const textbox = screen.getByRole('textbox', { name: 'Name' });
+    const button = screen.getByRole('button', { name: 'OK' });
+
+    expect(textbox).toHaveFocus();
+
+    await user.tab();
+    expect(button).toHaveFocus();
+
+    await user.tab();
+    expect(textbox).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(button).toHaveFocus();
+  });
+
+  it('prevents body scroll when open', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}} title="Body lock test">
+        <div>Modal Content</div>
+      </Modal>
+    );
+
+    expect(document.body).toHaveStyle('overflow: hidden');
+  });
+
+  it('restores focus to trigger element on close', () => {
+    const TriggerHarness = ({ isOpen }: { isOpen: boolean }) => (
+      <>
+        <button>Open modal</button>
+        <Modal isOpen={isOpen} onClose={() => {}} title="Focus Restore">
+          <button>Confirm</button>
+        </Modal>
+      </>
+    );
+
+    const { rerender } = render(<TriggerHarness isOpen={false} />);
+    const trigger = screen.getByRole('button', { name: 'Open modal' });
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    rerender(<TriggerHarness isOpen={true} />);
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveFocus();
+
+    rerender(<TriggerHarness isOpen={false} />);
+    expect(trigger).toHaveFocus();
+  });
+
+  it('has correct ARIA attributes and supports labels/description ids', () => {
+    render(
+      <Modal
+        isOpen={true}
+        onClose={() => {}}
+        title="Test Modal"
+        ariaDescribedBy="modal-description"
+      >
+        <p id="modal-description">Content</p>
+      </Modal>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const heading = screen.getByRole('heading', { name: 'Test Modal' });
+
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', heading.id);
+    expect(dialog).toHaveAttribute('aria-describedby', 'modal-description');
+  });
+
+  it('does not close on backdrop click when closeOnBackdropClick is false', () => {
+    const handleClose = vi.fn();
+    render(
+      <Modal isOpen={true} onClose={handleClose} title="Test Modal" closeOnBackdropClick={false}>
+        <div>Modal Content</div>
+      </Modal>
+    );
+
+    const backdrop = screen.getByRole('presentation');
+    fireEvent.click(backdrop);
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
   it('renders without a title', () => {
     render(
       <Modal isOpen={true} onClose={() => {}}>
@@ -72,6 +164,6 @@ describe('Modal Component', () => {
       </Modal>
     );
     expect(screen.queryByText('Test Modal')).toBeNull();
-    expect(screen.getByTestId('modal-content')).toBeDefined();
+    expect(screen.getByTestId('modal-content')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION


Implement WCAG-friendly dialog behavior in Modal: trap focus while open (Tab/Shift+Tab cycling), close on Escape, optionally close on backdrop click, restore focus to trigger on close, lock body scroll while open, and support dialog labelling via aria-labelledby/aria-describedby alongside aria-modal and role=dialog. Add/expand Modal tests for focus trapping, Escape close, body scroll lock, ARIA attributes, and configurable backdrop behavior.

Closes #415