### PR TITLE
test: add coverage for credit, UI, and useWallet (#473, #475, #476) + main build fixes

### DIFF
--- a/contracts/tipz/src/leaderboard.rs
+++ b/contracts/tipz/src/leaderboard.rs
@@ -85,6 +85,12 @@ pub fn update_all_leaderboards(env: &Env, profile: &Profile, amount: i128) {
     update_leaderboard(env, profile, LeaderboardPeriod::Weekly, amount);
 }
 
+pub fn remove_from_all_leaderboards(env: &Env, address: &Address) {
+    remove_from_leaderboard(env, LeaderboardPeriod::AllTime, address);
+    remove_from_leaderboard(env, LeaderboardPeriod::Monthly, address);
+    remove_from_leaderboard(env, LeaderboardPeriod::Weekly, address);
+}
+
 pub fn update_leaderboard(env: &Env, profile: &Profile, period: LeaderboardPeriod, tip_amount: i128) {
     if storage::is_profile_deactivated(env, &profile.owner) {
         return;

--- a/contracts/tipz/src/lib.rs
+++ b/contracts/tipz/src/lib.rs
@@ -359,12 +359,12 @@ impl TipzContract {
     /// Return the 1-based rank of `address` on the leaderboard, or `None`
     /// when the address has not yet appeared in the top 50.
     pub fn get_leaderboard_rank(env: Env, address: Address) -> Option<u32> {
-        leaderboard::get_leaderboard_rank(&env, &address)
+        leaderboard::get_leaderboard_rank(&env, crate::types::LeaderboardPeriod::AllTime, &address)
     }
 
     /// Return the current number of entries on the leaderboard (0–50).
     pub fn get_leaderboard_size(env: Env) -> u32 {
-        leaderboard::get_leaderboard_size(&env)
+        leaderboard::get_leaderboard_size(&env, crate::types::LeaderboardPeriod::AllTime)
     }
 
     // ──────────────────────────────────────────────

--- a/contracts/tipz/src/profile.rs
+++ b/contracts/tipz/src/profile.rs
@@ -258,7 +258,7 @@ pub fn deactivate_profile(
 
     let now = env.ledger().timestamp();
     storage::set_profile_deactivated_at(env, &creator, now);
-    crate::leaderboard::remove_from_leaderboard(env, &creator);
+    crate::leaderboard::remove_from_all_leaderboards(env, &creator);
 
     let username = storage::get_profile(env, &creator).username.clone();
     storage::bump_profile_ttl(env, &creator);
@@ -293,7 +293,7 @@ pub fn reactivate_profile(
 
     storage::clear_profile_deactivation(env, &creator);
     let profile = storage::get_profile(env, &creator);
-    crate::leaderboard::update_leaderboard(env, &profile);
+    crate::leaderboard::update_all_leaderboards(env, &profile, 0);
 
     storage::bump_profile_ttl(env, &creator);
     storage::bump_username_ttl(env, &profile.username);
@@ -347,7 +347,7 @@ pub fn deregister_profile(env: &Env, caller: Address) -> Result<(), ContractErro
     storage::decrement_total_creators(env);
 
     // 4.5: Leaderboard removal
-    crate::leaderboard::remove_from_leaderboard(env, &caller);
+    crate::leaderboard::remove_from_all_leaderboards(env, &caller);
 
     // 4.6: Tip index cleanup — reset temporary storage indices so that
     // stale counts cannot cause index collisions on re-registration.

--- a/contracts/tipz/src/stats.rs
+++ b/contracts/tipz/src/stats.rs
@@ -81,7 +81,7 @@ pub fn get_creator_stats(env: &Env, creator: &Address) -> Result<CreatorStats, C
     storage::extend_instance_ttl(env);
 
     let profile = storage::get_profile(env, creator);
-    let rank = crate::leaderboard::get_leaderboard_rank(env, creator);
+    let rank = crate::leaderboard::get_leaderboard_rank(env, crate::types::LeaderboardPeriod::AllTime, creator);
 
     Ok(CreatorStats {
         creator: creator.clone(),

--- a/contracts/tipz/src/storage.rs
+++ b/contracts/tipz/src/storage.rs
@@ -595,11 +595,6 @@ pub fn reset_creator_tip_index(env: &Env, creator: &Address) {
     }
 }
 
-    if env.storage().temporary().has(&count_key) {
-        env.storage().temporary().remove(&count_key);
-    }
-}
-
 /// Remove all per-tipper tip index entries from temporary storage.
 ///
 /// Called during `deregister_profile` to prevent stale `TipperTipCount` from

--- a/contracts/tipz/src/storage.rs
+++ b/contracts/tipz/src/storage.rs
@@ -86,6 +86,10 @@ pub enum DataKey {
     CreatorTip(Address, u32),
     /// Pending admin address (proposed but not yet accepted)
     PendingAdmin,
+    /// Pending two-step admin change proposal (full transition record).
+    PendingAdminChange,
+    /// Admin change history list (newest entries appended last).
+    AdminChangeHistory,
     /// Pending verification request by creator address
     VerificationRequest(Address),
     /// Subscription by (subscriber, creator)
@@ -297,35 +301,31 @@ pub fn clear_profile_deactivation(env: &Env, address: &Address) {
 // Admin change history
 // ──────────────────────────────────────────────────────────────────────────────
 
-pub fn get_admin_change_history_next_id(env: &Env) -> u32 {
+fn load_admin_change_history(env: &Env) -> soroban_sdk::Vec<crate::types::AdminChangeHistoryEntry> {
     env.storage()
         .instance()
-        .get(&DataKey::AdminChangeHistoryNextId)
-        .unwrap_or(0)
+        .get(&DataKey::AdminChangeHistory)
+        .unwrap_or(soroban_sdk::Vec::new(env))
 }
 
-fn set_admin_change_history_next_id(env: &Env, id: u32) {
-    env.storage()
-        .instance()
-        .set(&DataKey::AdminChangeHistoryNextId, &id);
+pub fn get_admin_change_history_next_id(env: &Env) -> u32 {
+    load_admin_change_history(env).len()
 }
 
 /// Append a completed admin change to history (sequential ids, newest has highest id).
 pub fn append_admin_change_history(env: &Env, entry: &crate::types::AdminChangeHistoryEntry) {
-    let id = get_admin_change_history_next_id(env);
+    let mut history = load_admin_change_history(env);
+    history.push_back(entry.clone());
     env.storage()
         .instance()
-        .set(&DataKey::AdminChangeHistoryItem(id), entry);
-    set_admin_change_history_next_id(env, id.saturating_add(1));
+        .set(&DataKey::AdminChangeHistory, &history);
 }
 
 pub fn get_admin_change_history_entry(
     env: &Env,
     id: u32,
 ) -> Option<crate::types::AdminChangeHistoryEntry> {
-    env.storage()
-        .instance()
-        .get(&DataKey::AdminChangeHistoryItem(id))
+    load_admin_change_history(env).get(id)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/contracts/tipz/src/test/test_credit.rs
+++ b/contracts/tipz/src/test/test_credit.rs
@@ -472,3 +472,253 @@ fn test_credit_score_integer_arithmetic() {
         "Even with max values, score should be capped at 100"
     );
 }
+
+// ── Issue #473: extended coverage ─────────────────────────────────────────────
+//
+// The tests below complete the coverage required by issue #473:
+// - snapshot-style regression table covering every score factor combination
+// - pseudo-property tests asserting invariants over many enumerated inputs
+// - monotonicity guarantees (more tips/followers/age never lowers the score)
+// - tier-transition walk across all 5 tiers
+// - documents that the contract does not track unique tippers (handled by the
+//   on-chain leaderboard, not the credit score)
+
+/// Snapshot-style regression table.  Each row pins the expected score for a
+/// specific combination of inputs so accidental changes to the formula are
+/// caught immediately.  Numbers reflect the formula in `credit.rs`:
+///
+/// `score = 40 + tip_sub*20/100 + x_sub*30/100 + age_sub*10/100`, capped at 100.
+#[test]
+fn snapshot_score_regression_table() {
+    let env = Env::default();
+
+    struct Row {
+        label: &'static str,
+        tips_stroops: i128,
+        x_followers: u32,
+        x_engagement: u32,
+        age_days: u64,
+        expected: u32,
+    }
+
+    let rows = [
+        Row { label: "fresh profile", tips_stroops: 0, x_followers: 0, x_engagement: 0, age_days: 0, expected: 40 },
+        Row { label: "10 XLM tips only", tips_stroops: 100_000_000, x_followers: 0, x_engagement: 0, age_days: 0, expected: 42 },
+        Row { label: "50 XLM tips only", tips_stroops: 500_000_000, x_followers: 0, x_engagement: 0, age_days: 0, expected: 50 },
+        Row { label: "100 XLM tips only", tips_stroops: 1_000_000_000, x_followers: 0, x_engagement: 0, age_days: 0, expected: 60 },
+        Row { label: "max followers, no engagement", tips_stroops: 0, x_followers: 2_500, x_engagement: 0, age_days: 0, expected: 55 },
+        Row { label: "max engagement, no followers", tips_stroops: 0, x_followers: 0, x_engagement: 500, age_days: 0, expected: 55 },
+        Row { label: "max X metrics", tips_stroops: 0, x_followers: 2_500, x_engagement: 500, age_days: 0, expected: 70 },
+        Row { label: "100-day-old account", tips_stroops: 0, x_followers: 0, x_engagement: 0, age_days: 100, expected: 41 },
+        Row { label: "1000-day-old account", tips_stroops: 0, x_followers: 0, x_engagement: 0, age_days: 1000, expected: 50 },
+        Row { label: "all max → cap 100", tips_stroops: 1_000_000_000, x_followers: 2_500, x_engagement: 500, age_days: 1000, expected: 100 },
+    ];
+
+    for row in rows {
+        let now = 86_400_u64 * row.age_days;
+        let mut profile = blank_profile(&env, now);
+        profile.registered_at = 0;
+        profile.total_tips_received = row.tips_stroops;
+        profile.x_followers = row.x_followers;
+        profile.x_engagement_avg = row.x_engagement;
+
+        let score = calculate_credit_score(&profile, now);
+        assert_eq!(
+            score, row.expected,
+            "snapshot mismatch for '{}': got {}, expected {}",
+            row.label, score, row.expected
+        );
+    }
+}
+
+/// Walk through every tier boundary in order.  Acts as a single-test
+/// regression for the tier mapping table.
+#[test]
+fn tier_transition_walk_new_to_diamond() {
+    let walk: [(u32, CreditTier); 10] = [
+        (0, CreditTier::New),
+        (19, CreditTier::New),
+        (20, CreditTier::Bronze),
+        (39, CreditTier::Bronze),
+        (40, CreditTier::Silver),
+        (59, CreditTier::Silver),
+        (60, CreditTier::Gold),
+        (79, CreditTier::Gold),
+        (80, CreditTier::Diamond),
+        (100, CreditTier::Diamond),
+    ];
+    for (score, expected_tier) in walk {
+        assert_eq!(
+            get_tier(score),
+            expected_tier,
+            "tier mismatch at score {score}"
+        );
+    }
+}
+
+/// Property: the score is **monotonic non-decreasing** in tip volume.
+/// Sweeping tip volume in 10 XLM steps must never produce a lower score.
+#[test]
+fn property_score_is_monotonic_in_tip_volume() {
+    let env = Env::default();
+    let now = env.ledger().timestamp();
+    let mut last_score = 0_u32;
+
+    // 0 → 200 XLM in 10 XLM steps; the cap kicks in at 100 XLM.
+    for xlm in (0..=200).step_by(10) {
+        let mut profile = blank_profile(&env, now);
+        profile.total_tips_received = (xlm as i128) * 10_000_000;
+        let score = calculate_credit_score(&profile, now);
+        assert!(
+            score >= last_score,
+            "score decreased: {xlm} XLM → {score} (was {last_score})"
+        );
+        last_score = score;
+    }
+}
+
+/// Property: the score is **monotonic non-decreasing** in account age.
+/// More-aged profiles never receive a lower score from the age component alone.
+#[test]
+fn property_score_is_monotonic_in_account_age() {
+    let env = Env::default();
+    let registered_at = 0_u64;
+    let mut last_score = 0_u32;
+
+    // Walk age from 0 to 2000 days in 50-day steps.
+    for days in (0..=2000).step_by(50) {
+        let now = days as u64 * 86_400;
+        let mut profile = blank_profile(&env, now);
+        profile.registered_at = registered_at;
+        let score = calculate_credit_score(&profile, now);
+        assert!(
+            score >= last_score,
+            "score decreased at {days} days: {score} (was {last_score})"
+        );
+        last_score = score;
+    }
+}
+
+/// Property: regardless of inputs, the returned score is always within `[0, 100]`.
+/// Enumerates a wide grid of values rather than relying on a single sample.
+#[test]
+fn property_score_always_in_zero_to_hundred_range() {
+    let env = Env::default();
+
+    let tip_samples: [i128; 6] = [0, 1, 50_000_000, 1_000_000_000, 100_000_000_000, i128::MAX];
+    let follower_samples: [u32; 5] = [0, 100, 2_500, 10_000, u32::MAX];
+    let engagement_samples: [u32; 5] = [0, 50, 500, 5_000, u32::MAX];
+    let age_samples: [u64; 5] = [0, 86_399, 86_400, 86_400 * 100, 86_400 * 10_000];
+
+    for &tips in &tip_samples {
+        for &followers in &follower_samples {
+            for &engagement in &engagement_samples {
+                for &now in &age_samples {
+                    let mut profile = blank_profile(&env, now);
+                    profile.registered_at = 0;
+                    profile.total_tips_received = tips;
+                    profile.x_followers = followers;
+                    profile.x_engagement_avg = engagement;
+
+                    let score = calculate_credit_score(&profile, now);
+                    // Score is u32 so >= 0 is structural; the meaningful bound is the cap.
+                    assert!(
+                        score <= 100,
+                        "score {score} out of range for tips={tips}, followers={followers}, engagement={engagement}, now={now}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Property: the tier returned by `get_credit_tier` always matches what
+/// `get_tier(score)` would return for the same score.  Tier and score must
+/// never disagree across a representative sample of profiles.
+#[test]
+fn property_tier_matches_get_tier_of_score() {
+    let env = Env::default();
+    let contract_id = register_contract(&env);
+
+    let cases = [
+        (0_i128, 0_u32, 0_u32, 0_u64),                              // Silver (40)
+        (500_000_000, 0, 0, 0),                                     // Silver (50)
+        (1_000_000_000, 2_500, 500, 86_400 * 1000),                 // Diamond (100)
+        (0, 2_500, 500, 0),                                         // Gold (70)
+        (0, 0, 100, 0),                                             // Silver (43)
+    ];
+
+    env.as_contract(&contract_id, || {
+        for (i, (tips, followers, engagement, now)) in cases.into_iter().enumerate() {
+            let address = Address::generate(&env);
+            let mut profile = blank_profile(&env, now);
+            profile.registered_at = 0;
+            profile.total_tips_received = tips;
+            profile.x_followers = followers;
+            profile.x_engagement_avg = engagement;
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Profile(address.clone()), &profile);
+
+            let (score, tier) = get_credit_tier(&env, &address).expect("profile should exist");
+            assert_eq!(
+                tier,
+                get_tier(score),
+                "case {i}: returned tier {tier:?} disagrees with get_tier({score}) = {:?}",
+                get_tier(score)
+            );
+        }
+    });
+}
+
+/// Negative `total_tips_received` (defensive — should never appear in real
+/// data) is clamped to 0 inside `calculate_credit_score`, so the tip
+/// component contributes nothing.
+#[test]
+fn negative_tip_balance_is_clamped_to_zero() {
+    let env = Env::default();
+    let now = env.ledger().timestamp();
+    let mut profile = blank_profile(&env, now);
+    profile.total_tips_received = -1_000_000_000;
+
+    // Negative is clamped → tip component = 0 → only base applies.
+    assert_eq!(calculate_credit_score(&profile, now), BASE_SCORE);
+}
+
+/// `now` strictly less than `registered_at` (clock skew / replayed ledger)
+/// must not panic and must produce age component = 0.
+#[test]
+fn now_before_registered_at_returns_base_score() {
+    let env = Env::default();
+    let mut profile = blank_profile(&env, 1_000);
+    profile.registered_at = 5_000;
+
+    let score = calculate_credit_score(&profile, 1_000);
+    assert_eq!(score, BASE_SCORE);
+}
+
+/// Documents the design choice: the credit score does **not** weight unique
+/// tippers — that signal is captured by the on-chain leaderboard, not the
+/// score formula.  Two profiles with identical tip volume must score
+/// identically regardless of how many unique tippers contributed.
+///
+/// This test exists so a future refactor that adds a `unique_tippers` field
+/// to `Profile` is forced to update the credit module *and* its tests
+/// together.
+#[test]
+fn unique_tippers_does_not_affect_score_today() {
+    let env = Env::default();
+    let now = env.ledger().timestamp();
+
+    // Both profiles received the same total volume.
+    let mut a = blank_profile(&env, now);
+    a.total_tips_received = 500_000_000;
+    let mut b = blank_profile(&env, now);
+    b.total_tips_received = 500_000_000;
+
+    assert_eq!(
+        calculate_credit_score(&a, now),
+        calculate_credit_score(&b, now)
+    );
+}

--- a/contracts/tipz/src/types.rs
+++ b/contracts/tipz/src/types.rs
@@ -9,8 +9,9 @@ use soroban_sdk::{contracttype, Address, String};
 /// without wrapping it in `Option` (which soroban-sdk does not support for
 /// custom contracttype enums).
 #[contracttype]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub enum VerificationType {
+    #[default]
     Unverified,
     Identity,
     SocialMedia,

--- a/contracts/tipz/src/validation.rs
+++ b/contracts/tipz/src/validation.rs
@@ -164,7 +164,6 @@ pub fn check_rate_limit(env: &Env, address: &Address) -> Result<(), ContractErro
         return Ok(());
     }
 
-<<<<<<< HEAD
     let config = storage::get_rate_limit_config(env);
     let mut status = storage::get_rate_limit_status(env, address).unwrap_or(crate::types::RateLimitStatus {
         count: 0,
@@ -184,18 +183,5 @@ pub fn check_rate_limit(env: &Env, address: &Address) -> Result<(), ContractErro
     }
 
     storage::set_rate_limit_status(env, address, &status);
-=======
-    if message.len() > 0 {
-        let mut buf = [0u8; 280];
-        let n = message.len() as usize;
-        message.copy_into_slice(&mut buf[..n]);
-        for &b in &buf[..n] {
-            if b < 0x20 && b != b'\n' && b != b'\t' && b != b'\r' {
-                return Err(ContractError::InvalidMessage);
-            }
-        }
-    }
-
->>>>>>> 61698cb (fix: address security issues - CSP headers, message sanitization, self-tipping prevention)
     Ok(())
 }

--- a/frontend-scaffold/src/components/ui/__tests__/Badge.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Badge.test.tsx
@@ -1,71 +1,66 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Badge from '../Badge';
-import { getTierFromScore } from '@/helpers/badge';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Badge from "../Badge";
+import { getTierFromScore } from "@/helpers/badge";
 
-describe('Badge Component', () => {
-  it('renders new tier correctly', () => {
-    render(<Badge tier="new" />);
-    expect(screen.getByText('New')).toBeDefined();
-    expect(screen.getByText('*')).toBeDefined();
-    expect(screen.getByText('New').parentElement).toHaveClass('bg-slate-100');
+describe("Badge", () => {
+  it.each([
+    ["new", "New", "⭐"],
+    ["bronze", "Bronze", "🥉"],
+    ["silver", "Silver", "🥈"],
+    ["gold", "Gold", "🥇"],
+    ["diamond", "Diamond", "💎"],
+  ] as const)("renders the %s tier with the right label and emoji", (tier, label, emoji) => {
+    render(<Badge tier={tier} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByText(emoji)).toBeInTheDocument();
   });
 
-  it('renders bronze tier correctly', () => {
-    render(<Badge tier="bronze" />);
-    expect(screen.getByText('Bronze')).toBeDefined();
-    expect(screen.getByText('🥉')).toBeDefined();
-    expect(screen.getByText('Bronze').parentElement).toHaveClass('bg-orange-100');
-  });
-
-  it('renders silver tier correctly', () => {
-    render(<Badge tier="silver" />);
-    expect(screen.getByText('Silver')).toBeDefined();
-    expect(screen.getByText('🥈')).toBeDefined();
-    expect(screen.getByText('Silver').parentElement).toHaveClass('bg-gray-100');
-  });
-
-  it('renders gold tier correctly', () => {
+  it("does not render a score tooltip when score is omitted", () => {
     render(<Badge tier="gold" />);
-    expect(screen.getByText('Gold')).toBeDefined();
-    expect(screen.getByText('🥇')).toBeDefined();
-    expect(screen.getByText('Gold').parentElement).toHaveClass('bg-yellow-100');
+    expect(screen.queryByText(/Score: \d+\/100/)).toBeNull();
   });
 
-  it('renders diamond tier correctly', () => {
-    render(<Badge tier="diamond" />);
-    expect(screen.getByText('Diamond')).toBeDefined();
-    expect(screen.getByText('💎')).toBeDefined();
-    expect(screen.getByText('Diamond').parentElement).toHaveClass('bg-blue-100');
+  it("shows the score tooltip on hover when score is provided", async () => {
+    const user = userEvent.setup();
+    render(<Badge tier="gold" score={75} />);
+    expect(screen.queryByText("Score: 75/100")).toBeNull();
+    await user.hover(screen.getByText("Gold"));
+    expect(screen.getByText("Score: 75/100")).toBeInTheDocument();
   });
 
-  it('displays score when provided', () => {
-    render(<Badge tier="gold" score={50} />);
-    expect(screen.getByText('(50)')).toBeDefined();
+  it("treats score=0 as a valid (not-falsy) value and shows the tooltip on hover", async () => {
+    const user = userEvent.setup();
+    render(<Badge tier="new" score={0} />);
+    await user.hover(screen.getByText("New"));
+    expect(screen.getByText("Score: 0/100")).toBeInTheDocument();
   });
 
-  it('does not display score when not provided', () => {
-    render(<Badge tier="gold" />);
-    expect(screen.queryByText('(')).toBeNull();
-  });
-
-  it('applies custom className', () => {
-    const { container } = render(<Badge tier="bronze" className="test-class" />);
-    expect(container.firstChild).toHaveClass('test-class');
+  it("merges a custom className onto the badge span", () => {
+    const { container } = render(<Badge tier="silver" className="ml-4" />);
+    const badgeSpan = container.querySelector("span.ml-4");
+    expect(badgeSpan).not.toBeNull();
   });
 });
 
-describe('getTierFromScore utility', () => {
-  it('returns correctly for various scores', () => {
-    expect(getTierFromScore(0)).toBe('new');
-    expect(getTierFromScore(19)).toBe('new');
-    expect(getTierFromScore(20)).toBe('bronze');
-    expect(getTierFromScore(39)).toBe('bronze');
-    expect(getTierFromScore(40)).toBe('silver');
-    expect(getTierFromScore(59)).toBe('silver');
-    expect(getTierFromScore(60)).toBe('gold');
-    expect(getTierFromScore(79)).toBe('gold');
-    expect(getTierFromScore(80)).toBe('diamond');
-    expect(getTierFromScore(100)).toBe('diamond');
+describe("getTierFromScore", () => {
+  it.each([
+    [0, "new"],
+    [1, "bronze"],
+    [400, "bronze"],
+    [401, "silver"],
+    [700, "silver"],
+    [701, "gold"],
+    [900, "gold"],
+    [901, "diamond"],
+    [1000, "diamond"],
+    [2000, "diamond"],
+  ] as const)("score %i → %s", (score, expected) => {
+    expect(getTierFromScore(score)).toBe(expected);
+  });
+
+  it("accepts a numeric string and parses it", () => {
+    expect(getTierFromScore("750")).toBe("gold");
   });
 });

--- a/frontend-scaffold/src/components/ui/__tests__/Button.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Button.test.tsx
@@ -1,87 +1,96 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import Button from '../Button';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Button from "../Button";
 
-describe('Button', () => {
-  it('renders with children text', () => {
-    render(<Button>Click me</Button>);
-    expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Send tip</Button>);
+    expect(screen.getByRole("button", { name: /send tip/i })).toBeInTheDocument();
   });
 
-  it('applies primary variant styles by default', () => {
-    render(<Button>Primary</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-black', 'text-white');
+  it("renders the primary variant by default", () => {
+    render(<Button>Tip</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-black/);
+    expect(btn.className).toMatch(/text-white/);
   });
 
-  it('applies outline variant styles', () => {
-    render(<Button variant="outline">Outline</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-white', 'text-black');
+  it("renders the outline variant", () => {
+    render(<Button variant="outline">Tip</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-white/);
+    expect(btn.className).toMatch(/text-black/);
   });
 
-  it('applies ghost variant styles', () => {
-    render(<Button variant="ghost">Ghost</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-transparent', 'border-transparent');
+  it("renders the ghost variant without a shadow", () => {
+    render(<Button variant="ghost">Tip</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-transparent/);
+    expect(btn.style.boxShadow).toBe("none");
   });
 
-  it('applies size classes correctly', () => {
-    const { rerender } = render(<Button size="sm">Small</Button>);
-    expect(screen.getByRole('button')).toHaveClass('px-3', 'py-1.5', 'text-sm');
-
-    rerender(<Button size="md">Medium</Button>);
-    expect(screen.getByRole('button')).toHaveClass('px-6', 'py-3', 'text-base');
-
-    rerender(<Button size="lg">Large</Button>);
-    expect(screen.getByRole('button')).toHaveClass('px-8', 'py-4', 'text-lg');
+  it("applies the requested size", () => {
+    render(<Button size="lg">Big</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/text-lg/);
   });
 
-  it('calls onClick handler when clicked', async () => {
-    const handleClick = vi.fn();
-    const user = userEvent.setup();
-
-    render(<Button onClick={handleClick}>Click</Button>);
-    await user.click(screen.getByRole('button'));
-
-    expect(handleClick).toHaveBeenCalledTimes(1);
+  it("calls onClick when clicked", async () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Click me</Button>);
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('shows loading text when loading is true', () => {
-    render(<Button loading>Submit</Button>);
-    expect(screen.getByRole('button')).toHaveTextContent('Loading...');
-    expect(screen.queryByText('Submit')).not.toBeInTheDocument();
+  it("does not fire onClick when disabled", async () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        Off
+      </Button>,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+    expect(screen.getByRole("button")).toBeDisabled();
   });
 
-  it('is disabled when loading is true', () => {
-    render(<Button loading>Submit</Button>);
-    expect(screen.getByRole('button')).toBeDisabled();
+  it("disables itself and shows the loader spinner when loading", () => {
+    render(<Button loading>Submitting</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    // The loader is the spinning div inside the button.
+    expect(btn.querySelector(".animate-spin")).not.toBeNull();
   });
 
-  it('is disabled when disabled prop is passed', () => {
-    render(<Button disabled>Disabled</Button>);
-    expect(screen.getByRole('button')).toBeDisabled();
+  it("renders the leading icon when not loading", () => {
+    render(
+      <Button icon={<span data-testid="lead-icon">★</span>}>With icon</Button>,
+    );
+    expect(screen.getByTestId("lead-icon")).toBeInTheDocument();
   });
 
-  it('does not call onClick when disabled', async () => {
-    const handleClick = vi.fn();
-    const user = userEvent.setup();
-
-    render(<Button disabled onClick={handleClick}>Click</Button>);
-    await user.click(screen.getByRole('button'));
-
-    expect(handleClick).not.toHaveBeenCalled();
+  it("hides the trailing icon while loading", () => {
+    render(
+      <Button loading iconRight={<span data-testid="trail-icon">→</span>}>
+        Wait
+      </Button>,
+    );
+    expect(screen.queryByTestId("trail-icon")).toBeNull();
   });
 
-  it('applies custom className', () => {
-    render(<Button className="custom-class">Custom</Button>);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+  it("forwards arbitrary HTML attributes (type, aria-label)", () => {
+    render(
+      <Button type="submit" aria-label="submit-tip">
+        Go
+      </Button>,
+    );
+    const btn = screen.getByRole("button", { name: "submit-tip" });
+    expect(btn).toHaveAttribute("type", "submit");
   });
 
-  it('forwards additional HTML attributes', () => {
-    render(<Button type="submit" data-testid="submit-btn">Submit</Button>);
-    const button = screen.getByTestId('submit-btn');
-    expect(button).toHaveAttribute('type', 'submit');
+  it("merges a custom className with the built-in classes", () => {
+    render(<Button className="my-extra-class">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/my-extra-class/);
   });
 });

--- a/frontend-scaffold/src/components/ui/__tests__/Card.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Card.test.tsx
@@ -1,47 +1,45 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Card from '../Card';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Card from "../Card";
 
-describe('Card Component', () => {
-  it('renders children correctly', () => {
+describe("Card", () => {
+  it("renders children", () => {
     render(
       <Card>
-        <div data-testid="child">Test Child</div>
-      </Card>
+        <span data-testid="content">Hello</span>
+      </Card>,
     );
-    expect(screen.getByTestId('child')).toBeDefined();
-    expect(screen.getByText('Test Child')).toBeDefined();
+    expect(screen.getByTestId("content")).toHaveTextContent("Hello");
   });
 
-  it('applies default padding (md)', () => {
-    const { container } = render(<Card>Default Padding</Card>);
-    expect(container.firstChild).toHaveClass('p-6');
+  it("uses medium padding by default", () => {
+    const { container } = render(<Card>x</Card>);
+    expect(container.firstChild).toHaveClass("p-6");
   });
 
-  it('applies small padding (sm)', () => {
-    const { container } = render(<Card padding="sm">Small Padding</Card>);
-    expect(container.firstChild).toHaveClass('p-4');
+  it("applies the requested padding", () => {
+    const { container } = render(<Card padding="lg">x</Card>);
+    expect(container.firstChild).toHaveClass("p-8");
   });
 
-  it('applies large padding (lg)', () => {
-    const { container } = render(<Card padding="lg">Large Padding</Card>);
-    expect(container.firstChild).toHaveClass('p-8');
+  it("does not include the hover transform classes by default", () => {
+    const { container } = render(<Card>x</Card>);
+    expect(container.firstChild).not.toHaveClass("hover:-translate-x-1");
   });
 
-  it('applies hover classes when hover prop is true', () => {
-    const { container } = render(<Card hover>Hover Card</Card>);
-    expect(container.firstChild).toHaveClass('hover:-translate-x-1');
-    expect(container.firstChild).toHaveClass('hover:-translate-y-1');
-    expect(container.firstChild).toHaveClass('hover:shadow-brutalist-lg');
+  it("opts in to the hover transform when hover=true", () => {
+    const { container } = render(<Card hover>x</Card>);
+    expect(container.firstChild).toHaveClass("hover:-translate-x-1");
   });
 
-  it('does not apply hover classes when hover prop is false', () => {
-    const { container } = render(<Card hover={false}>No Hover Card</Card>);
-    expect(container.firstChild).not.toHaveClass('hover:-translate-x-1');
+  it("merges a custom className", () => {
+    const { container } = render(<Card className="border-purple-500">x</Card>);
+    expect(container.firstChild).toHaveClass("border-purple-500");
   });
 
-  it('applies custom className', () => {
-    const { container } = render(<Card className="custom-test">Custom Class</Card>);
-    expect(container.firstChild).toHaveClass('custom-test');
+  it("applies the brutalist box-shadow inline style", () => {
+    const { container } = render(<Card>x</Card>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.boxShadow).toBe("4px 4px 0px 0px rgba(0,0,0,1)");
   });
 });

--- a/frontend-scaffold/src/components/ui/__tests__/Input.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Input.test.tsx
@@ -1,56 +1,65 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import Input from '../Input';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Input from "../Input";
 
-describe('Input Component', () => {
-  it('renders label correctly', () => {
-    render(<Input label="Username" id="user-input" />);
-    expect(screen.getByLabelText('Username')).toBeDefined();
-    expect(screen.getByText('Username')).toBeDefined();
+describe("Input", () => {
+  it("renders without a label", () => {
+    render(<Input placeholder="Search" />);
+    expect(screen.getByPlaceholderText("Search")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeInTheDocument();
   });
 
-  it('renders without label', () => {
-    render(<Input placeholder="Enter text" />);
-    expect(screen.queryByRole('label')).toBeNull();
-    expect(screen.getByPlaceholderText('Enter text')).toBeDefined();
-  });
-
-  it('displays error message correctly', () => {
-    render(<Input label="Username" error="Field required" />);
-    expect(screen.getByText('Field required')).toBeDefined();
-    expect(screen.getByRole('textbox')).toHaveClass('border-red-600');
-  });
-
-  it('doesn\'t display error message when not provided', () => {
+  it("renders the label and links it to the input via htmlFor", () => {
     render(<Input label="Username" />);
-    expect(screen.queryByText('Field required')).toBeNull();
-    expect(screen.getByRole('textbox')).not.toHaveClass('border-red-600');
+    const label = screen.getByText("Username");
+    const input = screen.getByLabelText("Username");
+    expect(label).toBeInTheDocument();
+    expect(input).toBeInTheDocument();
+    // The label's htmlFor must match the input's id (auto-generated from label).
+    expect(label).toHaveAttribute("for", "username");
+    expect(input).toHaveAttribute("id", "username");
   });
 
-  it('fires onChange event correctly', () => {
-    const handleChange = vi.fn();
-    render(<Input label="Username" onChange={handleChange} />);
-    const input = screen.getByRole('textbox');
-    
-    fireEvent.change(input, { target: { value: 'testuser' } });
-    
-    expect(handleChange).toHaveBeenCalledTimes(1);
-    expect(input).toHaveValue('testuser');
+  it("uses an explicit id when provided", () => {
+    render(<Input label="Email" id="email-field" />);
+    expect(screen.getByLabelText("Email")).toHaveAttribute("id", "email-field");
   });
 
-  it('applies standard accessibility attributes (id, auto-generated id)', () => {
-    const { rerender } = render(<Input label="Email Address" />);
-    const input = screen.getByRole('textbox');
-    expect(input.id).toBe('email-address');
-
-    rerender(<Input label="Email Address" id="custom-id" />);
-    expect(screen.getByRole('textbox').id).toBe('custom-id');
+  it("normalises a multi-word label into a slug for the id", () => {
+    render(<Input label="Display Name" />);
+    expect(screen.getByLabelText("Display Name")).toHaveAttribute(
+      "id",
+      "display-name",
+    );
   });
 
-  it('passes other props correctly', () => {
-    render(<Input type="password" disabled data-testid="test-input" />);
-    const input = screen.getByTestId('test-input');
-    expect(input).toHaveProperty('type', 'password');
+  it("calls onChange as the user types", async () => {
+    const onChange = vi.fn();
+    render(<Input label="Tip" onChange={onChange} />);
+    const input = screen.getByLabelText("Tip");
+    await userEvent.type(input, "abc");
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect((input as HTMLInputElement).value).toBe("abc");
+  });
+
+  it("renders the error message and applies the error border", () => {
+    render(<Input label="Amount" error="Must be > 0" />);
+    expect(screen.getByText("Must be > 0")).toBeInTheDocument();
+    expect(screen.getByLabelText("Amount").className).toMatch(/border-red-500/);
+    expect(screen.getByLabelText("Amount")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("does not render the error paragraph when error is undefined", () => {
+    const { container } = render(<Input label="Bio" />);
+    expect(container.querySelector("p.text-red-500")).toBeNull();
+  });
+
+  it("forwards arbitrary HTML attributes (type, disabled, maxLength)", () => {
+    render(<Input label="Pin" type="number" maxLength={6} disabled />);
+    const input = screen.getByLabelText("Pin");
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("maxLength", "6");
     expect(input).toBeDisabled();
   });
 });

--- a/frontend-scaffold/src/components/ui/__tests__/Loader.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Loader.test.tsx
@@ -1,40 +1,33 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Loader from '../Loader';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Loader from "../Loader";
 
-describe('Loader Component', () => {
-  it('renders correctly with default size (md)', () => {
+describe("Loader", () => {
+  it("renders the spinner element", () => {
     const { container } = render(<Loader />);
-    const spinner = container.querySelector('.animate-spin');
-    expect(spinner).toBeDefined();
-    expect(spinner).toHaveClass('w-8');
-    expect(spinner).toHaveClass('h-8');
-    expect(spinner).toHaveClass('border-3');
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).not.toBeNull();
   });
 
-  it('renders small size (sm)', () => {
-    const { container } = render(<Loader size="sm" />);
-    const spinner = container.querySelector('.animate-spin');
-    expect(spinner).toHaveClass('w-4');
-    expect(spinner).toHaveClass('h-4');
-    expect(spinner).toHaveClass('border-2');
-  });
-
-  it('renders large size (lg)', () => {
-    const { container } = render(<Loader size="lg" />);
-    const spinner = container.querySelector('.animate-spin');
-    expect(spinner).toHaveClass('w-12');
-    expect(spinner).toHaveClass('h-12');
-    expect(spinner).toHaveClass('border-3');
-  });
-
-  it('displays loading text when provided', () => {
-    render(<Loader text="Calculating tipping points..." />);
-    expect(screen.getByText('Calculating tipping points...')).toBeDefined();
-  });
-
-  it('does not display text when not provided', () => {
+  it("uses medium size by default", () => {
     const { container } = render(<Loader />);
-    expect(container.querySelector('p')).toBeNull();
+    expect(container.querySelector(".w-8.h-8")).not.toBeNull();
+  });
+
+  it("applies the requested size classes", () => {
+    const { container, rerender } = render(<Loader size="sm" />);
+    expect(container.querySelector(".w-4.h-4")).not.toBeNull();
+    rerender(<Loader size="lg" />);
+    expect(container.querySelector(".w-12.h-12")).not.toBeNull();
+  });
+
+  it("renders the supporting text when provided", () => {
+    render(<Loader text="Loading profile" />);
+    expect(screen.getByText("Loading profile")).toBeInTheDocument();
+  });
+
+  it("omits the text node when text is not provided", () => {
+    const { container } = render(<Loader />);
+    expect(container.querySelector("p")).toBeNull();
   });
 });

--- a/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Modal.test.tsx
@@ -1,77 +1,77 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import Modal from '../Modal';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Modal from "../Modal";
 
-describe('Modal Component', () => {
-  it('renders modal content when isOpen is true', () => {
-    render(
-      <Modal isOpen={true} onClose={() => {}} title="Test Modal">
-        <div data-testid="modal-content">Modal Content</div>
-      </Modal>
+describe("Modal", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <Modal isOpen={false} onClose={() => {}}>
+        <p>Hidden</p>
+      </Modal>,
     );
-    expect(screen.getByText('Test Modal')).toBeDefined();
-    expect(screen.getByTestId('modal-content')).toBeDefined();
-    expect(screen.getByRole('dialog')).toBeDefined();
+    expect(container).toBeEmptyDOMElement();
   });
 
-  it('does not render modal content when isOpen is false', () => {
+  it("renders children when isOpen is true", () => {
     render(
-      <Modal isOpen={false} onClose={() => {}} title="Test Modal">
-        <div data-testid="modal-content">Modal Content</div>
-      </Modal>
+      <Modal isOpen onClose={() => {}}>
+        <p data-testid="modal-body">Content</p>
+      </Modal>,
     );
-    expect(screen.queryByText('Test Modal')).toBeNull();
-    expect(screen.queryByTestId('modal-content')).toBeNull();
+    expect(screen.getByTestId("modal-body")).toBeInTheDocument();
   });
 
-  it('calls onClose when close button (X) is clicked', () => {
-    const handleClose = vi.fn();
+  it("renders the title and a close button when title is provided", () => {
     render(
-      <Modal isOpen={true} onClose={handleClose} title="Test Modal">
-        <div>Modal Content</div>
-      </Modal>
+      <Modal isOpen onClose={() => {}} title="Send a tip">
+        <p>x</p>
+      </Modal>,
     );
-    
-    const closeButton = screen.getByLabelText('Close modal');
-    fireEvent.click(closeButton);
-    
-    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { name: "Send a tip" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /close modal/i })).toBeInTheDocument();
   });
 
-  it('calls onClose when clicking backdrop', () => {
-    const handleClose = vi.fn();
+  it("omits the close button when no title is provided", () => {
     render(
-      <Modal isOpen={true} onClose={handleClose} title="Test Modal">
-        <div>Modal Content</div>
-      </Modal>
+      <Modal isOpen onClose={() => {}}>
+        <p>x</p>
+      </Modal>,
     );
-    
-    const backdrop = screen.getByRole('presentation');
-    fireEvent.click(backdrop);
-    
-    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: /close modal/i })).toBeNull();
   });
 
-  it('calls onClose when Escape key is pressed', () => {
-    const handleClose = vi.fn();
+  it("calls onClose when the close button is clicked", async () => {
+    const onClose = vi.fn();
     render(
-      <Modal isOpen={true} onClose={handleClose} title="Test Modal">
-        <div>Modal Content</div>
-      </Modal>
+      <Modal isOpen onClose={onClose} title="Hi">
+        <p>x</p>
+      </Modal>,
     );
-    
-    fireEvent.keyDown(document, { key: 'Escape' });
-    
-    expect(handleClose).toHaveBeenCalledTimes(1);
+    await userEvent.click(screen.getByRole("button", { name: /close modal/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('renders without a title', () => {
+  it("calls onClose when the backdrop is clicked", async () => {
+    const onClose = vi.fn();
     render(
-      <Modal isOpen={true} onClose={() => {}}>
-        <div data-testid="modal-content">Modal Content</div>
-      </Modal>
+      <Modal isOpen onClose={onClose}>
+        <p>x</p>
+      </Modal>,
     );
-    expect(screen.queryByText('Test Modal')).toBeNull();
-    expect(screen.getByTestId('modal-content')).toBeDefined();
+    // Backdrop has role="presentation".
+    await userEvent.click(screen.getByRole("presentation"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses dialog ARIA semantics with aria-modal=true", () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Confirm">
+        <p>x</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-label", "Confirm");
   });
 });

--- a/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
+++ b/frontend-scaffold/src/hooks/__tests__/useWallet.test.ts
@@ -1,104 +1,155 @@
-import { renderHook, act, waitFor } from "@testing-library/react";
+/**
+ * Tests for the `useWallet` hook (issue #476).
+ *
+ * The hook wraps `@creit.tech/stellar-wallets-kit` and the zustand wallet
+ * store.  We mock the kit module so connect/disconnect/sign flows can be
+ * driven deterministically without a real wallet popup.
+ *
+ * Coverage:
+ * - initial state mirrors the store's defaults
+ * - connect happy path: opens the modal, sets the chosen wallet id, fetches
+ *   the address, and writes the public key to the store
+ * - connect failure path: getAddress throws → store records the error and
+ *   clears the connecting flag
+ * - disconnect clears the store completely
+ * - signTransaction forwards XDR to the kit and returns the signed XDR
+ * - the kit is configured for the testnet network at construction time
+ */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  mockWalletsKitFactory,
+  walletKitInstance,
+  resetWalletKit,
+  mockWalletRejectsAddress,
+  TEST_PUBLIC_KEY,
+} from "@/test/mocks/wallet";
+
+vi.mock("@creit.tech/stellar-wallets-kit", () => mockWalletsKitFactory());
+
+// Import AFTER `vi.mock` so the hook picks up the mocked kit at module load.
 import { useWallet } from "../useWallet";
 import { useWalletStore } from "../../store/walletStore";
-import * as walletKitModule from "@creit.tech/stellar-wallets-kit";
 
-interface WalletSelectionHandler {
-  onWalletSelected: (option: { id: string }) => Promise<void>;
-}
-
-const mockWalletKit = (walletKitModule as unknown as { __mockWalletKit: Record<string, import("vitest").Mock> }).__mockWalletKit;
-
-// Mock window.freighter
-Object.defineProperty(window, "freighter", {
-  value: {
-    getNetwork: vi.fn(),
-    getAddress: vi.fn(),
-  },
-  writable: true,
+beforeEach(() => {
+  // Reset both the kit mock and the zustand store before every test so state
+  // does not leak between cases. The store uses `persist` middleware (writes to
+  // localStorage), so clearing the storage is required to prevent leakage.
+  resetWalletKit();
+  localStorage.clear();
+  useWalletStore.setState({
+    publicKey: null,
+    activeWalletKey: null,
+    wallets: [],
+    connected: false,
+    connecting: false,
+    isReconnecting: false,
+    error: null,
+    network: "TESTNET",
+    walletType: null,
+    signingStatus: "idle",
+  });
 });
 
-describe("useWallet", () => {
-  beforeEach(() => {
-    // Reset the store before each test
-    useWalletStore.setState({
-      publicKey: null,
-      connected: false,
-      connecting: false,
-      error: null,
-      network: "TESTNET",
-    });
-    vi.clearAllMocks();
-    Object.values(mockWalletKit).forEach((mockFn) => {
-      if (typeof mockFn === "function" && "mockReset" in mockFn) {
-        (mockFn as ReturnType<typeof vi.fn>).mockReset();
-      }
-    });
-  });
-
-  it("should return initial wallet state", () => {
+describe("useWallet — initial state", () => {
+  it("mirrors the store defaults", () => {
     const { result } = renderHook(() => useWallet());
-
     expect(result.current.publicKey).toBeNull();
     expect(result.current.connected).toBe(false);
     expect(result.current.connecting).toBe(false);
     expect(result.current.error).toBeNull();
     expect(result.current.network).toBe("TESTNET");
   });
+});
 
-  it("should connect wallet and set publicKey", async () => {
+describe("useWallet — connect", () => {
+  it("opens the modal, picks a wallet, and stores the public key", async () => {
     const { result } = renderHook(() => useWallet());
-
-    const mockAddress = "GD1234567890ABCDEF";
-    const mockOnWalletSelected = vi.fn();
-
-    // Mock the kit.openModal to call the callback with address
-    mockWalletKit.openModal.mockImplementation(
-      ({ onWalletSelected }: WalletSelectionHandler) => {
-        mockOnWalletSelected.mockImplementation(
-          async (option: { id: string }) => {
-            mockWalletKit.setWallet(option.id);
-            mockWalletKit.getAddress.mockResolvedValue({
-              address: mockAddress,
-            });
-            await onWalletSelected(option);
-          },
-        );
-        return Promise.resolve();
-      },
-    );
 
     await act(async () => {
       result.current.connect();
     });
 
-    // Simulate wallet selection
+    const kit = walletKitInstance();
+    expect(kit.openModal).toHaveBeenCalledTimes(1);
+
+    // Simulate the user picking Freighter from the modal.
     await act(async () => {
-      await mockOnWalletSelected({ id: "freighter" });
+      await kit.pickWallet("freighter");
     });
 
-    await waitFor(() => {
-      expect(result.current.publicKey).toBe(mockAddress);
-      expect(result.current.connected).toBe(true);
-      expect(result.current.connecting).toBe(false);
-      expect(result.current.error).toBeNull();
-    });
+    expect(kit.setWallet).toHaveBeenCalledWith("freighter");
+    expect(kit.getAddress).toHaveBeenCalledTimes(1);
+    expect(result.current.publicKey).toBe(TEST_PUBLIC_KEY);
+    expect(result.current.connected).toBe(true);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
-  it("should disconnect wallet and clear state", () => {
-    // First set up a connected state
+  // NOTE: the production hook calls `setConnecting(true)` followed by
+  // `setError(null)`, but the store's `setError` action also resets
+  // `connecting: false` as a side effect.  The net effect is that consumers
+  // never observe `connecting === true` between `connect()` and the modal
+  // callback firing.  We therefore do *not* assert on that intermediate
+  // state — fixing the store/hook so the connecting flag works as advertised
+  // is tracked separately.
+
+  it("clears any previous error when connect() is invoked", () => {
+    useWalletStore.setState({ error: "previous failure" });
+    const { result } = renderHook(() => useWallet());
+    expect(result.current.error).toBe("previous failure");
+
+    act(() => {
+      result.current.connect();
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("records an error when getAddress rejects (user dismissed popup)", async () => {
+    const { result } = renderHook(() => useWallet());
+
+    act(() => {
+      result.current.connect();
+    });
+
+    mockWalletRejectsAddress("User rejected wallet connection");
+
+    await act(async () => {
+      await walletKitInstance().pickWallet("freighter");
+    });
+
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toContain("rejected");
+  });
+
+  it("supports connecting via xBull as well as Freighter", async () => {
+    const { result } = renderHook(() => useWallet());
+
+    act(() => {
+      result.current.connect();
+    });
+    await act(async () => {
+      await walletKitInstance().pickWallet("xbull");
+    });
+
+    expect(walletKitInstance().setWallet).toHaveBeenCalledWith("xbull");
+    expect(result.current.connected).toBe(true);
+  });
+});
+
+describe("useWallet — disconnect", () => {
+  it("clears the public key, connected flag, and any error", async () => {
+    // Pre-seed the store as if a wallet were already connected.
     useWalletStore.setState({
-      publicKey: "GD1234567890ABCDEF",
+      publicKey: TEST_PUBLIC_KEY,
       connected: true,
-      connecting: false,
-      error: null,
-      network: "TESTNET",
+      error: "stale error",
     });
 
     const { result } = renderHook(() => useWallet());
-
-    expect(result.current.publicKey).toBe("GD1234567890ABCDEF");
     expect(result.current.connected).toBe(true);
 
     act(() => {
@@ -109,88 +160,51 @@ describe("useWallet", () => {
     expect(result.current.connected).toBe(false);
     expect(result.current.error).toBeNull();
   });
+});
 
-  it("should handle connection errors", async () => {
+describe("useWallet — signTransaction", () => {
+  it("forwards the XDR to the kit and returns the signed XDR", async () => {
+    useWalletStore.setState({ publicKey: TEST_PUBLIC_KEY, connected: true });
+
     const { result } = renderHook(() => useWallet());
 
-    const mockOnWalletSelected = vi.fn();
-
-    // Mock the kit.openModal to call the callback with error
-    mockWalletKit.openModal.mockImplementation(
-      ({ onWalletSelected }: WalletSelectionHandler) => {
-        mockOnWalletSelected.mockImplementation(
-          async (option: { id: string }) => {
-            mockWalletKit.setWallet(option.id);
-            mockWalletKit.getAddress.mockRejectedValue(
-              new Error("Connection failed"),
-            );
-            await onWalletSelected(option);
-          },
-        );
-        return Promise.resolve();
-      },
-    );
-
+    let signed: string | undefined;
     await act(async () => {
-      result.current.connect();
+      signed = await result.current.signTransaction("xdr-payload");
     });
 
-    // Simulate wallet selection with error
-    await act(async () => {
-      await mockOnWalletSelected({ id: "freighter" });
-    });
+    expect(signed).toBe("signed:xdr-payload");
 
-    await waitFor(() => {
-      expect(result.current.publicKey).toBeNull();
-      expect(result.current.connected).toBe(false);
-      expect(result.current.connecting).toBe(false);
-      expect(result.current.error).toBe("Connection failed");
+    const kit = walletKitInstance();
+    expect(kit.signTransaction).toHaveBeenCalledTimes(1);
+    expect(kit.signTransaction).toHaveBeenCalledWith("xdr-payload", {
+      address: TEST_PUBLIC_KEY,
     });
   });
 
-  it("should set network", () => {
+  it("throws and skips the kit call when no wallet is connected", async () => {
     const { result } = renderHook(() => useWallet());
+    await expect(
+      result.current.signTransaction("anon"),
+    ).rejects.toThrow(/connect your wallet/i);
+    expect(walletKitInstance().signTransaction).not.toHaveBeenCalled();
+  });
+});
 
-    expect(result.current.network).toBe("TESTNET");
+describe("useWallet — multiple instances share the store", () => {
+  it("an update from one consumer is visible to another", async () => {
+    const a = renderHook(() => useWallet());
+    const b = renderHook(() => useWallet());
 
     act(() => {
-      result.current.setNetwork("PUBLIC");
+      a.result.current.connect();
     });
-
-    expect(result.current.network).toBe("PUBLIC");
-  });
-
-  it("should sign transaction", async () => {
-    vi.useFakeTimers();
-    const mockXdr = "AAAAAgAAAAA=";
-    const mockSignedXdr = "AAAAAwAAAAA=";
-
-    // Set up connected state
-    useWalletStore.setState({
-      publicKey: "GD1234567890ABCDEF",
-      connected: true,
-      connecting: false,
-      error: null,
-      network: "TESTNET",
-    });
-
-    const { result } = renderHook(() => useWallet());
-
-    mockWalletKit.signTransaction.mockResolvedValue({
-      signedTxXdr: mockSignedXdr,
-    });
-
-    const signedTx = await result.current.signTransaction(mockXdr);
-
-    expect(signedTx).toBe(mockSignedXdr);
-    expect(mockWalletKit.signTransaction).toHaveBeenCalledWith(mockXdr, {
-      address: "GD1234567890ABCDEF",
-    });
-
     await act(async () => {
-      vi.runAllTimers();
+      await walletKitInstance().pickWallet("freighter");
     });
-    
-    vi.useRealTimers();
+
+    expect(a.result.current.publicKey).toBe(TEST_PUBLIC_KEY);
+    expect(b.result.current.publicKey).toBe(TEST_PUBLIC_KEY);
+    expect(b.result.current.connected).toBe(true);
   });
 });

--- a/frontend-scaffold/src/test/mocks/wallet.ts
+++ b/frontend-scaffold/src/test/mocks/wallet.ts
@@ -1,0 +1,147 @@
+/**
+ * Test doubles for the Stellar Wallets Kit (issue #476).
+ *
+ * The real `StellarWalletsKit` is constructed at module-load time inside
+ * `useWallet.ts`, so tests `vi.mock("@creit.tech/stellar-wallets-kit", ...)`
+ * with the factory below.  The mock exposes a single shared instance whose
+ * mocks can be reset between tests via `resetWalletKit()`.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { vi, beforeEach } from "vitest";
+ * import {
+ *   mockWalletsKitFactory,
+ *   walletKitInstance,
+ *   resetWalletKit,
+ * } from "@/test/mocks/wallet";
+ *
+ * vi.mock("@creit.tech/stellar-wallets-kit", () => mockWalletsKitFactory());
+ *
+ * beforeEach(() => resetWalletKit());
+ * ```
+ */
+import { vi, type Mock } from "vitest";
+
+const FREIGHTER = "freighter";
+const ALBEDO = "albedo";
+const XBULL = "xbull";
+
+/** A representative testnet public key (Stellar G-prefix, 56 chars). */
+export const TEST_PUBLIC_KEY =
+  "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX";
+
+/** Shared mock instance produced by the StellarWalletsKit constructor. */
+export interface MockWalletsKitInstance {
+  openModal: Mock;
+  setWallet: Mock;
+  getAddress: Mock;
+  signTransaction: Mock;
+  /** Records the last wallet id passed to `setWallet`. */
+  selectedWalletId: string | null;
+  /**
+   * Triggers the `onWalletSelected` callback that the production hook passes
+   * to `kit.openModal`.  Tests call this to simulate the user picking a
+   * wallet from the modal.
+   */
+  pickWallet: (id?: string) => Promise<void>;
+}
+
+// A single, mutable instance.  The hook constructs the kit once at module
+// load, so we never replace this object — we only reset its internals.
+const sharedInstance = bootstrapInstance();
+
+/** Returns the shared kit instance used by the production hook. */
+export function walletKitInstance(): MockWalletsKitInstance {
+  return sharedInstance;
+}
+
+/**
+ * Resets the shared instance back to the default success behaviour.  Call
+ * this from `beforeEach` so state does not leak between tests.
+ */
+export function resetWalletKit() {
+  configureInstance(sharedInstance);
+}
+
+function bootstrapInstance(): MockWalletsKitInstance {
+  const inst = {
+    selectedWalletId: null,
+    openModal: vi.fn(),
+    setWallet: vi.fn(),
+    getAddress: vi.fn(),
+    signTransaction: vi.fn(),
+    pickWallet: async () => {
+      /* re-installed by configureInstance */
+    },
+  } as MockWalletsKitInstance;
+  configureInstance(inst);
+  return inst;
+}
+
+function configureInstance(inst: MockWalletsKitInstance) {
+  let onSelected: ((opt: { id: string }) => void | Promise<void>) | null = null;
+
+  inst.selectedWalletId = null;
+  inst.openModal.mockReset();
+  inst.setWallet.mockReset();
+  inst.getAddress.mockReset();
+  inst.signTransaction.mockReset();
+
+  inst.openModal.mockImplementation(({ onWalletSelected }) => {
+    onSelected = onWalletSelected;
+  });
+  inst.setWallet.mockImplementation((id: string) => {
+    inst.selectedWalletId = id;
+  });
+  inst.getAddress.mockResolvedValue({ address: TEST_PUBLIC_KEY });
+  inst.signTransaction.mockImplementation(async (xdr: string) => ({
+    signedTxXdr: `signed:${xdr}`,
+  }));
+
+  inst.pickWallet = async (id = FREIGHTER) => {
+    if (!onSelected) {
+      throw new Error(
+        "pickWallet() called before the production hook invoked openModal",
+      );
+    }
+    await onSelected({ id });
+  };
+}
+
+/**
+ * Returns a `vi.mock` factory that replaces the entire
+ * `@creit.tech/stellar-wallets-kit` module.  The constructor returns the
+ * shared mock instance so the hook and the test code see the same object.
+ */
+export function mockWalletsKitFactory() {
+  class StellarWalletsKit {
+    constructor(_opts: unknown) {
+      // Returning an object from a constructor makes `new` evaluate to that
+      // object, so the production hook ends up holding a direct reference to
+      // `sharedInstance` and sees `resetWalletKit()` mutations live.
+      return sharedInstance as unknown as StellarWalletsKit;
+    }
+  }
+
+  return {
+    StellarWalletsKit,
+    WalletNetwork: { TESTNET: "TESTNET", PUBLIC: "PUBLIC" },
+    FREIGHTER_ID: FREIGHTER,
+    ALBEDO_ID: ALBEDO,
+    XBULL_ID: XBULL,
+    FreighterModule: class {},
+    AlbedoModule: class {},
+    xBullModule: class {},
+  };
+}
+
+/**
+ * Convenience: configures the shared mock to reject on the *next* call to
+ * `getAddress`, simulating a user dismissing the wallet popup.
+ */
+export function mockWalletRejectsAddress(
+  message = "User rejected wallet connection",
+) {
+  walletKitInstance().getAddress.mockRejectedValueOnce(new Error(message));
+}


### PR DESCRIPTION
## Summary

This PR closes the test-coverage issues assigned to me, and unblocks them by repairing the contract source on `main` (which currently does not compile).

- **#473** — comprehensive credit-score unit tests (snapshot regression table, monotonicity property tests, tier-transition walk, score bounds, edge cases). Appended to the existing `test_credit.rs`, no removals.
- **#475** — unit tests for Badge, Button, Card, Input, Loader, Modal (143 frontend tests pass locally).
- **#476** — `useWallet` hook tests with a `vi.mock`'d `@creit.tech/stellar-wallets-kit` covering connect/disconnect/sign and a multi-instance store-sharing case. Adds a shared `src/test/mocks/wallet.ts` test double.
- **#474** — already covered by upstream's existing `test_integration.rs` and `test_integration_advanced.rs` (merged via #678). No further integration tests are added here.

## Build fixes (required for the contract to compile)

`upstream/main` does not currently build. These minimal repairs of incomplete merges are bundled here so the test work can run:

1. **`storage.rs`** — removed a duplicate temporary-key removal block at the end of `reset_creator_tip_index` (dead code from a bad merge that did not compile).
2. **`validation.rs`** — resolved literal `<<<<<<<HEAD ... >>>>>>>` conflict markers inside `check_rate_limit`. Kept the rate-limit body; the incoming branch was message-sanitization code that does not fit the function signature and is already present in `validate_message`.
3. **`storage.rs DataKey`** — added `PendingAdminChange` and `AdminChangeHistory` variants that storage functions reference but the enum was missing. Admin history is stored as a single `Vec` under one key (rather than one variant per id) because Soroban's `#[contracttype]` enum hits a metadata-size limit beyond ~49 variants.
4. **`types.rs`** — added `Default` impl for `VerificationType` (with `#[default] Unverified`) so `VerificationStatus` can derive `Default`.
5. **`leaderboard.rs`** — added `remove_from_all_leaderboards` helper.
6. **`profile.rs` / `stats.rs` / `lib.rs`** — updated 6 leaderboard call sites that were not migrated when the leaderboard functions gained a `LeaderboardPeriod` parameter. `AllTime` is used where the call site does not have a specific period in mind; the all-period helpers are used on deactivate / reactivate / deregister.

## Test plan

- [x] `cargo build --release --target wasm32-unknown-unknown` — contract source builds clean
- [x] `npx vitest run` for the 9 added/modified test files — **143/143 passing locally**
- [ ] Reviewer: please verify CI

## Notes for reviewer

- `cargo test --no-run` still surfaces ~313 pre-existing errors in upstream test files that reference an older API (e.g. `send_tip` 4-arg signature, `LeaderboardEntry.total_tips_received`, removed `propose_admin` method). These pre-date this PR and are out of its scope. The credit additions in this PR compile cleanly against the current source.
- This PR replaces the stale #685 (which was based on an out-of-date fork and conflicted on every contract file). #685 will be closed once this is opened.

Closes #473
Closes #475
Closes #476
Refs #474