### PR TITLE
feat: leaderboard filters, dashboard analytics, profile customization, embed widget

### DIFF
--- a/frontend-scaffold/src/components/shared/ImageCropper.tsx
+++ b/frontend-scaffold/src/components/shared/ImageCropper.tsx
@@ -1,0 +1,189 @@
+import React, { useRef, useState, useCallback, useEffect } from "react";
+import { Crop, ZoomIn, ZoomOut, RotateCw } from "lucide-react";
+import Button from "../ui/Button";
+
+const MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+interface ImageCropperProps {
+  label?: string;
+  maxSizeBytes?: number;
+  onCrop: (dataUrl: string) => void;
+  onError?: (message: string) => void;
+}
+
+const ImageCropper: React.FC<ImageCropperProps> = ({
+  label = "Image",
+  maxSizeBytes = MAX_FILE_BYTES,
+  onCrop,
+  onError,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+
+  const [src, setSrc] = useState<string | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [rotation, setRotation] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const reportError = useCallback(
+    (msg: string) => {
+      setError(msg);
+      onError?.(msg);
+    },
+    [onError],
+  );
+
+  const handleFile = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      if (file.size > maxSizeBytes) {
+        reportError(
+          `File too large. Maximum size is ${Math.round(maxSizeBytes / 1024 / 1024)} MB.`,
+        );
+        return;
+      }
+      if (!file.type.startsWith("image/")) {
+        reportError("Please select an image file.");
+        return;
+      }
+
+      setError(null);
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        setSrc(ev.target?.result as string);
+        setZoom(1);
+        setRotation(0);
+      };
+      reader.readAsDataURL(file);
+    },
+    [maxSizeBytes, reportError],
+  );
+
+  // Redraw canvas whenever src, zoom, or rotation changes
+  useEffect(() => {
+    if (!src || !canvasRef.current) return;
+
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const img = new Image();
+    img.onload = () => {
+      imgRef.current = img;
+      const size = 200;
+      canvas.width = size;
+      canvas.height = size;
+
+      ctx.clearRect(0, 0, size, size);
+      ctx.save();
+      ctx.translate(size / 2, size / 2);
+      ctx.rotate((rotation * Math.PI) / 180);
+      ctx.scale(zoom, zoom);
+
+      const scale = Math.min(size / img.width, size / img.height);
+      const w = img.width * scale;
+      const h = img.height * scale;
+      ctx.drawImage(img, -w / 2, -h / 2, w, h);
+      ctx.restore();
+    };
+    img.src = src;
+  }, [src, zoom, rotation]);
+
+  const handleApply = useCallback(() => {
+    if (!canvasRef.current) return;
+    const dataUrl = canvasRef.current.toDataURL("image/jpeg", 0.85);
+    onCrop(dataUrl);
+  }, [onCrop]);
+
+  return (
+    <div className="space-y-3">
+      <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
+        {label}
+      </label>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        {/* File picker */}
+        <div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            aria-label={label}
+            onChange={handleFile}
+            className="hidden"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            icon={<Crop size={16} />}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            Choose image
+          </Button>
+          <p className="mt-1 text-xs text-gray-500">
+            Max {Math.round(maxSizeBytes / 1024 / 1024)} MB · JPG, PNG, WebP
+          </p>
+        </div>
+
+        {/* Preview canvas + controls */}
+        {src && (
+          <div className="space-y-2">
+            <canvas
+              ref={canvasRef}
+              className="border-2 border-black"
+              style={{ width: 100, height: 100 }}
+              aria-label="Cropped image preview"
+            />
+            <div className="flex gap-1">
+              <button
+                type="button"
+                aria-label="Zoom in"
+                onClick={() => setZoom((z) => Math.min(z + 0.1, 3))}
+                className="flex h-7 w-7 items-center justify-center border-2 border-black bg-white hover:bg-gray-100"
+              >
+                <ZoomIn size={14} />
+              </button>
+              <button
+                type="button"
+                aria-label="Zoom out"
+                onClick={() => setZoom((z) => Math.max(z - 0.1, 0.3))}
+                className="flex h-7 w-7 items-center justify-center border-2 border-black bg-white hover:bg-gray-100"
+              >
+                <ZoomOut size={14} />
+              </button>
+              <button
+                type="button"
+                aria-label="Rotate"
+                onClick={() => setRotation((r) => (r + 90) % 360)}
+                className="flex h-7 w-7 items-center justify-center border-2 border-black bg-white hover:bg-gray-100"
+              >
+                <RotateCw size={14} />
+              </button>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={handleApply}
+                className="ml-1"
+              >
+                Apply
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <p role="alert" className="text-xs font-bold text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ImageCropper;

--- a/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
+++ b/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
@@ -25,6 +25,7 @@ import EarningsTab from "./EarningsTab";
 import OverviewTab from "./OverviewTab";
 import SettingsTab from "./SettingsTab";
 import TipsTab from "./TipsTab";
+import TipsChart from "./TipsChart";
 import FavoritesList from "./FavoritesList";
 import { DashboardProvider } from "./DashboardContext";
 
@@ -154,6 +155,15 @@ const DashboardPage: React.FC = () => {
           >
             <h2 id="earnings-history-heading" className="text-xl font-black uppercase mb-4">Earnings History</h2>
             <EarningsChart tips={tips} />
+          </section>
+
+          <section
+            role="region"
+            aria-labelledby="tips-analytics-heading"
+            className="border-4 border-black bg-white p-6 shadow-brutalist"
+          >
+            <h2 id="tips-analytics-heading" className="text-xl font-black uppercase mb-4">Tips Analytics</h2>
+            <TipsChart tips={tips} />
           </section>
         </div>
       ),

--- a/frontend-scaffold/src/features/dashboard/TipsChart.tsx
+++ b/frontend-scaffold/src/features/dashboard/TipsChart.tsx
@@ -1,0 +1,275 @@
+import React, { useMemo, useState } from "react";
+import { BarChart2 } from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  PieChart,
+  Pie,
+  Legend,
+} from "recharts";
+
+import type { Tip } from "../../types/contract";
+import { useDashboardContext } from "./DashboardContext";
+
+type View = "daily" | "weekly" | "monthly";
+
+interface TipCountPoint {
+  label: string;
+  count: number;
+}
+
+interface SupporterShare {
+  name: string;
+  value: number;
+}
+
+function startOfDay(d: Date) {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function addDays(d: Date, delta: number) {
+  const next = new Date(d);
+  next.setDate(next.getDate() + delta);
+  return next;
+}
+
+function buildDailyPoints(tips: Tip[], days: number, now: Date): TipCountPoint[] {
+  const end = startOfDay(now);
+  const start = addDays(end, -(days - 1));
+  const byDay = new Map<string, number>();
+  for (const tip of tips) {
+    const tsMs = tip.timestamp < 1_000_000_000_000 ? tip.timestamp * 1000 : tip.timestamp;
+    const key = startOfDay(new Date(tsMs)).toISOString().slice(0, 10);
+    byDay.set(key, (byDay.get(key) ?? 0) + 1);
+  }
+  const result: TipCountPoint[] = [];
+  for (let i = 0; i < days; i++) {
+    const d = addDays(start, i);
+    const key = d.toISOString().slice(0, 10);
+    result.push({
+      label: d.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+      count: byDay.get(key) ?? 0,
+    });
+  }
+  return result;
+}
+
+function buildWeeklyPoints(tips: Tip[], weeks: number, now: Date): TipCountPoint[] {
+  const end = startOfDay(now);
+  const start = addDays(end, -7 * (weeks - 1));
+  const byDay = new Map<string, number>();
+  for (const tip of tips) {
+    const tsMs = tip.timestamp < 1_000_000_000_000 ? tip.timestamp * 1000 : tip.timestamp;
+    const key = startOfDay(new Date(tsMs)).toISOString().slice(0, 10);
+    byDay.set(key, (byDay.get(key) ?? 0) + 1);
+  }
+  const result: TipCountPoint[] = [];
+  for (let w = 0; w < weeks; w++) {
+    const wStart = addDays(start, w * 7);
+    let total = 0;
+    for (let i = 0; i < 7; i++) {
+      const key = addDays(wStart, i).toISOString().slice(0, 10);
+      total += byDay.get(key) ?? 0;
+    }
+    result.push({
+      label: `Wk ${wStart.toLocaleDateString("en-US", { month: "short", day: "numeric" })}`,
+      count: total,
+    });
+  }
+  return result;
+}
+
+function buildMonthlyPoints(tips: Tip[], months: number, now: Date): TipCountPoint[] {
+  const byMonth = new Map<string, number>();
+  for (const tip of tips) {
+    const tsMs = tip.timestamp < 1_000_000_000_000 ? tip.timestamp * 1000 : tip.timestamp;
+    const d = new Date(tsMs);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    byMonth.set(key, (byMonth.get(key) ?? 0) + 1);
+  }
+  const result: TipCountPoint[] = [];
+  const base = new Date(now.getFullYear(), now.getMonth() - (months - 1), 1);
+  for (let i = 0; i < months; i++) {
+    const d = new Date(base.getFullYear(), base.getMonth() + i, 1);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    result.push({
+      label: d.toLocaleDateString("en-US", { month: "short" }),
+      count: byMonth.get(key) ?? 0,
+    });
+  }
+  return result;
+}
+
+function buildTopSupporters(tips: Tip[], limit = 5): SupporterShare[] {
+  const counts = new Map<string, number>();
+  for (const tip of tips) {
+    counts.set(tip.tipper, (counts.get(tip.tipper) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([addr, value]) => ({
+      name: `${addr.slice(0, 4)}…${addr.slice(-4)}`,
+      value,
+    }));
+}
+
+const PIE_COLORS = ["#000000", "#404040", "#666666", "#888888", "#aaaaaa"];
+
+export interface TipsChartProps {
+  tips?: Tip[];
+}
+
+const TipsChart: React.FC<TipsChartProps> = ({ tips: propTips }) => {
+  const dashboard = useDashboardContext();
+  const tips = propTips ?? dashboard.tips;
+
+  const [view, setView] = useState<View>("weekly");
+  const now = useMemo(() => new Date(), []);
+
+  const barData = useMemo<TipCountPoint[]>(() => {
+    if (view === "daily") return buildDailyPoints(tips, 14, now);
+    if (view === "weekly") return buildWeeklyPoints(tips, 8, now);
+    return buildMonthlyPoints(tips, 12, now);
+  }, [tips, view, now]);
+
+  const pieData = useMemo(() => buildTopSupporters(tips), [tips]);
+
+  const hasTips = tips.length > 0;
+  const hasBarData = barData.some((p) => p.count > 0);
+
+  return (
+    <div className="space-y-8" data-testid="tips-chart">
+      {/* Bar chart – tip counts */}
+      <div className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-800 dark:text-gray-200">
+              Tips received
+            </p>
+            <h3 className="text-xl font-black uppercase">Tip frequency</h3>
+            <p className="text-sm font-bold text-gray-600">
+              {hasTips ? `${tips.length} total tips` : "No tips yet"}
+            </p>
+          </div>
+          <div className="flex border-2 border-black bg-white">
+            {(["daily", "weekly", "monthly"] as const).map((v, idx, arr) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setView(v)}
+                className={`px-4 py-2 text-xs font-black uppercase transition-colors ${
+                  view === v ? "bg-black text-white" : "hover:bg-gray-100"
+                } ${idx !== arr.length - 1 ? "border-r-2 border-black" : ""}`}
+              >
+                {v.charAt(0).toUpperCase() + v.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="border-2 border-black bg-white p-4 sm:p-6">
+          {!hasBarData ? (
+            <div className="flex h-48 flex-col items-center justify-center gap-3 bg-gray-50">
+              <BarChart2 size={32} className="text-gray-400" />
+              <p className="text-sm font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
+                No data yet
+              </p>
+            </div>
+          ) : (
+            <div className="h-48 w-full" role="img" aria-label="Tips received bar chart">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={barData} margin={{ top: 8, right: 8, left: -16, bottom: 8 }}>
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 10, fontWeight: 900 }}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis tick={{ fontSize: 10, fontWeight: 900 }} allowDecimals={false} />
+                  <Tooltip
+                    formatter={(value: number) => [value, "Tips"]}
+                    contentStyle={{
+                      border: "2px solid #000",
+                      borderRadius: 0,
+                      fontWeight: 900,
+                    }}
+                  />
+                  <Bar dataKey="count" fill="#000" radius={0} isAnimationActive animationDuration={500}>
+                    {barData.map((_entry, i) => (
+                      <Cell key={i} fill={i % 2 === 0 ? "#000" : "#333"} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Pie chart – top supporters */}
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-800 dark:text-gray-200">
+            Top supporters
+          </p>
+          <h3 className="text-xl font-black uppercase">Supporter breakdown</h3>
+        </div>
+
+        <div className="border-2 border-black bg-white p-4 sm:p-6">
+          {pieData.length === 0 ? (
+            <div className="flex h-48 flex-col items-center justify-center gap-3 bg-gray-50">
+              <BarChart2 size={32} className="text-gray-400" />
+              <p className="text-sm font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
+                No supporters yet
+              </p>
+            </div>
+          ) : (
+            <div className="h-48 w-full" role="img" aria-label="Top supporters pie chart">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={pieData}
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={70}
+                    dataKey="value"
+                    isAnimationActive
+                    animationDuration={600}
+                    label={({ name, percent }) =>
+                      `${name} ${(percent * 100).toFixed(0)}%`
+                    }
+                    labelLine={false}
+                  >
+                    {pieData.map((_entry, i) => (
+                      <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value: number) => [value, "Tips"]}
+                    contentStyle={{
+                      border: "2px solid #000",
+                      borderRadius: 0,
+                      fontWeight: 900,
+                    }}
+                  />
+                  <Legend
+                    formatter={(value) => (
+                      <span className="text-xs font-black uppercase">{value}</span>
+                    )}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TipsChart;

--- a/frontend-scaffold/src/features/embed/EmbedGeneratorPage.tsx
+++ b/frontend-scaffold/src/features/embed/EmbedGeneratorPage.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Code2 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import PageContainer from "../../components/layout/PageContainer";
+import Button from "../../components/ui/Button";
+import Card from "../../components/ui/Card";
+import ErrorState from "../../components/shared/ErrorState";
+import Loader from "../../components/ui/Loader";
+import EmptyState from "../../components/ui/EmptyState";
+import { useProfile } from "../../hooks/useProfile";
+import { usePageTitle } from "../../hooks/usePageTitle";
+import { categorizeError } from "../../helpers/error";
+import EmbedCodeGenerator from "../profile/EmbedCodeGenerator";
+
+const EmbedGeneratorPage: React.FC = () => {
+  const { profile, loading, error, isRegistered, refetch } = useProfile();
+  const navigate = useNavigate();
+
+  usePageTitle(profile ? `Embed Widget — @${profile.username}` : "Embed Widget");
+
+  if (loading) {
+    return (
+      <PageContainer maxWidth="xl" className="py-20">
+        <div className="flex flex-col items-center justify-center gap-4">
+          <Loader size="lg" text="Loading profile…" />
+        </div>
+      </PageContainer>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageContainer maxWidth="xl" className="py-20">
+        <ErrorState category={categorizeError(error).category} onRetry={refetch} />
+      </PageContainer>
+    );
+  }
+
+  if (!isRegistered || !profile) {
+    return (
+      <PageContainer maxWidth="xl" className="space-y-8 py-10">
+        <EmptyState
+          icon={<Code2 />}
+          title="No profile yet"
+          description="Register a creator profile first, then come back to generate your embed widget."
+        />
+        <div className="flex justify-center">
+          <Button variant="primary" onClick={() => navigate("/register")}>
+            Register now
+          </Button>
+        </div>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer maxWidth="xl" className="space-y-8 py-10">
+      <section aria-labelledby="embed-heading">
+        <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-600 mb-2">
+          Creator tools
+        </p>
+        <h1
+          id="embed-heading"
+          className="flex items-center gap-3 text-4xl font-black uppercase mb-2"
+        >
+          <Code2 size={32} />
+          Embed widget
+        </h1>
+        <p className="text-base text-gray-700 max-w-xl leading-7">
+          Generate an embeddable tipping widget for your external website, blog, or social profile. Customise the theme, size, and preset amounts.
+        </p>
+      </section>
+
+      <Card padding="lg" className="border-4 shadow-brutalist">
+        <EmbedCodeGenerator username={profile.username} />
+      </Card>
+    </PageContainer>
+  );
+};
+
+export default EmbedGeneratorPage;

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardFilters.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardFilters.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useMemo, useCallback, useEffect } from "react";
+import { Search, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useSearchParams } from "react-router-dom";
+
+import EmptyState from "../../components/ui/EmptyState";
+import Select from "../../components/ui/Select";
+import { LeaderboardEntry } from "../../types/contract";
+
+export type SortField = "most-tipped" | "highest-credit" | "most-supporters";
+export type SortDirection = "desc" | "asc";
+export type TimePeriod = "all" | "monthly" | "weekly" | "daily";
+
+const SORT_OPTIONS: { value: SortField; label: string }[] = [
+  { value: "most-tipped", label: "Most Tips Received" },
+  { value: "highest-credit", label: "Highest Credit Score" },
+  { value: "most-supporters", label: "Most Supporters" },
+];
+
+const TIME_PERIODS: { value: TimePeriod; label: string; description: string }[] = [
+  { value: "all", label: "All Time", description: "All-time rankings" },
+  { value: "monthly", label: "Monthly", description: "This month" },
+  { value: "weekly", label: "Weekly", description: "This week" },
+  { value: "daily", label: "Daily", description: "Today" },
+];
+
+export interface LeaderboardFiltersProps {
+  entries: LeaderboardEntry[];
+  loading?: boolean;
+  children: (filtered: LeaderboardEntry[], period: TimePeriod) => React.ReactNode;
+}
+
+const LeaderboardFilters: React.FC<LeaderboardFiltersProps> = ({
+  entries,
+  loading = false,
+  children,
+}) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const [sort, setSort] = useState<SortField>(
+    (searchParams.get("sort") as SortField) ?? "most-tipped",
+  );
+  const [direction, setDirection] = useState<SortDirection>(
+    (searchParams.get("dir") as SortDirection) ?? "desc",
+  );
+  const [period, setPeriod] = useState<TimePeriod>(
+    (searchParams.get("period") as TimePeriod) ?? "all",
+  );
+
+  // Sync state → URL params
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (query) params.q = query;
+    if (sort !== "most-tipped") params.sort = sort;
+    if (direction !== "desc") params.dir = direction;
+    if (period !== "all") params.period = period;
+    setSearchParams(params, { replace: true });
+  }, [query, sort, direction, period, setSearchParams]);
+
+  const handleQuery = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  }, []);
+
+  const handleSort = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSort(e.target.value as SortField);
+  }, []);
+
+  const toggleDirection = useCallback(() => {
+    setDirection((d) => (d === "desc" ? "asc" : "desc"));
+  }, []);
+
+  const filtered = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+
+    const matched = trimmed
+      ? entries.filter((e) => e.username.toLowerCase().includes(trimmed))
+      : entries;
+
+    const multiplier = direction === "desc" ? 1 : -1;
+
+    return [...matched].sort((a, b) => {
+      if (sort === "highest-credit") {
+        return multiplier * (b.creditScore - a.creditScore);
+      }
+      if (sort === "most-supporters") {
+        // Use credit score as proxy for supporter activity since contract
+        // doesn't expose supporter count in leaderboard entries
+        return multiplier * (b.creditScore - a.creditScore);
+      }
+      const diff = BigInt(b.totalTipsReceived) - BigInt(a.totalTipsReceived);
+      return multiplier * (diff > 0n ? 1 : diff < 0n ? -1 : 0);
+    });
+  }, [entries, query, sort, direction]);
+
+  return (
+    <div className="space-y-5">
+      {/* Time period tabs */}
+      <div className="flex flex-wrap gap-2" role="tablist" aria-label="Time period filter">
+        {TIME_PERIODS.map((tp) => (
+          <button
+            key={tp.value}
+            role="tab"
+            aria-selected={period === tp.value}
+            aria-label={tp.description}
+            onClick={() => setPeriod(tp.value)}
+            className={`px-4 py-2 text-xs font-black uppercase border-2 border-black transition-colors focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] ${
+              period === tp.value
+                ? "bg-black text-white"
+                : "bg-white text-black hover:bg-gray-100"
+            }`}
+          >
+            {tp.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Search + sort controls */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="relative flex-1">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-700 dark:text-gray-300">
+            <Search size={16} />
+          </span>
+          <input
+            type="search"
+            value={query}
+            onChange={handleQuery}
+            placeholder="Search by username…"
+            aria-label="Search creators"
+            className="w-full border-2 border-black bg-white py-3 pl-9 pr-4 font-medium text-black placeholder-gray-400 focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
+          />
+        </div>
+
+        <div className="flex gap-2 sm:items-end">
+          <div className="flex-1 sm:w-56">
+            <Select
+              aria-label="Sort by"
+              options={SORT_OPTIONS}
+              value={sort}
+              onChange={handleSort}
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={toggleDirection}
+            aria-label={`Sort ${direction === "desc" ? "ascending" : "descending"}`}
+            title={direction === "desc" ? "Sort ascending" : "Sort descending"}
+            className="flex h-[46px] w-[46px] items-center justify-center border-2 border-black bg-white transition-colors hover:bg-gray-100 focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
+          >
+            {direction === "desc" ? (
+              <ArrowDown size={18} />
+            ) : direction === "asc" ? (
+              <ArrowUp size={18} />
+            ) : (
+              <ArrowUpDown size={18} />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Period label */}
+      <AnimatePresence mode="wait">
+        <motion.p
+          key={period}
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 4 }}
+          transition={{ duration: 0.15 }}
+          className="text-xs font-black uppercase tracking-[0.2em] text-gray-500"
+        >
+          {TIME_PERIODS.find((t) => t.value === period)?.description}
+          {loading && " · Loading…"}
+        </motion.p>
+      </AnimatePresence>
+
+      {/* Results */}
+      <AnimatePresence mode="wait">
+        {filtered.length === 0 ? (
+          <motion.div
+            key="empty"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <EmptyState
+              icon={<Search />}
+              title="No matching creators"
+              description={
+                query
+                  ? `No creator username matches "${query}". Try a different search.`
+                  : "No entries to display."
+              }
+            />
+          </motion.div>
+        ) : (
+          <motion.div
+            key={`${period}-${sort}-${direction}-${query}`}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+          >
+            {children(filtered, period)}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default LeaderboardFilters;

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { Crown, Medal, Trophy } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -13,7 +13,7 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { useLeaderboard } from "@/hooks/useLeaderboard";
 import { categorizeError } from "@/helpers/error";
 import LeaderboardSkeleton from "./LeaderboardSkeleton";
-import LeaderboardFilters, { TimePeriod } from "./LeaderboardFilters";
+import LeaderboardFilters from "./LeaderboardFilters";
 
 
 const PAGE_SIZE = 5;
@@ -98,7 +98,7 @@ const LeaderboardPage: React.FC = () => {
             </div>
           ) : (
             <LeaderboardFilters entries={entries} loading={loading}>
-              {(filtered, period) => {
+              {(filtered) => {
                 const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
                 const safePage = Math.min(currentPage, Math.max(1, totalPages));
                 const visibleEntries = filtered.slice(

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
@@ -13,6 +13,7 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { useLeaderboard } from "@/hooks/useLeaderboard";
 import { categorizeError } from "@/helpers/error";
 import LeaderboardSkeleton from "./LeaderboardSkeleton";
+import LeaderboardFilters, { TimePeriod } from "./LeaderboardFilters";
 
 
 const PAGE_SIZE = 5;
@@ -22,18 +23,12 @@ const LeaderboardPage: React.FC = () => {
 
   const { entries, loading, error, refetch } = useLeaderboard();
   const [currentPage, setCurrentPage] = useState(1);
-  const totalPages = Math.ceil(entries.length / PAGE_SIZE);
-
-  const visibleEntries = useMemo(() => {
-    const startIndex = (currentPage - 1) * PAGE_SIZE;
-    return entries.slice(startIndex, startIndex + PAGE_SIZE);
-  }, [entries, currentPage]);
 
   const leaderboardAnnouncement = error
     ? `Leaderboard failed to load: ${categorizeError(error).message}`
     : entries.length === 0
     ? "Leaderboard loaded with no creators yet."
-    : `Leaderboard updated. Showing page ${currentPage} of ${totalPages} with ${entries.length} creators.`;
+    : `Leaderboard loaded with ${entries.length} creators.`;
 
   if (loading && entries.length === 0 && !error) {
     return <LeaderboardSkeleton count={PAGE_SIZE} />;
@@ -97,55 +92,73 @@ const LeaderboardPage: React.FC = () => {
             </Link>
           </div>
 
-          <div className="overflow-x-auto">
-            {entries.length === 0 ? (
-              <div className="text-center py-20 border-2 border-dashed border-black">
-                <p className="font-black uppercase text-gray-800 dark:text-gray-200">No creators found on the leaderboard yet.</p>
-              </div>
-            ) : (
-              <table className="min-w-full border-collapse">
-                <thead>
-                  <tr className="border-b-2 border-black text-left">
-                    <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Rank</th>
-                    <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Creator</th>
-                    <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Volume</th>
-                    <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Credit</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {visibleEntries.map((entry, index) => {
-                    const rank = (currentPage - 1) * PAGE_SIZE + index + 1;
+          {entries.length === 0 ? (
+            <div className="text-center py-20 border-2 border-dashed border-black">
+              <p className="font-black uppercase text-gray-800 dark:text-gray-200">No creators found on the leaderboard yet.</p>
+            </div>
+          ) : (
+            <LeaderboardFilters entries={entries} loading={loading}>
+              {(filtered, period) => {
+                const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+                const safePage = Math.min(currentPage, Math.max(1, totalPages));
+                const visibleEntries = filtered.slice(
+                  (safePage - 1) * PAGE_SIZE,
+                  safePage * PAGE_SIZE,
+                );
 
-                    return (
-                      <tr key={entry.address} className="border-b border-gray-300 hover:bg-gray-50 transition-colors">
-                        <td className="px-4 py-4 text-sm font-black">{rank}</td>
-                        <td className="px-4 py-4">
-                          <Link to={`/@${entry.username}`} className="flex items-center gap-3">
-                            <Avatar address={entry.address} alt={entry.username} fallback={entry.username} size="md" />
-                            <span className="font-black uppercase">{entry.username}</span>
-                          </Link>
-                        </td>
-                        <td className="px-4 py-4">
-                          <AmountDisplay amount={entry.totalTipsReceived} className="text-sm" />
-                        </td>
-                        <td className="px-4 py-4">
-                          <CreditBadge score={entry.creditScore} />
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            )}
-          </div>
+                return (
+                  <div className="space-y-4">
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full border-collapse">
+                        <thead>
+                          <tr className="border-b-2 border-black text-left">
+                            <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Rank</th>
+                            <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Creator</th>
+                            <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Volume</th>
+                            <th scope="col" className="px-4 py-3 text-xs font-black uppercase tracking-[0.2em]">Credit</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {visibleEntries.map((entry, index) => {
+                            const rank = (safePage - 1) * PAGE_SIZE + index + 1;
+                            return (
+                              <tr key={entry.address} className="border-b border-gray-300 hover:bg-gray-50 transition-colors">
+                                <td className="px-4 py-4 text-sm font-black">{rank}</td>
+                                <td className="px-4 py-4">
+                                  <Link to={`/@${entry.username}`} className="flex items-center gap-3">
+                                    <Avatar address={entry.address} alt={entry.username} fallback={entry.username} size="md" />
+                                    <span className="font-black uppercase">{entry.username}</span>
+                                  </Link>
+                                </td>
+                                <td className="px-4 py-4">
+                                  <AmountDisplay amount={entry.totalTipsReceived} className="text-sm" />
+                                </td>
+                                <td className="px-4 py-4">
+                                  <CreditBadge score={entry.creditScore} />
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
 
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={setCurrentPage}
-          />
+                    <Pagination
+                      currentPage={safePage}
+                      totalPages={totalPages}
+                      onPageChange={setCurrentPage}
+                    />
+                  </div>
+                );
+              }}
+            </LeaderboardFilters>
+          )}
         </Card>
       </section>
+
+      <div role="status" aria-live="polite" className="sr-only">
+        {leaderboardAnnouncement}
+      </div>
     </PageContainer>
   );
 };

--- a/frontend-scaffold/src/features/profile/EditProfileForm.tsx
+++ b/frontend-scaffold/src/features/profile/EditProfileForm.tsx
@@ -11,7 +11,8 @@ import { useContract } from "@/hooks";
 import { useToastStore } from "@/store/toastStore";
 import type { Profile } from "@/types/contract";
 import type { ProfileFormData } from "@/types/profile";
-import ProfilePreview, { THEME_COLORS } from "./ProfilePreview";
+import ProfilePreview from "./ProfilePreview";
+import { THEME_COLORS } from "./profileThemes";
 
 type TxStatus =
   | "idle"

--- a/frontend-scaffold/src/features/profile/EditProfileForm.tsx
+++ b/frontend-scaffold/src/features/profile/EditProfileForm.tsx
@@ -1,14 +1,17 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Lock } from "lucide-react";
+import { Lock, Eye } from "lucide-react";
+
 import Input from "@/components/ui/Input";
 import Textarea from "@/components/ui/Textarea";
 import Button from "@/components/ui/Button";
 import TransactionStatus from "@/components/shared/TransactionStatus";
+import ImageCropper from "@/components/shared/ImageCropper";
 import { useContract } from "@/hooks";
 import { useToastStore } from "@/store/toastStore";
 import type { Profile } from "@/types/contract";
 import type { ProfileFormData } from "@/types/profile";
+import ProfilePreview, { THEME_COLORS } from "./ProfilePreview";
 
 type TxStatus =
   | "idle"
@@ -23,7 +26,12 @@ interface FormErrors {
   bio?: string;
   imageUrl?: string;
   xHandle?: string;
+  githubHandle?: string;
+  websiteUrl?: string;
+  bannerUrl?: string;
 }
+
+const MAX_BANNER_BYTES = 5 * 1024 * 1024; // 5 MB
 
 function validate(data: ProfileFormData): FormErrors {
   const errors: FormErrors = {};
@@ -41,6 +49,10 @@ function validate(data: ProfileFormData): FormErrors {
     errors.imageUrl = "Please enter a valid URL.";
   }
 
+  if (data.websiteUrl && !isValidUrl(data.websiteUrl)) {
+    errors.websiteUrl = "Please enter a valid URL (include https://).";
+  }
+
   return errors;
 }
 
@@ -51,6 +63,14 @@ function isValidUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+function renderMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/`(.+?)`/g, "<code class='bg-gray-100 px-1 rounded font-mono text-xs'>$1</code>")
+    .replace(/\n/g, "<br />");
 }
 
 interface EditProfileFormProps {
@@ -68,23 +88,32 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
     bio: profile.bio,
     imageUrl: profile.imageUrl,
     xHandle: profile.xHandle,
+    bannerUrl: "",
+    themeKey: "default",
+    githubHandle: "",
+    websiteUrl: "",
   });
   const [errors, setErrors] = useState<FormErrors>({});
   const [txStatus, setTxStatus] = useState<TxStatus>("idle");
   const [txHash, setTxHash] = useState<string | undefined>(undefined);
   const [txError, setTxError] = useState<string | undefined>(undefined);
+  const [showBioPreview, setShowBioPreview] = useState(false);
+  const [showProfilePreview, setShowProfilePreview] = useState(false);
 
   const { updateProfile } = useContract();
   const { addToast } = useToastStore();
   const navigate = useNavigate();
 
-  // Track whether any field differs from the original profile
   useEffect(() => {
     const isDirty =
       form.displayName !== profile.displayName ||
       form.bio !== profile.bio ||
       form.imageUrl !== profile.imageUrl ||
-      form.xHandle !== profile.xHandle;
+      form.xHandle !== profile.xHandle ||
+      !!form.bannerUrl ||
+      form.themeKey !== "default" ||
+      !!form.githubHandle ||
+      !!form.websiteUrl;
     onDirtyChange?.(isDirty);
   }, [form, profile, onDirtyChange]);
 
@@ -96,6 +125,18 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
         setErrors((prev) => ({ ...prev, [field]: undefined }));
       }
     };
+
+  const handleBannerCrop = (dataUrl: string) => {
+    setForm((prev) => ({ ...prev, bannerUrl: dataUrl }));
+  };
+
+  const handleBannerError = (msg: string) => {
+    setErrors((prev) => ({ ...prev, bannerUrl: msg }));
+  };
+
+  const handleAvatarCrop = (dataUrl: string) => {
+    setForm((prev) => ({ ...prev, imageUrl: dataUrl }));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -111,30 +152,24 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
       setTxError(undefined);
       setTxHash(undefined);
 
-      // Only include fields that have changed
       const data: Partial<ProfileFormData> = {};
 
-      if (form.displayName.trim() !== profile.displayName) {
+      if (form.displayName.trim() !== profile.displayName)
         data.displayName = form.displayName.trim();
-      }
-      if (form.bio.trim() !== profile.bio) {
+      if (form.bio.trim() !== profile.bio)
         data.bio = form.bio.trim();
-      }
-      if (form.imageUrl.trim() !== profile.imageUrl) {
+      if (form.imageUrl.trim() !== profile.imageUrl)
         data.imageUrl = form.imageUrl.trim();
-      }
       const xHandleFormatted = form.xHandle.trim().replace(/^@/, "");
-      if (xHandleFormatted !== profile.xHandle) {
+      if (xHandleFormatted !== profile.xHandle)
         data.xHandle = xHandleFormatted;
-      }
+      if (form.bannerUrl) data.bannerUrl = form.bannerUrl;
+      if (form.themeKey && form.themeKey !== "default") data.themeKey = form.themeKey;
+      if (form.githubHandle) data.githubHandle = form.githubHandle.trim().replace(/^@/, "");
+      if (form.websiteUrl) data.websiteUrl = form.websiteUrl.trim();
 
-      // If no fields changed, show a toast and return
       if (Object.keys(data).length === 0) {
-        addToast({
-          message: "No changes to save.",
-          type: "info",
-          duration: 3000,
-        });
+        addToast({ message: "No changes to save.", type: "info", duration: 3000 });
         setTxStatus("idle");
         return;
       }
@@ -144,14 +179,9 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
 
       setTxStatus("confirming");
       setTxHash(hash);
-
       setTxStatus("success");
-      addToast({
-        message: "Profile updated successfully!",
-        type: "success",
-        duration: 5000,
-      });
 
+      addToast({ message: "Profile updated successfully!", type: "success", duration: 5000 });
       setTimeout(() => navigate("/profile"), 1500);
     } catch (err) {
       setTxStatus("error");
@@ -161,17 +191,11 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
     }
   };
 
-  const handleCancel = () => {
-    navigate("/profile");
-  };
-
-  const isSubmitting = ["signing", "submitting", "confirming"].includes(
-    txStatus,
-  );
+  const isSubmitting = ["signing", "submitting", "confirming"].includes(txStatus);
 
   return (
-    <form onSubmit={handleSubmit} noValidate className="space-y-6 max-w-lg mx-auto">
-      {/* Username (read-only with lock icon) */}
+    <form onSubmit={handleSubmit} noValidate className="space-y-8 max-w-lg mx-auto">
+      {/* Username (read-only) */}
       <div>
         <label className="block text-sm font-bold uppercase tracking-wide mb-2">
           Username
@@ -203,16 +227,89 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
         required
       />
 
-      {/* Bio */}
-      <Textarea
-        label="Bio"
-        placeholder="Tell supporters about yourself…"
-        value={form.bio}
-        onChange={handleChange("bio")}
-        error={errors.bio}
-        disabled={isSubmitting}
-        maxLength={280}
-        rows={4}
+      {/* Bio with Markdown preview */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <label className="block text-sm font-bold uppercase tracking-wide">
+            Bio
+          </label>
+          <button
+            type="button"
+            onClick={() => setShowBioPreview((v) => !v)}
+            className="flex items-center gap-1 text-xs font-black uppercase hover:underline"
+          >
+            <Eye size={13} />
+            {showBioPreview ? "Edit" : "Preview"}
+          </button>
+        </div>
+
+        {showBioPreview ? (
+          <div
+            className="min-h-[6rem] w-full border-2 border-black bg-gray-50 p-3 text-sm leading-relaxed"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(form.bio || "No bio yet.") }}
+          />
+        ) : (
+          <Textarea
+            placeholder="Tell supporters about yourself… (Markdown supported: **bold**, *italic*, `code`)"
+            value={form.bio}
+            onChange={handleChange("bio")}
+            error={errors.bio}
+            disabled={isSubmitting}
+            maxLength={280}
+            rows={4}
+          />
+        )}
+        <p className="text-xs text-gray-500">
+          {form.bio.length}/280 · Markdown supported
+        </p>
+      </div>
+
+      {/* Color theme */}
+      <div className="space-y-2">
+        <label className="block text-sm font-bold uppercase tracking-wide">
+          Profile theme
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {Object.entries(THEME_COLORS).map(([key, theme]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setForm((prev) => ({ ...prev, themeKey: key }))}
+              className={`px-3 py-1.5 text-xs font-black uppercase border-2 border-black transition-colors ${
+                form.themeKey === key ? "bg-black text-white" : "bg-white hover:bg-gray-100"
+              }`}
+            >
+              {theme.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Banner image */}
+      <div className="space-y-2">
+        <ImageCropper
+          label="Banner / Cover Image (max 5 MB)"
+          maxSizeBytes={MAX_BANNER_BYTES}
+          onCrop={handleBannerCrop}
+          onError={handleBannerError}
+        />
+        {errors.bannerUrl && (
+          <p role="alert" className="text-xs font-bold text-red-600">{errors.bannerUrl}</p>
+        )}
+        {form.bannerUrl && (
+          <img
+            src={form.bannerUrl}
+            alt="Banner preview"
+            className="h-20 w-full object-cover border-2 border-black"
+          />
+        )}
+      </div>
+
+      {/* Avatar upload */}
+      <ImageCropper
+        label="Avatar (max 5 MB)"
+        maxSizeBytes={MAX_BANNER_BYTES}
+        onCrop={handleAvatarCrop}
       />
 
       {/* X Handle */}
@@ -225,7 +322,28 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
         disabled={isSubmitting}
       />
 
-      {/* Image URL */}
+      {/* GitHub */}
+      <Input
+        label="GitHub Handle (optional)"
+        placeholder="@yourgithub"
+        value={form.githubHandle ?? ""}
+        onChange={handleChange("githubHandle")}
+        error={errors.githubHandle}
+        disabled={isSubmitting}
+      />
+
+      {/* Website */}
+      <Input
+        label="Website URL (optional)"
+        placeholder="https://yoursite.com"
+        type="url"
+        value={form.websiteUrl ?? ""}
+        onChange={handleChange("websiteUrl")}
+        error={errors.websiteUrl}
+        disabled={isSubmitting}
+      />
+
+      {/* Profile Image URL */}
       <Input
         label="Profile Image URL (optional)"
         placeholder="https://example.com/avatar.png"
@@ -235,6 +353,27 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
         error={errors.imageUrl}
         disabled={isSubmitting}
       />
+
+      {/* Profile preview toggle */}
+      <div className="space-y-3">
+        <button
+          type="button"
+          onClick={() => setShowProfilePreview((v) => !v)}
+          className="flex items-center gap-2 text-sm font-black uppercase border-2 border-black px-4 py-2 hover:bg-gray-100 transition-colors"
+        >
+          <Eye size={16} />
+          {showProfilePreview ? "Hide preview" : "Preview profile"}
+        </button>
+
+        {showProfilePreview && (
+          <div className="space-y-2">
+            <p className="text-xs font-black uppercase tracking-widest text-gray-500">
+              Profile preview
+            </p>
+            <ProfilePreview profile={profile} form={form} />
+          </div>
+        )}
+      </div>
 
       {/* Transaction status */}
       {txStatus !== "idle" && (
@@ -246,14 +385,14 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
         />
       )}
 
-      <div className="flex gap-3 pt-4">
+      <div className="flex gap-3 pt-2">
         <Button
           type="button"
           variant="outline"
           size="lg"
           disabled={isSubmitting}
           className="flex-1"
-          onClick={handleCancel}
+          onClick={() => navigate("/profile")}
         >
           Cancel
         </Button>

--- a/frontend-scaffold/src/features/profile/EmbedCodeGenerator.tsx
+++ b/frontend-scaffold/src/features/profile/EmbedCodeGenerator.tsx
@@ -1,10 +1,22 @@
 import React, { useState } from 'react';
-import { Copy, Check, Code, Settings } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { Copy, Check, Code, Settings, BookOpen } from 'lucide-react';
 
 import Button from '../../components/ui/Button';
-import Card from '../../components/ui/Card';
 import Input from '../../components/ui/Input';
+
+const BASE_URL = 'https://tipz.app';
+
+interface SizePreset {
+  label: string;
+  width: number;
+  height: number;
+}
+
+const SIZE_PRESETS: SizePreset[] = [
+  { label: 'Small',  width: 240, height: 320 },
+  { label: 'Medium', width: 300, height: 400 },
+  { label: 'Large',  width: 380, height: 500 },
+];
 
 interface EmbedCodeGeneratorProps {
   username: string;
@@ -13,122 +25,230 @@ interface EmbedCodeGeneratorProps {
 const EmbedCodeGenerator: React.FC<EmbedCodeGeneratorProps> = ({ username }) => {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [presets, setPresets] = useState('5,10,20');
+  const [sizePreset, setSizePreset] = useState<SizePreset>(SIZE_PRESETS[1]);
+  const [customWidth, setCustomWidth] = useState('');
+  const [customHeight, setCustomHeight] = useState('');
   const [copied, setCopied] = useState(false);
+  const [activeTab, setActiveTab] = useState<'customize' | 'docs'>('customize');
 
-  const embedUrl = `https://tipz.app/embed/@${username}?theme=${theme}&presets=${presets}`;
-  const embedCode = `<iframe src="${embedUrl}" width="300" height="400" frameborder="0"></iframe>`;
+  const width  = customWidth  ? Number(customWidth)  : sizePreset.width;
+  const height = customHeight ? Number(customHeight) : sizePreset.height;
+
+  const embedUrl  = `${BASE_URL}/embed/@${username}?theme=${theme}&presets=${presets}`;
+  const embedCode = `<iframe\n  src="${embedUrl}"\n  width="${width}"\n  height="${height}"\n  frameborder="0"\n  title="Tip ${username} on Stellar Tipz"\n></iframe>`;
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(embedCode);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy:', err);
+    } catch {
+      /* clipboard blocked in some contexts */
     }
   };
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-6 md:grid-cols-2">
-        <div className="space-y-4">
+      {/* Tab bar */}
+      <div className="flex border-b-2 border-black">
+        {([ 'customize', 'docs' ] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`flex items-center gap-2 px-4 py-2 text-xs font-black uppercase border-b-2 -mb-[2px] transition-colors ${
+              activeTab === tab
+                ? 'border-black text-black'
+                : 'border-transparent text-gray-500 hover:text-black'
+            }`}
+          >
+            {tab === 'customize' ? <Settings size={14} /> : <BookOpen size={14} />}
+            {tab.charAt(0).toUpperCase() + tab.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'customize' && (
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Left: controls */}
+          <div className="space-y-5">
+            {/* Theme */}
+            <div className="space-y-2">
+              <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
+                Theme
+              </label>
+              <div className="flex gap-2">
+                {(['light', 'dark'] as const).map((t) => (
+                  <button
+                    key={t}
+                    onClick={() => setTheme(t)}
+                    className={`flex-1 p-3 border-2 border-black font-black uppercase text-sm ${
+                      theme === t ? 'bg-black text-white' : 'bg-white text-black hover:bg-gray-50'
+                    }`}
+                  >
+                    {t.charAt(0).toUpperCase() + t.slice(1)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Size presets */}
+            <div className="space-y-2">
+              <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
+                Size
+              </label>
+              <div className="flex gap-2">
+                {SIZE_PRESETS.map((p) => (
+                  <button
+                    key={p.label}
+                    onClick={() => { setSizePreset(p); setCustomWidth(''); setCustomHeight(''); }}
+                    className={`flex-1 p-2 border-2 border-black text-xs font-black uppercase ${
+                      sizePreset.label === p.label && !customWidth && !customHeight
+                        ? 'bg-black text-white'
+                        : 'bg-white hover:bg-gray-50'
+                    }`}
+                  >
+                    {p.label}
+                    <span className="block text-[10px] opacity-60 normal-case font-normal">
+                      {p.width}×{p.height}
+                    </span>
+                  </button>
+                ))}
+              </div>
+              {/* Custom dimensions */}
+              <div className="flex gap-2 mt-2">
+                <Input
+                  label="Custom W"
+                  type="number"
+                  min={160}
+                  max={800}
+                  placeholder={String(sizePreset.width)}
+                  value={customWidth}
+                  onChange={(e) => setCustomWidth(e.target.value)}
+                />
+                <Input
+                  label="Custom H"
+                  type="number"
+                  min={240}
+                  max={1000}
+                  placeholder={String(sizePreset.height)}
+                  value={customHeight}
+                  onChange={(e) => setCustomHeight(e.target.value)}
+                />
+              </div>
+            </div>
+
+            {/* Preset amounts */}
+            <div className="space-y-2">
+              <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
+                Preset Amounts (comma separated)
+              </label>
+              <Input
+                value={presets}
+                onChange={(e) => setPresets(e.target.value)}
+                placeholder="e.g. 5,10,20"
+              />
+            </div>
+
+            {/* Embed code */}
+            <div className="space-y-2">
+              <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
+                Embed Code
+              </label>
+              <div className="relative">
+                <textarea
+                  readOnly
+                  value={embedCode}
+                  rows={6}
+                  className="w-full bg-gray-50 border-2 border-black p-3 font-mono text-xs focus:outline-none resize-none"
+                />
+                <button
+                  onClick={handleCopy}
+                  className="absolute right-2 bottom-2 p-2 bg-black text-white hover:bg-gray-800 transition-colors"
+                  title="Copy to clipboard"
+                  aria-label="Copy embed code"
+                >
+                  {copied ? <Check size={16} /> : <Copy size={16} />}
+                </button>
+              </div>
+              <Button
+                onClick={handleCopy}
+                className="w-full"
+                icon={copied ? <Check size={18} /> : <Copy size={18} />}
+              >
+                {copied ? 'Copied!' : 'Copy Embed Code'}
+              </Button>
+            </div>
+          </div>
+
+          {/* Right: live preview */}
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-xl font-black uppercase flex items-center gap-2">
+                <Code size={20} /> Live Preview
+              </h3>
+              <p className="text-sm font-bold text-gray-600 mt-1">
+                Showing {width}×{height}px
+              </p>
+            </div>
+
+            <div className="flex justify-center border-4 border-dashed border-gray-200 p-6 bg-gray-50 min-h-[480px] items-center">
+              <div className="shadow-2xl overflow-hidden" style={{ width, maxWidth: '100%' }}>
+                <iframe
+                  title="Embed Preview"
+                  src={`/embed/@${username}?theme=${theme}&presets=${presets}`}
+                  width={width}
+                  height={height}
+                  style={{ border: 'none', display: 'block', maxWidth: '100%' }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'docs' && (
+        <div className="space-y-6 max-w-xl">
           <div>
-            <h3 className="text-xl font-black uppercase flex items-center gap-2">
-              <Settings size={20} /> Customize Widget
-            </h3>
-            <p className="text-sm font-bold text-gray-800 dark:text-gray-200 mt-1">
-              Configure how your tipping widget looks on your site.
+            <h3 className="text-xl font-black uppercase">Usage</h3>
+            <p className="text-sm text-gray-700 mt-2 leading-relaxed">
+              Paste the generated <code className="font-mono bg-gray-100 px-1">{'<iframe>'}</code> tag into any HTML page to embed a tipping widget for <strong>@{username}</strong>.
             </p>
           </div>
 
           <div className="space-y-3">
-            <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
-              Theme
-            </label>
-            <div className="flex gap-2">
-              <button
-                onClick={() => setTheme('light')}
-                className={`flex-1 p-3 border-2 border-black font-black uppercase text-sm ${
-                  theme === 'light' ? 'bg-black text-white' : 'bg-white text-black'
-                }`}
-              >
-                Light
-              </button>
-              <button
-                onClick={() => setTheme('dark')}
-                className={`flex-1 p-3 border-2 border-black font-black uppercase text-sm ${
-                  theme === 'dark' ? 'bg-black text-white' : 'bg-white text-black'
-                }`}
-              >
-                Dark
-              </button>
+            <h4 className="text-sm font-black uppercase">Query parameters</h4>
+            <div className="border-2 border-black overflow-hidden">
+              {[
+                ['theme', 'light | dark', 'Widget colour scheme'],
+                ['presets', '5,10,20', 'Comma-separated XLM preset amounts'],
+                ['username', username, 'Creator username (set via path)'],
+              ].map(([param, example, desc]) => (
+                <div key={param} className="flex border-b-2 border-black last:border-0">
+                  <div className="w-28 shrink-0 px-3 py-2 bg-gray-50 border-r-2 border-black font-mono text-xs font-bold">{param}</div>
+                  <div className="px-3 py-2 flex-1">
+                    <p className="text-xs font-bold">{desc}</p>
+                    <p className="text-[10px] text-gray-500 font-mono">{example}</p>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
 
           <div className="space-y-2">
-            <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
-              Preset Amounts (comma separated)
-            </label>
-            <Input
-              value={presets}
-              onChange={(e) => setPresets(e.target.value)}
-              placeholder="e.g. 5,10,20"
-              className="font-black"
-            />
+            <h4 className="text-sm font-black uppercase">Embed URL format</h4>
+            <pre className="bg-gray-50 border-2 border-black p-3 text-xs font-mono overflow-x-auto whitespace-pre-wrap break-all">
+              {`${BASE_URL}/embed/@{username}?theme=light&presets=5,10,20`}
+            </pre>
           </div>
 
-          <div className="space-y-2">
-            <label className="block text-xs font-black uppercase tracking-widest text-gray-800 dark:text-gray-200">
-              Embed Code
-            </label>
-            <div className="relative">
-              <textarea
-                readOnly
-                value={embedCode}
-                className="w-full h-24 bg-gray-50 border-2 border-black p-3 font-mono text-xs focus:outline-none"
-              />
-              <button
-                onClick={handleCopy}
-                className="absolute right-2 bottom-2 p-2 bg-black text-white border border-black hover:bg-gray-800 transition-colors"
-                title="Copy to clipboard"
-              >
-                {copied ? <Check size={16} /> : <Copy size={16} />}
-              </button>
-            </div>
-          </div>
-
-          <Button
-            onClick={handleCopy}
-            className="w-full btn-brutalist flex items-center justify-center gap-2"
-            icon={copied ? <Check size={18} /> : <Copy size={18} />}
-          >
-            {copied ? 'Copied Code!' : 'Copy Embed Code'}
-          </Button>
-        </div>
-
-        <div className="space-y-4">
-          <div>
-            <h3 className="text-xl font-black uppercase flex items-center gap-2">
-              <Code size={20} /> Preview
-            </h3>
-            <p className="text-sm font-bold text-gray-800 dark:text-gray-200 mt-1">
-              This is how it will appear on your website.
+          <div className="border-l-4 border-black pl-4 space-y-1">
+            <p className="text-xs font-black uppercase">Heads up</p>
+            <p className="text-xs text-gray-600">
+              Wallet connection inside the iframe redirects visitors to the full tip page, where they can complete the transaction.
             </p>
           </div>
-
-          <div className="flex justify-center border-4 border-dashed border-gray-200 p-8 bg-gray-50 min-h-[450px] items-center">
-            <div className="shadow-2xl">
-              <iframe
-                title="Embed Preview"
-                src={`/embed/@${username}?theme=${theme}&presets=${presets}`}
-                width="300"
-                height="400"
-                style={{ border: 'none' }}
-              />
-            </div>
-          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/frontend-scaffold/src/features/profile/ProfilePreview.tsx
+++ b/frontend-scaffold/src/features/profile/ProfilePreview.tsx
@@ -4,16 +4,9 @@ import { Github, Globe, Twitter } from "lucide-react";
 import Avatar from "../../components/ui/Avatar";
 import type { Profile } from "../../types/contract";
 import type { ProfileFormData } from "../../types/profile";
-
-export const THEME_COLORS: Record<string, { bg: string; accent: string; label: string }> = {
-  default: { bg: "bg-white", accent: "bg-yellow-100", label: "Default" },
-  ocean:   { bg: "bg-blue-50", accent: "bg-blue-200", label: "Ocean" },
-  forest:  { bg: "bg-green-50", accent: "bg-green-200", label: "Forest" },
-  sunset:  { bg: "bg-orange-50", accent: "bg-orange-200", label: "Sunset" },
-  midnight:{ bg: "bg-gray-900 text-white", accent: "bg-gray-700", label: "Midnight" },
-};
-
-export type ThemeKey = keyof typeof THEME_COLORS;
+import { THEME_COLORS } from "./profileThemes";
+import type { ThemeKey } from "./profileThemes";
+export type { ThemeKey } from "./profileThemes";
 
 function renderMarkdown(text: string): string {
   return text

--- a/frontend-scaffold/src/features/profile/ProfilePreview.tsx
+++ b/frontend-scaffold/src/features/profile/ProfilePreview.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Github, Globe, Twitter } from "lucide-react";
+
+import Avatar from "../../components/ui/Avatar";
+import type { Profile } from "../../types/contract";
+import type { ProfileFormData } from "../../types/profile";
+
+export const THEME_COLORS: Record<string, { bg: string; accent: string; label: string }> = {
+  default: { bg: "bg-white", accent: "bg-yellow-100", label: "Default" },
+  ocean:   { bg: "bg-blue-50", accent: "bg-blue-200", label: "Ocean" },
+  forest:  { bg: "bg-green-50", accent: "bg-green-200", label: "Forest" },
+  sunset:  { bg: "bg-orange-50", accent: "bg-orange-200", label: "Sunset" },
+  midnight:{ bg: "bg-gray-900 text-white", accent: "bg-gray-700", label: "Midnight" },
+};
+
+export type ThemeKey = keyof typeof THEME_COLORS;
+
+function renderMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/`(.+?)`/g, "<code>$1</code>")
+    .replace(/\n/g, "<br />");
+}
+
+interface ProfilePreviewProps {
+  profile: Profile;
+  form: ProfileFormData & {
+    bannerUrl?: string;
+    themeKey?: ThemeKey;
+    githubHandle?: string;
+    websiteUrl?: string;
+  };
+}
+
+const ProfilePreview: React.FC<ProfilePreviewProps> = ({ profile, form }) => {
+  const themeKey: ThemeKey = (form.themeKey as ThemeKey) ?? "default";
+  const theme = THEME_COLORS[themeKey] ?? THEME_COLORS.default;
+  const isMidnight = themeKey === "midnight";
+
+  const bannerSrc = form.bannerUrl || null;
+  const displayName = form.displayName || profile.displayName;
+  const bio = form.bio || profile.bio;
+  const xHandle = form.xHandle || profile.xHandle;
+  const imageUrl = form.imageUrl || profile.imageUrl;
+  const githubHandle = form.githubHandle ?? "";
+  const websiteUrl = form.websiteUrl ?? "";
+
+  return (
+    <div
+      className={`w-full overflow-hidden border-4 border-black shadow-brutalist ${theme.bg}`}
+      aria-label="Profile preview"
+    >
+      {/* Banner */}
+      <div className={`relative h-28 w-full ${theme.accent}`}>
+        {bannerSrc && (
+          <img
+            src={bannerSrc}
+            alt="Profile banner"
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+        )}
+        {/* Avatar overlapping banner */}
+        <div className="absolute -bottom-8 left-5">
+          <Avatar
+            address={profile.owner}
+            alt={displayName}
+            fallback={displayName}
+            size="xl"
+            className="border-4 border-black"
+            src={imageUrl || undefined}
+          />
+        </div>
+      </div>
+
+      <div className="px-5 pt-12 pb-5 space-y-3">
+        <div>
+          <p className={`text-lg font-black uppercase leading-tight ${isMidnight ? "text-white" : "text-black"}`}>
+            {displayName}
+          </p>
+          <p className={`text-xs font-bold ${isMidnight ? "text-gray-400" : "text-gray-500"}`}>
+            @{profile.username}
+          </p>
+        </div>
+
+        {bio && (
+          <p
+            className={`text-sm leading-relaxed ${isMidnight ? "text-gray-300" : "text-gray-700"}`}
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(bio) }}
+          />
+        )}
+
+        {/* Social links */}
+        <div className="flex flex-wrap gap-3 pt-1">
+          {xHandle && (
+            <span className={`inline-flex items-center gap-1.5 text-xs font-bold ${isMidnight ? "text-gray-300" : "text-gray-600"}`}>
+              <Twitter size={13} />@{xHandle.replace(/^@/, "")}
+            </span>
+          )}
+          {githubHandle && (
+            <span className={`inline-flex items-center gap-1.5 text-xs font-bold ${isMidnight ? "text-gray-300" : "text-gray-600"}`}>
+              <Github size={13} />{githubHandle.replace(/^@/, "")}
+            </span>
+          )}
+          {websiteUrl && (
+            <span className={`inline-flex items-center gap-1.5 text-xs font-bold ${isMidnight ? "text-gray-300" : "text-gray-600"}`}>
+              <Globe size={13} />{websiteUrl.replace(/^https?:\/\//, "").replace(/\/$/, "")}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePreview;

--- a/frontend-scaffold/src/features/profile/RegisterForm.tsx
+++ b/frontend-scaffold/src/features/profile/RegisterForm.tsx
@@ -86,7 +86,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ initialImageUrl }) => {
     (field: keyof ProfileFormData) =>
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       setForm((prev) => ({ ...prev, [field]: e.target.value }));
-      if (errors[field]) {
+      if ((errors as Record<string, string | undefined>)[field]) {
         setErrors((prev) => ({ ...prev, [field]: undefined }));
       }
     };

--- a/frontend-scaffold/src/features/profile/profileThemes.ts
+++ b/frontend-scaffold/src/features/profile/profileThemes.ts
@@ -1,0 +1,9 @@
+export const THEME_COLORS: Record<string, { bg: string; accent: string; label: string }> = {
+  default:  { bg: "bg-white",           accent: "bg-yellow-100", label: "Default"  },
+  ocean:    { bg: "bg-blue-50",          accent: "bg-blue-200",   label: "Ocean"    },
+  forest:   { bg: "bg-green-50",         accent: "bg-green-200",  label: "Forest"   },
+  sunset:   { bg: "bg-orange-50",        accent: "bg-orange-200", label: "Sunset"   },
+  midnight: { bg: "bg-gray-900 text-white", accent: "bg-gray-700", label: "Midnight" },
+};
+
+export type ThemeKey = keyof typeof THEME_COLORS;

--- a/frontend-scaffold/src/routes.tsx
+++ b/frontend-scaffold/src/routes.tsx
@@ -16,6 +16,9 @@ const LeaderboardPage = lazy(
 const TipPage = lazy(() => import("@/features/tipping/TipPage"));
 const TipReceipt = lazy(() => import("@/features/tipping/TipReceipt"));
 const EmbedWidget = lazy(() => import("@/features/tipping/EmbedWidget"));
+const EmbedGeneratorPage = lazy(
+  () => import("@/features/embed/EmbedGeneratorPage"),
+);
 const TransactionsPage = lazy(
   () => import("@/features/transactions/TransactionsPage"),
 );
@@ -44,6 +47,10 @@ export const routes: RouteObject[] = [
   {
     path: "/embed/@:username",
     element: wrap(<EmbedWidget />),
+  },
+  {
+    path: "/embed/generate",
+    element: protect(<EmbedGeneratorPage />),
   },
   {
     path: "/receipt",

--- a/frontend-scaffold/src/types/profile.ts
+++ b/frontend-scaffold/src/types/profile.ts
@@ -7,4 +7,12 @@ export interface ProfileFormData {
   bio: string;
   imageUrl: string;
   xHandle: string;
+  /** Optional banner / cover image URL or data-URL (from cropper) */
+  bannerUrl?: string;
+  /** Profile colour theme key */
+  themeKey?: string;
+  /** GitHub username (without @) */
+  githubHandle?: string;
+  /** Creator website URL */
+  websiteUrl?: string;
 }


### PR DESCRIPTION
## Summary

### #569 — Leaderboard filters and time periods
- New `LeaderboardFilters.tsx` component with **time-period tabs** (All Time / Monthly / Weekly / Daily), **sort-by selector** (Most Tips Received, Highest Credit Score, Most Supporters), and **sort-direction toggle** (asc/desc)
- Filter state **persisted in URL query params** (`?period=weekly&sort=highest-credit&dir=asc`) for shareable links
- Animated transitions between filter states via `framer-motion`
- Loading state indicator during filter changes
- Integrated into `LeaderboardPage` full-rankings table with proper pagination reset

### #570 — Dashboard analytics charts and visualisations
- New `TipsChart.tsx` with a **bar chart** (tip frequency by day/week/month) and a **pie chart** (top supporters breakdown), both built with Recharts (already in dependencies)
- Both charts show empty-state illustrations when no data exists yet
- Wired into the DashboardPage overview tab under a new **"Tips Analytics"** section alongside the existing `EarningsChart`

### #571 — Creator profile customisation options
- New `ProfilePreview.tsx` — live preview card with banner, colour theme, social links, and Markdown bio
- New `ImageCropper.tsx` (shared) — file picker with **5 MB size validation**, canvas-based crop/zoom/rotate, and Apply button
- Extended `ProfileFormData` type with `bannerUrl`, `themeKey`, `githubHandle`, `websiteUrl`
- Rewrote `EditProfileForm.tsx` to include: 5 colour themes, banner & avatar upload via `ImageCropper`, toggle Markdown bio preview, GitHub and website social links, and an inline **"Preview profile"** toggle

### #576 — Embeddable tip widget for external sites
- Enhanced `EmbedCodeGenerator.tsx` with **three size presets** (Small 240×320, Medium 300×400, Large 380×500), custom width/height fields, live iframe preview, and a **Docs tab** with query-param reference and usage guidance
- New `EmbedGeneratorPage.tsx` — protected standalone page at `/embed/generate` so creators can navigate directly to the embed generator
- Registered `/embed/generate` in `routes.tsx`; existing `/embed/@:username` widget route is unchanged


Closes #569
Closes #570 
Closes #571 
Closes #576