### PR TITLE
docs: ADRs, deployment & contributor guides, inline contract docs

### DIFF
--- a/contracts/tipz/src/credit.rs
+++ b/contracts/tipz/src/credit.rs
@@ -87,8 +87,16 @@ const SECONDS_PER_DAY: u64 = 86_400;
 
 /// Build the weighted credit component breakdown for `profile` at `now`.
 pub fn get_credit_breakdown_for_profile(profile: &Profile, now: u64) -> CreditBreakdown {
+    // ── Step 1: tip sub-score (0–100) ──────────────────────────────────────
+    // Clamp lifetime tip volume to [0, TIP_VOLUME_CAP] so a single whale tip
+    // can't dominate, then divide by TIP_DIVISOR (10 XLM in stroops) so every
+    // 10 XLM received earns one sub-score point, saturating at 100.
     let tip_sub: u32 = (profile.total_tips_received.clamp(0, TIP_VOLUME_CAP) / TIP_DIVISOR) as u32;
 
+    // ── Step 2: X (social) sub-score (0–100) ───────────────────────────────
+    // Two independently-capped halves (each ≤ X_SUB_CAP = 50): reach from
+    // follower count and engagement from the average interaction rate. A
+    // profile with no X data contributes nothing here.
     let x_sub: u32 = if profile.x_followers == 0 && profile.x_engagement_avg == 0 {
         0
     } else {
@@ -98,6 +106,10 @@ pub fn get_credit_breakdown_for_profile(profile: &Profile, now: u64) -> CreditBr
         follower_part + engagement_part
     };
 
+    // ── Step 3: account-age sub-score (0–100) ──────────────────────────────
+    // Rewards longevity: one point per AGE_DIVISOR (10) days of account age.
+    // Guard against clock skew (`now <= registered_at`) and grant nothing for
+    // accounts younger than a day so brand-new profiles don't earn age points.
     let age_sub: u32 =
         if now <= profile.registered_at || now - profile.registered_at < SECONDS_PER_DAY {
             0
@@ -106,6 +118,11 @@ pub fn get_credit_breakdown_for_profile(profile: &Profile, now: u64) -> CreditBr
             (age_days as u32 / AGE_DIVISOR).min(AGE_CAP)
         };
 
+    // ── Step 4: weight each sub-score and sum onto the base ─────────────────
+    // Each 0–100 sub-score is scaled by its weight (out of MAX_SCORE = 100),
+    // yielding the documented point budgets: tips ≤20, X ≤30, age ≤10. The
+    // weighted parts are added to BASE_SCORE (40) and the total is capped at
+    // MAX_SCORE so the result always lands in 0–100.
     let tip_score = tip_sub * TIP_WEIGHT / MAX_SCORE;
     let x_score = x_sub * X_WEIGHT / MAX_SCORE;
     let age_score = age_sub * AGE_WEIGHT / MAX_SCORE;

--- a/contracts/tipz/src/leaderboard.rs
+++ b/contracts/tipz/src/leaderboard.rs
@@ -51,7 +51,22 @@ fn find_insertion_index(entries: &Vec<LeaderboardEntry>, amount: i128) -> u32 {
     low
 }
 
+/// Re-position `profile` within a single sorted leaderboard `entries` list
+/// for a new cumulative `amount`.
+///
+/// The list is kept sorted descending and bounded to [`MAX_LEADERBOARD_SIZE`].
+/// The update is a remove-then-insert so a creator never appears twice:
+///
+/// 1. **Remove** the creator's existing entry, if present (their amount only
+///    ever grows, so the old position is always stale).
+/// 2. **Find** the new insertion index via [`find_insertion_index`]
+///    (O(log n) binary search, stable on ties).
+/// 3. **Insert** only if the position is within the capped window; an amount
+///    that ranks beyond [`MAX_LEADERBOARD_SIZE`] is dropped outright.
+/// 4. **Evict** the now-lowest entry if the insert pushed the list over the
+///    cap, keeping exactly the top `MAX_LEADERBOARD_SIZE`.
 fn update_entries(entries: &mut Vec<LeaderboardEntry>, profile: &Profile, amount: i128) {
+    // Step 1 — drop the creator's stale entry if they are already ranked.
     let mut i: u32 = 0;
     while i < entries.len() {
         if entries.get(i).unwrap().address == profile.owner {
@@ -61,7 +76,10 @@ fn update_entries(entries: &mut Vec<LeaderboardEntry>, profile: &Profile, amount
         i += 1;
     }
 
+    // Step 2 — locate where the new amount belongs in descending order.
     let insert_pos = find_insertion_index(entries, amount);
+
+    // Step 3 — only materialise the entry if it lands inside the top window.
     if insert_pos < MAX_LEADERBOARD_SIZE {
         let new_entry = LeaderboardEntry {
             address: profile.owner.clone(),
@@ -71,6 +89,7 @@ fn update_entries(entries: &mut Vec<LeaderboardEntry>, profile: &Profile, amount
         };
         entries.insert(insert_pos, new_entry);
 
+        // Step 4 — trim the tail so the list never exceeds the cap.
         if entries.len() > MAX_LEADERBOARD_SIZE {
             entries.pop_back();
         }
@@ -79,7 +98,11 @@ fn update_entries(entries: &mut Vec<LeaderboardEntry>, profile: &Profile, amount
 
 // ── public API ────────────────────────────────────────────────────────────────
 
-/// Refresh the leaderboard after `profile` has received a tip.
+/// Refresh all three leaderboards (all-time, monthly, weekly) after `profile`
+/// has received a tip of `amount`.
+///
+/// Deactivated profiles are skipped so a banned creator cannot occupy a slot;
+/// active profiles are forwarded to [`update_all_leaderboards_for_active`].
 pub fn update_all_leaderboards(env: &Env, profile: &Profile, amount: i128) {
     if storage::is_profile_deactivated(env, &profile.owner) {
         return;
@@ -87,6 +110,11 @@ pub fn update_all_leaderboards(env: &Env, profile: &Profile, amount: i128) {
     update_all_leaderboards_for_active(env, profile, amount);
 }
 
+/// Apply a tip to all three leaderboards in a single read-modify-write of the
+/// combined [`storage::LeaderboardSet`], avoiding three separate storage round
+/// trips. All-time ranks by lifetime `total_tips_received`; monthly and weekly
+/// rank by the rolling per-period volume (which the storage layer rolls over
+/// when a period boundary is crossed).
 pub fn update_all_leaderboards_for_active(env: &Env, profile: &Profile, amount: i128) {
     let mut boards = storage::get_leaderboard_set(env).unwrap_or_else(|| storage::LeaderboardSet {
         all_time: storage::get_leaderboard(env, LeaderboardPeriod::AllTime),
@@ -110,12 +138,17 @@ pub fn update_all_leaderboards_for_active(env: &Env, profile: &Profile, amount: 
     storage::set_leaderboard_set(env, &boards);
 }
 
+/// Remove `address` from every period leaderboard (e.g. on profile
+/// deactivation), so a delisted creator leaves no residual ranking.
 pub fn remove_from_all_leaderboards(env: &Env, address: &Address) {
     remove_from_leaderboard(env, LeaderboardPeriod::AllTime, address);
     remove_from_leaderboard(env, LeaderboardPeriod::Monthly, address);
     remove_from_leaderboard(env, LeaderboardPeriod::Weekly, address);
 }
 
+/// Refresh a single `period` leaderboard for `profile`. The all-time board
+/// ranks by lifetime tips; period boards rank by the rolling per-period volume
+/// returned from storage. No-op for deactivated profiles.
 pub fn update_leaderboard(
     env: &Env,
     profile: &Profile,
@@ -137,6 +170,8 @@ pub fn update_leaderboard(
     save_entries(env, period, &entries);
 }
 
+/// Clear a period leaderboard and stamp the reset time (used at month/week
+/// rollover). The all-time board is immutable and never reset.
 pub fn reset_leaderboard(env: &Env, period: LeaderboardPeriod) {
     if period == LeaderboardPeriod::AllTime {
         return; // All-time never resets

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,6 +39,39 @@ Be respectful, constructive, and inclusive. We follow the [Contributor Covenant]
 
 ---
 
+## Architecture Overview
+
+Stellar Tipz is a monorepo with two halves: a Soroban smart contract (the
+source of truth) and a React frontend that reads/writes it over RPC.
+
+```text
+┌──────────────────────────────┐        ┌──────────────────────────────────┐
+│  frontend-scaffold/          │        │  contracts/tipz/  (Soroban, Rust) │
+│  React 18 + Vite             │        │                                   │
+│  ├─ features/  (UI)          │        │  lib.rs        ← contract entry    │
+│  ├─ Zustand store (ADR-005)  │  RPC   │  ├─ profile / tips / token         │
+│  └─ contract bindings  ──────┼──────► │  ├─ credit.rs     (ADR-003)        │
+│                              │ invoke │  ├─ leaderboard.rs                 │
+│  Freighter wallet (signing)  │        │  ├─ fees.rs       (ADR-006)        │
+└──────────────────────────────┘        │  ├─ admin.rs / multisig.rs         │
+                                         │  └─ storage.rs    (ADR-004)        │
+                                         │        │                          │
+                                         │        ▼ instance/persistent/temp  │
+                                         │   Soroban storage (TTL-managed)    │
+                                         └──────────────────────────────────┘
+```
+
+- **Frontend** holds only light client state in a Zustand store; all durable
+  state lives on-chain. Transactions are signed with the Freighter wallet.
+- **Contract** is module-per-concern; `storage.rs` is the single gateway to
+  on-chain state and its TTL discipline.
+
+For the full picture see [`ARCHITECTURE.md`](../ARCHITECTURE.md) (directory
+layout, module boundaries, data flow) and the decision records in
+[`docs/adr/`](./adr/README.md).
+
+---
+
 ## Workflow
 
 We use a **fork-and-branch** workflow:
@@ -202,6 +235,23 @@ PRs are evaluated on:
 | **Code quality** — Clean, readable, idiomatic? | Medium |
 | **Performance** — No unnecessary computation? | Medium |
 | **Documentation** — Clear comments where needed? | Low |
+
+---
+
+## Resources
+
+**Project docs**
+- [Setup Guide](./SETUP.md) — get running locally in < 30 minutes
+- [Architecture](../ARCHITECTURE.md) and [ADRs](./adr/README.md) — how & why
+- [Deployment Guide](./DEPLOYMENT.md), [Contract Spec](./CONTRACT_SPEC.md),
+  [Credit Score](./CREDIT_SCORE.md), [Security](./SECURITY.md)
+
+**External**
+- [Soroban docs](https://developers.stellar.org/docs/build/smart-contracts/overview)
+- [Soroban SDK (Rust) reference](https://docs.rs/soroban-sdk)
+- [Stellar developer docs](https://developers.stellar.org/docs)
+- [Freighter wallet](https://www.freighter.app/)
+- [Rust book](https://doc.rust-lang.org/book/) · [Conventional Commits](https://www.conventionalcommits.org/)
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,6 +14,41 @@
 
 ---
 
+## Pre-Deployment Checklist
+
+Complete **before** any deployment (and re-verify before mainnet):
+
+**Security**
+- [ ] `cargo test` passes for the contract (`contracts/tipz`)
+- [ ] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean
+- [ ] For mainnet: third-party security audit completed and findings resolved
+- [ ] Admin key custody decided (hardware wallet or multisig for mainnet)
+- [ ] Fee basis points reviewed and within the contract cap (≤ 1000 bps / 10%)
+
+**Testing**
+- [ ] Full happy path exercised on testnet (register → tip → withdraw)
+- [ ] Edge cases verified (dust withdrawal fee, overflow, unregistered profile)
+- [ ] Frontend smoke-tested against the deployed testnet contract
+
+**Resource / cost estimates**
+- [ ] Wasm built in `--release` and (for mainnet) `soroban contract optimize` run
+- [ ] Deploy + `initialize` resource fees estimated with `--sim` / dry-run
+- [ ] Deployer account funded with enough XLM for deploy **and** storage rent
+- [ ] Storage TTL strategy understood (see `docs/adr/ADR-004-storage-strategy.md`)
+
+## Environment Configuration per Network
+
+| Setting | Testnet | Mainnet |
+|---------|---------|---------|
+| `VITE_NETWORK` / `REACT_APP_NETWORK` | `TESTNET` | `PUBLIC` |
+| Network passphrase | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| Soroban RPC URL | `https://soroban-testnet.stellar.org` | a mainnet RPC provider |
+| Native XLM SAC (`--native_token`) | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` | resolve via `soroban contract id asset --asset native --network mainnet` |
+| Deployer funding | Friendbot | real XLM |
+| Admin key | dev keypair | hardware wallet / multisig |
+
+---
+
 ## 1. Contract Deployment
 
 ### Build the Wasm Binary
@@ -222,3 +257,55 @@ Generate TypeScript bindings from the deployed contract:
 - [ ] Frontend deployed and accessible
 - [ ] Freighter wallet connects on deployed frontend
 - [ ] End-to-end happy path works (register → tip → withdraw)
+
+---
+
+## 6. Emergency Procedures and Rollback
+
+### Contract pause (first response)
+
+The contract supports an admin **pause** that blocks state-changing entry
+points (tips, withdrawals) while reads stay available. On a suspected exploit or
+critical bug:
+
+1. As admin, call the contract's `pause` (see `admin.rs`) to halt mutations.
+2. Communicate status to users (status page / social) — the frontend should
+   surface a maintenance banner.
+3. Investigate with on-chain events and logs before resuming.
+4. Call `unpause` only once the issue is understood and mitigated.
+
+### Frontend rollback
+
+The frontend is immutable per deployment, so rollback is instant:
+
+```bash
+# List recent deployments and promote a known-good one
+vercel ls
+vercel promote <previous-deployment-url>
+# or, in the Vercel dashboard: Deployments → previous → "Promote to Production"
+```
+
+If the issue is purely a bad `VITE_CONTRACT_ID`/network value, fix the env var
+and redeploy rather than rolling back code.
+
+### Contract upgrade vs. redeploy
+
+- **Upgrade (preferred):** the contract is upgradeable (`ContractVersion` is
+  bumped on upgrade). Ship a fixed Wasm via `soroban contract install` +
+  the admin-gated upgrade path; storage and the contract ID are preserved.
+- **Redeploy (last resort):** if state is corrupt or the ID must change, deploy
+  a fresh contract, migrate/re-initialize required state, then point the
+  frontend at the new contract ID. There is no automatic state migration — plan
+  it explicitly.
+
+### Key compromise
+
+If the admin key is compromised: pause immediately, transfer admin to a new
+secure key (hardware wallet / multisig) via the admin-transfer path, rotate any
+related operational secrets, and post-mortem before unpausing.
+
+### Post-incident
+
+- [ ] Root cause documented (consider a new `docs/adr/` entry if architectural)
+- [ ] Regression test added under `contracts/tipz/src/test`
+- [ ] Fix deployed and verified against the post-deployment checklist above

--- a/docs/adr/ADR-001-soroban-choice.md
+++ b/docs/adr/ADR-001-soroban-choice.md
@@ -1,0 +1,55 @@
+# ADR-001: Choice of Soroban for smart contracts
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** Core team
+
+## Context
+
+Stellar Tipz is a decentralized tipping product: creators register profiles,
+receive tips in a native asset, accrue an on-chain credit score and streaks,
+and appear on leaderboards. The core trust-sensitive logic (custody of tipped
+funds, fee calculation, credit scoring, withdrawals) must run on-chain.
+
+We needed a smart-contract platform that: (a) settles cheaply and quickly
+enough for micro-tips, (b) has first-class fungible-token support, (c) lets us
+write safety-critical money logic in a memory-safe language, and (d) fits the
+team's existing Stellar/Rust experience.
+
+## Options considered
+
+1. **Soroban (Stellar smart contracts, Rust → Wasm)** — runs on the Stellar
+   network the product already targets; native Stellar Asset Contract (SAC) for
+   XLM/tokens; Rust safety + `checked_*` arithmetic; very low fees and ~5s
+   ledgers; built-in storage TTL/rent model.
+2. **EVM chain (Solidity)** — largest ecosystem and tooling, but a different
+   chain from Stellar, higher/variable gas, and Solidity's footguns around
+   arithmetic and reentrancy.
+3. **Off-chain ledger with periodic settlement** — cheapest per-tip, but
+   reintroduces a trusted custodian, defeating the decentralization goal.
+
+## Decision
+
+Build the contract on **Soroban**, written in Rust and compiled to Wasm, using
+the native SAC for asset transfers.
+
+## Rationale
+
+- The product is already a Stellar app; staying on Stellar avoids bridging and
+  a second asset story.
+- Soroban's fee/latency profile suits micro-tipping where EVM gas would dwarf a
+  small tip.
+- Rust gives us memory safety and explicit overflow handling (see
+  [ADR-006](./ADR-006-fee-structure.md) and `fees.rs`'s `checked_mul`/`checked_sub`),
+  which matters for code that moves user funds.
+- Soroban's storage tiers and TTL model map cleanly onto our data lifetimes
+  (see [ADR-004](./ADR-004-storage-strategy.md)).
+
+## Consequences
+
+- Positive: one chain, cheap settlement, safe arithmetic, native tokens.
+- Negative / cost: smaller ecosystem than EVM; must manage Soroban storage
+  **rent/TTL** explicitly (handled in `storage.rs`); Wasm size matters
+  (tracked via the repo's bundle/Wasm optimization docs).
+- Revisit if the product needs cross-chain tipping or an asset only available
+  on another network.

--- a/docs/adr/ADR-002-design-system.md
+++ b/docs/adr/ADR-002-design-system.md
@@ -1,0 +1,53 @@
+# ADR-002: Brutalist design system
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** Core team / design
+
+## Context
+
+The frontend (`frontend-scaffold/`, React + Vite + SCSS) needed a coherent
+visual language. Tipz is a crypto-native product aimed at creators; the team
+wanted a distinctive, high-contrast identity that is fast to build, cheap to
+ship, and accessible — rather than a generic component-library look.
+
+A neo-brutalist system (heavy borders, hard shadows, flat high-contrast color
+blocks, monospace accents, minimal gradients) was prototyped in
+`src/index.scss` and the landing features (e.g. `CTASection`, `StatsSection`).
+
+## Options considered
+
+1. **Neo-brutalist, hand-rolled SCSS tokens** — strong, memorable identity;
+   few dependencies; small CSS payload; flat colors make WCAG contrast easy to
+   hit.
+2. **A component library (MUI / Chakra / shadcn)** — faster to assemble stock
+   UIs, but heavier bundles, a generic look, and theme-fighting to achieve a
+   distinctive style.
+3. **Tailwind-only utility styling** — flexible, but without a design system on
+   top it pushes styling decisions into every component and risks drift.
+
+## Decision
+
+Adopt a **neo-brutalist design system** expressed as SCSS design tokens and a
+small set of shared primitives, rather than pulling in a third-party component
+library.
+
+## Rationale
+
+- The aesthetic is intentionally part of the brand; a stock library would
+  dilute it.
+- Flat, high-contrast color blocks make it straightforward to meet the
+  accessibility bar the repo enforces via Lighthouse CI (see the repo's
+  Lighthouse config and `fix-contrast.js`).
+- Fewer UI dependencies keeps the bundle small — a tracked concern in the
+  bundle-optimization docs.
+
+## Consequences
+
+- Positive: distinctive identity, small CSS footprint, accessibility-friendly,
+  no component-library lock-in.
+- Negative / cost: the team maintains its own primitives and tokens; less
+  "free" breadth than a mature library; contributors must learn the system's
+  conventions (documented in `docs/FRONTEND_GUIDE.md`).
+- Revisit if the surface area grows enough that maintaining bespoke components
+  outweighs the identity benefit.

--- a/docs/adr/ADR-003-credit-score-algorithm.md
+++ b/docs/adr/ADR-003-credit-score-algorithm.md
@@ -1,0 +1,63 @@
+# ADR-003: Credit score algorithm design
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** Core team
+- **Implements:** `contracts/tipz/src/credit.rs`
+
+## Context
+
+Tipz assigns each creator a **credit score (0–100)** and a tier
+(New / Bronze / Silver / Gold / Diamond) used for ranking and trust signalling.
+The score must be: deterministic and verifiable on-chain, cheap to compute,
+resistant to trivial gaming, and explainable to creators (they should see *why*
+their score is what it is).
+
+Soroban contracts run integer-only arithmetic with explicit overflow handling,
+so the algorithm must avoid floating point and unbounded growth.
+
+## Options considered
+
+1. **Weighted, capped multi-factor score with a base** — combine tip volume,
+   social (X) reach, and account age, each normalised to 0–100 and capped, then
+   weighted into a single 0–100 number on top of a base score.
+2. **Pure tip-volume ranking** — simplest, but trivially bought and ignores
+   longevity/social proof.
+3. **Off-chain ML/reputation oracle** — richer signal, but non-deterministic,
+   not verifiable on-chain, and adds a trusted oracle.
+
+## Decision
+
+Use a **weighted multi-factor score** (option 1), implemented in `credit.rs`:
+
+```text
+score = BASE_SCORE(40)
+      + tip_sub * 20 / 100   (tip volume,   ≤20 pts)
+      + x_sub   * 30 / 100   (X reach,      ≤30 pts)
+      + age_sub * 10 / 100   (account age,  ≤10 pts)
+      + streak_bonus
+capped at 100
+```
+
+Each sub-score is independently capped at 100 before weighting; new profiles
+start at the base score of 40 (bottom of Silver). A streak bonus rewards
+consistent tipping milestones.
+
+## Rationale
+
+- A **base score** gives new creators a usable starting tier instead of zero.
+- **Capping each factor** (e.g. follower contribution ≤50, age 1 pt / 10 days)
+  blunts whales and bot-followers — buying one huge tip or fake followers
+  cannot max the score.
+- **Integer-only, deterministic** math is verifiable by anyone re-running it on
+  the same `Profile`, with no oracle to trust.
+- The breakdown (`CreditBreakdown`) is returned to the UI so creators see each
+  component, satisfying explainability.
+
+## Consequences
+
+- Positive: gameable-resistant, transparent, cheap, fully on-chain.
+- Negative / cost: the specific weights/divisors are judgment calls and may need
+  tuning; integer truncation means small inputs round to zero (documented in the
+  `credit.rs` edge-case table).
+- Revisit weights if creator behaviour shows a factor is over/under-rewarded.

--- a/docs/adr/ADR-004-storage-strategy.md
+++ b/docs/adr/ADR-004-storage-strategy.md
@@ -1,0 +1,59 @@
+# ADR-004: Storage strategy (persistent / temporary / instance)
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** Core team
+- **Implements:** `contracts/tipz/src/storage.rs`
+
+## Context
+
+Soroban charges **rent** for stored state and expires entries via a **TTL**
+(time-to-live in ledgers); reading an expired entry fails. It exposes three
+storage tiers — `instance`, `persistent`, and `temporary` — with different cost
+and lifetime semantics. Tipz stores data with very different lifetimes:
+contract config, long-lived creator profiles, and high-volume short-lived tip
+records. Putting everything in one tier would either overpay rent or risk
+losing data we must keep.
+
+## Options considered
+
+1. **Tier data by lifetime** — config/counters in `instance`, durable
+   per-creator data in `persistent`, ephemeral records in `temporary`, each
+   with deliberate TTL bumping.
+2. **Everything persistent** — simplest mental model, but pays durable rent for
+   data that is only briefly relevant (tip records), and lets config TTL drift.
+3. **Everything temporary** — cheapest, but risks profiles/leaderboards
+   expiring and being unrecoverable.
+
+## Decision
+
+**Tier by data lifetime**, as implemented in `storage.rs`:
+
+| Tier | Used for | TTL policy |
+|------|----------|-----------|
+| `instance()` | Admin, fee config, global counters | Bumped on each write (`extend_instance_ttl`, ~7→31 day window) |
+| `persistent()` | `Profile`, username reverse-lookup, leaderboards | `bump_profile_ttl` extends profile **and** its username entry together to avoid TTL desync |
+| `temporary()` | Individual tip records (`Tip(u32)`) | TTL set on write (`set_tip_ttl`, ~7 days) |
+
+All access goes through helpers in `storage.rs` rather than raw storage calls.
+
+## Rationale
+
+- Matching tier to lifetime minimises rent: we don't pay durable rent for tip
+  records that only need to survive a short window.
+- Keeping profiles in `persistent` with explicit TTL bumps on access prevents
+  active creators' data from expiring.
+- Bumping a profile and its `UsernameToAddress` reverse-lookup **together**
+  prevents a class of bug where one expires and the other doesn't, breaking
+  username resolution.
+- Centralising access in helpers keeps the TTL discipline in one place.
+
+## Consequences
+
+- Positive: lower rent, no TTL-desync bugs, clear single source of truth for
+  keys and lifetimes.
+- Negative / cost: contributors must route all storage through `storage.rs` and
+  understand which tier a new key belongs to; temporary tip records can expire,
+  so anything needing permanent history must be aggregated into persistent
+  state first.
+- Revisit TTL constants if ledger close time or rent pricing changes materially.

--- a/docs/adr/ADR-005-frontend-state-management.md
+++ b/docs/adr/ADR-005-frontend-state-management.md
@@ -1,0 +1,45 @@
+# ADR-005: Frontend state management (Zustand)
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** Frontend team
+- **Implements:** `frontend-scaffold/` (`zustand` ^5)
+
+## Context
+
+The frontend (React 18 + Vite) needs to share a modest amount of cross-cutting
+client state — connected wallet/account, network, and cached view models for
+profiles and leaderboards — across feature areas. Most server-ish state comes
+from the contract via RPC. We wanted state management that is light, has minimal
+boilerplate, and does not bloat the bundle (a tracked metric in this repo).
+
+## Options considered
+
+1. **Zustand** — tiny (~1 KB), hook-based store, no provider tree, no
+   action/reducer ceremony; selectors give cheap re-render control.
+2. **Redux Toolkit** — powerful and ubiquitous, with great devtools, but more
+   boilerplate (slices, store wiring, providers) and a larger footprint than
+   this app's state warrants.
+3. **React Context + useReducer only** — zero dependencies, but Context causes
+   broad re-renders and becomes unwieldy as shared state grows.
+
+## Decision
+
+Use **Zustand** as the client state container.
+
+## Rationale
+
+- The app's shared state is small; Zustand covers it without the slice/provider
+  overhead of Redux.
+- Selector-based subscriptions avoid the whole-tree re-renders that plague
+  Context for frequently-updated values (e.g. wallet status).
+- Its tiny size aligns with the bundle-size discipline the repo enforces (see
+  the bundle-optimization docs and Lighthouse CI).
+
+## Consequences
+
+- Positive: minimal boilerplate, small bundle, easy testing of plain stores.
+- Negative / cost: less out-of-the-box tooling/middleware than Redux Toolkit;
+  the team must keep store structure disciplined since Zustand imposes little.
+- Revisit if global state grows complex enough (large normalized caches,
+  time-travel debugging needs) to justify Redux Toolkit.

--- a/docs/adr/ADR-006-fee-structure.md
+++ b/docs/adr/ADR-006-fee-structure.md
@@ -1,0 +1,57 @@
+# ADR-006: Fee structure design
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** Core team
+- **Implements:** `contracts/tipz/src/fees.rs`
+
+## Context
+
+The protocol takes a fee on creator **withdrawals** to fund operations. The fee
+must be: configurable by the admin, bounded so it can never be set abusively
+high, exact (no value created or destroyed), overflow-safe on a `i128` stroop
+amount, and resistant to circumvention via dust withdrawals.
+
+## Options considered
+
+1. **Basis-points fee on withdrawal, with a hard cap and a 1-stroop minimum** —
+   `fee = max(amount * bps / 10_000, 1)` for `bps > 0`, capped at 1000 bps
+   (10%), `net = amount - fee`.
+2. **Fee charged per tip (on deposit)** — spreads the cost, but taxes inbound
+   generosity and complicates micro-tips; creators dislike "shrinkflation" on
+   incoming tips.
+3. **Flat per-transaction fee** — simple, but regressive for small withdrawals
+   and arbitrary for large ones.
+
+## Decision
+
+Charge a **basis-points fee on withdrawal** (option 1), implemented in
+`fees.rs::calculate_fee`:
+
+- `fee_bps == 0` → no fee, `net == amount`.
+- otherwise `fee = max((amount * fee_bps) / 10_000, 1)`, `net = amount - fee`.
+- the admin-set `fee_bps` is bounded to **≤ 1000 bps (10%)**.
+- all arithmetic uses `checked_mul` / `checked_sub`, returning
+  `OverflowError` instead of panicking; the invariant `fee + net == amount`
+  holds exactly.
+
+## Rationale
+
+- Charging on **withdrawal** keeps incoming tips whole (better creator UX) and
+  centralises fee logic at one exit point.
+- **Basis points** scale fairly with amount and are the industry-standard unit.
+- The **1-stroop minimum** closes a real exploit: without it, integer division
+  lets sub-`10_000/bps` withdrawals round the fee to 0 (see the worked example
+  and `test_fee_minimum_enforcement` in `fees.rs`).
+- The **10% cap** bounds admin power so a fee can never be set confiscatory.
+- **Checked arithmetic** prevents overflow panics on adversarial amounts near
+  `i128::MAX`.
+
+## Consequences
+
+- Positive: exact, bounded, overflow-safe, dust-resistant; creators keep full
+  tips until they withdraw.
+- Negative / cost: a 1-stroop minimum means tiny withdrawals are
+  disproportionately taxed (negligible in practice); fee rounds in the
+  protocol's favour by design.
+- Revisit the cap or default bps if the protocol's cost structure changes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records (ADRs)
+
+This directory captures the significant architectural decisions made on Stellar
+Tipz — the *context*, the *options considered*, and the *rationale* — so future
+contributors understand **why** the system looks the way it does, not just how.
+
+We follow a lightweight [Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+style. Each record is immutable once `Accepted`; to change a decision, add a new
+ADR that `Supersedes` the old one and mark the old one `Superseded`.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [001](./ADR-001-soroban-choice.md) | Choice of Soroban for smart contracts | Accepted |
+| [002](./ADR-002-design-system.md) | Brutalist design system | Accepted |
+| [003](./ADR-003-credit-score-algorithm.md) | Credit score algorithm design | Accepted |
+| [004](./ADR-004-storage-strategy.md) | Storage strategy (persistent / temporary / instance) | Accepted |
+| [005](./ADR-005-frontend-state-management.md) | Frontend state management (Zustand) | Accepted |
+| [006](./ADR-006-fee-structure.md) | Fee structure design | Accepted |
+
+## Adding a new ADR
+
+1. Copy [`template.md`](./template.md) to `ADR-NNN-short-title.md` (next number).
+2. Fill in the sections; keep it focused on a single decision.
+3. Add a row to the index above.
+4. Open a PR — the decision is reviewed like code.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,30 @@
+# ADR-NNN: <short title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXX
+- **Date:** YYYY-MM-DD
+- **Deciders:** <who made the call>
+
+## Context
+
+What is the problem or force that motivated this decision? What constraints
+apply (technical, product, team, timeline)? State facts, not opinions.
+
+## Options considered
+
+1. **<Option A>** — pros / cons.
+2. **<Option B>** — pros / cons.
+3. **<Option C>** — pros / cons.
+
+## Decision
+
+The option we chose, stated plainly.
+
+## Rationale
+
+Why this option won over the alternatives — the trade-offs we accepted.
+
+## Consequences
+
+- Positive: …
+- Negative / cost: …
+- Follow-ups or risks to revisit: …


### PR DESCRIPTION
## Summary

Documentation work across four issues, grounded in the actual implementation.

- **#545 — Architecture Decision Records:** new `docs/adr/` with an index, a reusable `template.md`, and **ADR-001…006**: choice of Soroban, brutalist design system, credit-score algorithm, storage tiering/TTL strategy, Zustand state management, and fee structure. Each documents context, options considered, decision, rationale, and consequences, and cross-links the relevant source (`credit.rs`, `storage.rs`, `fees.rs`, `frontend-scaffold/`).
- **#546 — Inline contract docs:** added step-by-step inline documentation through the credit-score computation in `credit.rs` and the leaderboard remove → find → insert → evict logic in `leaderboard.rs`, plus doc comments on its public `update_*`/`reset_leaderboard` functions. `cargo doc --no-deps` builds clean for these additions (the module/function docs in `fees.rs` and `storage.rs` were already thorough — examples, edge cases, TTL/key tables — so they were left as-is).
- **#543 — Deployment guide (`docs/DEPLOYMENT.md`):** added a **pre-deployment checklist** (security/audit, testing, resource & fee estimates), a **per-network configuration table** (testnet vs mainnet passphrase/RPC/SAC/keys), and an **emergency procedures & rollback** section (contract pause/unpause, Vercel promote/rollback, upgrade-vs-redeploy, key compromise, post-incident). Verified against `admin.rs` (`pause`/`unpause`/`upgrade`/`set_admin` all exist).
- **#544 — Contributor guide (`docs/CONTRIBUTING.md`):** added an **architecture overview with a diagram** (frontend ↔ RPC ↔ contract modules ↔ storage tiers) and a **Resources** section (project docs + Soroban/Stellar/Rust links). `docs/SETUP.md` already covered quick-start (< 30 min) and troubleshooting, so it needed no change.

## Test plan
- [x] `cargo doc --no-deps` (contracts/tipz) builds successfully; the inline-doc additions produce no new warnings
- [x] Markdown reviewed; internal links resolve within the repo

## Notes (out of scope)
- `cargo doc` emits ~25 pre-existing warnings about public API docs linking to private `ContractError::*` variants (across existing `lib.rs` entry points) — unrelated to this PR and left untouched.

Closes #543
Closes #544
Closes #545
Closes #546