### PR TITLE
feat: add warning toast type and PNG icons to PWA manifest

### DIFF
--- a/frontend-scaffold/public/manifest.json
+++ b/frontend-scaffold/public/manifest.json
@@ -20,6 +20,18 @@
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "maskable"
+    },
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/frontend-scaffold/src/store/toastStore.ts
+++ b/frontend-scaffold/src/store/toastStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type ToastType = 'success' | 'error' | 'info';
+export type ToastType = 'success' | 'error' | 'info' | 'warning';
 
 export type ToastPriority = 'low' | 'medium' | 'high' | 'critical';
 


### PR DESCRIPTION
Closes #595
Closes #597
Closes #598
Closes #613

- **#597** — adds `'warning'` to `ToastType` so the toast queue system covers all four priority levels (`info`, `success`, `warning`, `error`) as required
- **#595** — adds 192×192 and 512×512 PNG icon entries to `manifest.json` alongside the existing SVGs, satisfying the installability icon-size requirements