### PR TITLE
feat: env validation, Sentry integration, commitlint hooks, changelog…

### DIFF
--- a/.changelogrc.json
+++ b/.changelogrc.json
@@ -1,0 +1,17 @@
+{
+  "preset": "angular",
+  "releaseCount": 0,
+  "outputUnreleased": true,
+  "types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation", "hidden": false },
+    { "type": "chore", "section": "Miscellaneous", "hidden": false },
+    { "type": "refactor", "hidden": true },
+    { "type": "test", "hidden": true },
+    { "type": "build", "hidden": true },
+    { "type": "ci", "hidden": true }
+  ]
+}

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate changelog
+        run: npx conventional-changelog-cli@latest -p angular -i CHANGELOG.md -s -r 0
+
+      - name: Commit updated CHANGELOG
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore(release): update CHANGELOG for ${{ github.ref_name }}" || true
+          git push origin HEAD:main || true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES=$(npx conventional-changelog-cli@latest -p angular -r 1 --outfile /dev/stdout 2>/dev/null || echo "See CHANGELOG.md for details.")
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes "$NOTES"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh" 2>/dev/null || true
+
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,5 +15,11 @@ if git diff --cached --name-only | xargs grep -lE \
   exit 1
 fi
 
+# Run cargo fmt on staged Rust files
+STAGED_RS=$(git diff --cached --name-only | grep '\.rs$' || true)
+if [ -n "$STAGED_RS" ]; then
+  cargo fmt -- $STAGED_RS 2>/dev/null || true
+fi
+
 # Run lint-staged in frontend-scaffold
 cd frontend-scaffold && npx lint-staged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [conventional commits](https://www.conventionalcommits.org/)
+and this file is auto-generated on each release tag via the `release` GitHub Actions workflow.

--- a/frontend-scaffold/package.json
+++ b/frontend-scaffold/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
+    "@sentry/react": "^8.0.0",
     "@emotion/is-prop-valid": "^1.4.0",
     "@stellar/freighter-api": "1.7.1",
     "@stellar/stellar-sdk": "^11.3.0",

--- a/frontend-scaffold/src/components/shared/ErrorBoundary.tsx
+++ b/frontend-scaffold/src/components/shared/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ErrorState from './ErrorState';
 import { categorizeError } from '@/helpers/error';
 import { logger } from '../../services/logger';
+import { captureError } from '@/services/sentry';
 
 interface ErrorBoundaryProps {
   fallback?: React.ReactNode;
@@ -61,7 +62,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   };
 
   reportError = (error: Error, errorInfo: React.ErrorInfo) => {
-    // Future: Send to analytics service
+    captureError(error);
     logger.debug('components/shared/ErrorBoundary', 'Error reporting hook', {
       error: error.message,
       stack: error.stack,

--- a/frontend-scaffold/src/helpers/__tests__/env.test.ts
+++ b/frontend-scaffold/src/helpers/__tests__/env.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { getEnv } from '../env';
+import { getEnv, validateEnv } from '../env';
 
 describe('env helper', () => {
   it('uses default config when variables are missing', () => {
@@ -15,6 +15,10 @@ describe('env helper', () => {
   });
 
 
+
+  it('uses empty string for contractId when variable is missing', () => {
+    expect(getEnv({}).contractId).toBe('');
+  });
 
   it('can read runtime defaults without explicit map', () => {
     const runtimeEnv = getEnv();
@@ -40,5 +44,51 @@ describe('env helper', () => {
       network: 'FUTURENET',
       useMockData: true,
     });
+  });
+});
+
+describe('validateEnv', () => {
+  it('throws on missing VITE_CONTRACT_ID', () => {
+    expect(() => validateEnv({})).toThrow(/VITE_CONTRACT_ID is required/);
+  });
+
+  it('throws when VITE_CONTRACT_ID is empty string', () => {
+    expect(() => validateEnv({ VITE_CONTRACT_ID: '' })).toThrow(/VITE_CONTRACT_ID is required/);
+  });
+
+  it('validates RPC URL format', () => {
+    expect(() =>
+      validateEnv({ VITE_CONTRACT_ID: 'ABC', VITE_SOROBAN_RPC_URL: 'not-a-url' }),
+    ).toThrow(/must be a valid URL/);
+  });
+
+  it('validates Horizon URL format', () => {
+    expect(() =>
+      validateEnv({ VITE_CONTRACT_ID: 'ABC', VITE_HORIZON_URL: 'not-a-url' }),
+    ).toThrow(/must be a valid URL/);
+  });
+
+  it('warns on missing optional VITE_SENTRY_DSN', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    validateEnv({ VITE_CONTRACT_ID: 'ABC' });
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('VITE_SENTRY_DSN'));
+    spy.mockRestore();
+  });
+
+  it('does not warn when VITE_SENTRY_DSN is set', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    validateEnv({ VITE_CONTRACT_ID: 'ABC', VITE_SENTRY_DSN: 'https://sentry.example/1' });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('passes with valid required and optional vars', () => {
+    expect(() =>
+      validateEnv({
+        VITE_CONTRACT_ID: 'ABC123',
+        VITE_SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+        VITE_SENTRY_DSN: 'https://sentry.example/1',
+      }),
+    ).not.toThrow();
   });
 });

--- a/frontend-scaffold/src/helpers/env.ts
+++ b/frontend-scaffold/src/helpers/env.ts
@@ -42,3 +42,39 @@ export function getEnv(envVars?: Record<string, string | undefined>): EnvConfig 
 }
 
 export const env = getEnv();
+
+function isValidUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates required environment variables at startup.
+ * Throws on missing critical vars; warns on missing optional vars.
+ */
+export function validateEnv(envVars?: Record<string, string | undefined>): void {
+  const source =
+    envVars ??
+    (import.meta as unknown as { env: Record<string, string | undefined> }).env ??
+    {};
+
+  if (!source.VITE_CONTRACT_ID) {
+    throw new Error("VITE_CONTRACT_ID is required");
+  }
+
+  if (source.VITE_SOROBAN_RPC_URL && !isValidUrl(source.VITE_SOROBAN_RPC_URL)) {
+    throw new Error("VITE_SOROBAN_RPC_URL must be a valid URL");
+  }
+
+  if (source.VITE_HORIZON_URL && !isValidUrl(source.VITE_HORIZON_URL)) {
+    throw new Error("VITE_HORIZON_URL must be a valid URL");
+  }
+
+  if (!source.VITE_SENTRY_DSN) {
+    console.warn("[env] VITE_SENTRY_DSN is not set – error tracking will be disabled");
+  }
+}

--- a/frontend-scaffold/src/index.tsx
+++ b/frontend-scaffold/src/index.tsx
@@ -4,8 +4,24 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { I18nProvider } from "./i18n";
 import { logger } from "./services/logger";
+import { validateEnv } from "./helpers/env";
+import { initSentry } from "./services/sentry";
 
 import "./index.scss";
+
+try {
+  validateEnv();
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  logger.error("startup", "Environment validation failed", { error: msg });
+  const root = document.getElementById("root");
+  if (root) {
+    root.innerHTML = `<pre style="color:red;font-family:monospace;padding:1rem">Environment error: ${msg}\n\nSet the required variables in your .env file and restart.</pre>`;
+  }
+  throw err;
+}
+
+initSentry();
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<void>;

--- a/frontend-scaffold/src/services/sentry.ts
+++ b/frontend-scaffold/src/services/sentry.ts
@@ -1,0 +1,23 @@
+import * as Sentry from "@sentry/react";
+
+const viteEnv = (import.meta as { env?: Record<string, string | undefined> }).env ?? {};
+
+export function initSentry(): void {
+  const dsn = viteEnv.VITE_SENTRY_DSN;
+  if (!dsn) return;
+
+  Sentry.init({
+    dsn,
+    environment: viteEnv.VITE_NETWORK ?? "TESTNET",
+    tracesSampleRate: 0.1,
+    integrations: [Sentry.browserTracingIntegration()],
+  });
+}
+
+export function captureError(error: Error): void {
+  Sentry.captureException(error);
+}
+
+export function setUser(walletAddress: string | null): void {
+  Sentry.setUser(walletAddress ? { id: walletAddress } : null);
+}

--- a/frontend-scaffold/src/store/walletStore.ts
+++ b/frontend-scaffold/src/store/walletStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { secureStorage } from "../services/secureStorage";
 import type { WalletErrorType } from "../helpers/error";
+import { setUser } from "../services/sentry";
 
 export type Network = 'TESTNET' | 'PUBLIC';
 type SigningStatus = 'idle' | 'signing' | 'signed' | 'error';
@@ -106,13 +107,15 @@ export const useWalletStore = create<WalletStore>()(
           walletType: wt,
           sessionExpiresAt: Date.now() + SESSION_TIMEOUT_MS,
         });
+        setUser(publicKey);
       },
 
       setAddress: (publicKey: string, walletType?: string) => {
         get().connect(publicKey, walletType);
       },
 
-      disconnect: () =>
+      disconnect: () => {
+        setUser(null);
         set({
           wallets: [],
           activeWalletKey: null,
@@ -123,7 +126,8 @@ export const useWalletStore = create<WalletStore>()(
           walletType: null,
           signingStatus: 'idle',
           sessionExpiresAt: null,
-        }),
+        });
+      },
 
       clearAddress: () => {
         get().disconnect();

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "directories": {
     "doc": "docs"
   },
+  "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0"
+  },
   "scripts": {
     "prepare": "cd frontend-scaffold && npx husky ../../.husky || true",
     "dev": "cd frontend-scaffold && npm run dev",


### PR DESCRIPTION
… automation

Closes #615 - validateEnv() in env.ts throws on missing VITE_CONTRACT_ID, validates URL format for RPC/Horizon URLs, warns on missing VITE_SENTRY_DSN; called at startup in index.tsx before mounting.

Closes #548 - @sentry/react added; sentry.ts exposes initSentry/captureError/setUser; ErrorBoundary calls captureError; walletStore calls setUser on connect/disconnect; initSentry called in index.tsx after env validation.

Closes #535 - .husky/commit-msg enforces conventional commits via commitlint; @commitlint/cli + @commitlint/config-conventional added to root package.json; pre-commit hook extended with cargo fmt for staged .rs files.

Closes #537 - .github/workflows/release.yml auto-generates CHANGELOG.md and creates GitHub Release notes on every v* tag push; .changelogrc.json configures conventional-changelog output groups.

## Description

<!-- Brief description of what this PR does -->

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)

## Changes Made

<!-- List the specific changes -->

- 
- 
- 

## How to Test

<!-- Steps to verify the changes -->

1. 
2. 
3. 

## Checklist

### Contract Changes
- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (all tests)
- [ ] New tests written for new functionality
- [ ] No hardcoded values that should be configurable

### Frontend Changes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] Tested in browser with Freighter wallet
- [ ] Responsive design verified

### General
- [ ] Code follows project conventions
- [ ] Self-reviewed my own code
- [ ] No `console.log` or debug code left in
- [ ] Branch is up to date with `main`

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
