### PR TITLE
Feat/604 notification center with history

### DIFF
--- a/contracts/tipz/src/events.rs
+++ b/contracts/tipz/src/events.rs
@@ -60,7 +60,7 @@ pub fn emit_profile_reactivated(env: &Env, creator: &Address, actor: &Address) {
 // ── Tip events ────────────────────────────────────────────────────────────────
 
 /// Topics : `("tip", "sent")`
-/// Data   : `(id: u32, tipper: Address, creator: Address, amount: i128, message: String, timestamp: u64, is_anonymous: bool)`
+/// Data   : `(id: u32, tipper: Address, creator: Address, amount: i128, message: String, timestamp: u64, is_anonymous: bool, is_encrypted: bool)`
 ///
 /// All tip fields are included so that off-chain indexers can reconstruct the
 /// complete tip history from events alone, without relying on temporary storage
@@ -75,6 +75,7 @@ pub fn emit_tip_sent(
     message: &String,
     timestamp: u64,
     is_anonymous: bool,
+    is_encrypted: bool,
 ) {
     env.events().publish(
         (symbol_short!("tip"), symbol_short!("sent")),
@@ -86,6 +87,7 @@ pub fn emit_tip_sent(
             message.clone(),
             timestamp,
             is_anonymous,
+            is_encrypted,
         ),
     );
 }

--- a/contracts/tipz/src/lib.rs
+++ b/contracts/tipz/src/lib.rs
@@ -225,8 +225,9 @@ impl TipzContract {
         amount: i128,
         message: String,
         is_anonymous: bool,
+        is_encrypted: bool,
     ) -> Result<(), ContractError> {
-        tips::send_tip(&env, &tipper, &creator, amount, &message, is_anonymous)
+        tips::send_tip(&env, &tipper, &creator, amount, &message, is_anonymous, is_encrypted)
     }
 
     /// Send a tip on behalf of someone else.

--- a/contracts/tipz/src/test/test_access_control.rs
+++ b/contracts/tipz/src/test/test_access_control.rs
@@ -128,6 +128,7 @@ fn test_fee_collector_only_receives_fees_on_withdrawal() {
         &100_000_000_i128,
         &String::from_str(&ctx.env, "tip"),
         &false,
+        &false,
     );
     // Withdraw; fee goes to fee_collector, not arbitrary address
     ctx.client.withdraw_tips(&ctx.creator, &50_000_000_i128);
@@ -190,6 +191,7 @@ fn test_pause_blocks_send_tip() {
         &1_000_000_i128,
         &String::from_str(&ctx.env, "msg"),
         &false,
+        &false,
     );
     assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
 }
@@ -203,6 +205,7 @@ fn test_pause_blocks_withdraw_tips() {
         &ctx.creator,
         &10_000_000_i128,
         &String::from_str(&ctx.env, "tip"),
+        &false,
         &false,
     );
     ctx.client.pause(&ctx.admin);

--- a/contracts/tipz/src/test/test_anonymous_tips.rs
+++ b/contracts/tipz/src/test/test_anonymous_tips.rs
@@ -41,6 +41,7 @@ fn test_anonymous_tip() {
         &1_000_000,
         &String::from_str(&env, "Great work!"),
         &true,
+        &false,
     );
 
     // Get tip history for creator
@@ -72,6 +73,7 @@ fn test_tipper_sees_own_anonymous_tip() {
         &1_000_000,
         &String::from_str(&env, "Great work!"),
         &true,
+        &false,
     );
 
     // Tipper can see their own tips
@@ -102,6 +104,7 @@ fn test_non_anonymous_tip() {
         &creator,
         &1_000_000,
         &String::from_str(&env, "Great work!"),
+        &false,
         &false,
     );
 
@@ -137,6 +140,7 @@ fn test_mixed_anonymous_and_public_tips() {
         &1_000_000,
         &String::from_str(&env, "Anonymous support"),
         &true,
+        &false,
     );
 
     // Send public tip
@@ -145,6 +149,7 @@ fn test_mixed_anonymous_and_public_tips() {
         &creator,
         &2_000_000,
         &String::from_str(&env, "Public support"),
+        &false,
         &false,
     );
 

--- a/contracts/tipz/src/test/test_benchmark.rs
+++ b/contracts/tipz/src/test/test_benchmark.rs
@@ -142,6 +142,7 @@ fn benchmark_send_tip_gas() {
             &10_000_000_i128,
             &String::from_str(&s.env, "tip"),
             &false,
+            &false,
         );
     });
 

--- a/contracts/tipz/src/test/test_budget.rs
+++ b/contracts/tipz/src/test/test_budget.rs
@@ -252,7 +252,7 @@ fn test_send_tip_budget_short_message() {
 
     env.budget().reset_unlimited();
 
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 
     let cpu = env.budget().cpu_instruction_cost();
     let mem = env.budget().memory_bytes_cost();
@@ -292,7 +292,7 @@ fn test_send_tip_budget_max_message() {
 
     env.budget().reset_unlimited();
 
-    client.send_tip(&tipper, &creator, &amount, &max_msg, &false);
+    client.send_tip(&tipper, &creator, &amount, &max_msg, &false, &false);
 
     let cpu = env.budget().cpu_instruction_cost();
     let mem = env.budget().memory_bytes_cost();
@@ -345,7 +345,7 @@ fn test_send_tip_budget_full_leaderboard_rebalance() {
 
     env.budget().reset_unlimited();
 
-    client.send_tip(&tipper, &top_creator, &amount, &message, &false);
+    client.send_tip(&tipper, &top_creator, &amount, &message, &false, &false);
 
     let cpu = env.budget().cpu_instruction_cost();
     let mem = env.budget().memory_bytes_cost();
@@ -382,6 +382,7 @@ fn test_withdraw_tips_budget() {
         &creator,
         &tip_amount,
         &String::from_str(&env, ""),
+        &false,
         &false,
     );
 
@@ -473,6 +474,7 @@ fn test_send_tip_message_length_overhead() {
         &amount,
         &String::from_str(&env_empty, ""),
         &false,
+        &false,
     );
     let cpu_empty = env_empty.budget().cpu_instruction_cost();
 
@@ -485,7 +487,7 @@ fn test_send_tip_message_length_overhead() {
          AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     );
     env_full.budget().reset_unlimited();
-    client_full.send_tip(&tipper_full, &creator_full, &amount, &max_msg, &false);
+    client_full.send_tip(&tipper_full, &creator_full, &amount, &max_msg, &false, &false);
     let cpu_full = env_full.budget().cpu_instruction_cost();
 
     let overhead = cpu_full.saturating_sub(cpu_empty);

--- a/contracts/tipz/src/test/test_creator_min_tip.rs
+++ b/contracts/tipz/src/test/test_creator_min_tip.rs
@@ -48,10 +48,10 @@ fn test_creator_custom_min_tip() {
 
     client.set_min_tip(&creator, &500_i128);
 
-    let result = client.try_send_tip(&tipper, &creator, &100_i128, &msg, &false);
+    let result = client.try_send_tip(&tipper, &creator, &100_i128, &msg, &false, &false);
     assert_eq!(result, Err(Ok(ContractError::BelowCreatorMinimum)));
 
-    client.send_tip(&tipper, &creator, &500_i128, &msg, &false);
+    client.send_tip(&tipper, &creator, &500_i128, &msg, &false, &false);
 }
 
 #[test]

--- a/contracts/tipz/src/test/test_dos_protection.rs
+++ b/contracts/tipz/src/test/test_dos_protection.rs
@@ -155,6 +155,7 @@ fn test_message_length_bounded() {
         &1_000_000_i128,
         &valid_msg,
         &false,
+        &false,
     );
     assert!(result.is_ok());
 
@@ -165,6 +166,7 @@ fn test_message_length_bounded() {
         &bob,
         &1_000_000_i128,
         &long_msg,
+        &false,
         &false,
     );
     assert_eq!(result2, Err(Ok(ContractError::MessageTooLong)));
@@ -361,6 +363,7 @@ fn test_leaderboard_size_bounded() {
         &100_000_000_i128,
         &String::from_str(&env, "big tip"),
         &false,
+        &false,
     );
 
     // After update, the leaderboard should be capped at MAX_LEADERBOARD_SIZE
@@ -427,6 +430,7 @@ fn test_cleanup_inactive_profile_with_balance_rejected() {
         &creator,
         &1_000_000_i128,
         &String::from_str(&env, "tip"),
+        &false,
         &false,
     );
 

--- a/contracts/tipz/src/test/test_events.rs
+++ b/contracts/tipz/src/test/test_events.rs
@@ -64,7 +64,7 @@ fn test_event_tip_sent() {
     let message = String::from_str(&env, "thanks!");
 
     env.as_contract(&contract_id, || {
-        events::emit_tip_sent(&env, 0, &from, &to, 5_000_000, &message, 1234567890, false);
+        events::emit_tip_sent(&env, 0, &from, &to, 5_000_000, &message, 1234567890, false, false);
     });
 
     let all = env.events().all();
@@ -90,6 +90,7 @@ fn test_event_tip_sent_contains_all_indexing_fields() {
     env.as_contract(&contract_id, || {
         events::emit_tip_sent(
             &env, tip_id, &tipper, &creator, amount, &message, timestamp, false,
+            false,
         );
     });
 
@@ -102,14 +103,15 @@ fn test_event_tip_sent_contains_all_indexing_fields() {
     assert_topic!(topics.get(0).unwrap(), symbol_short!("tip"));
     assert_topic!(topics.get(1).unwrap(), symbol_short!("sent"));
 
-    // Verify data contains all 7 fields by decoding the tuple
-    let (ev_tip_id, ev_tipper, ev_creator, ev_amount, ev_message, ev_timestamp, ev_is_anonymous): (
+    // Verify data contains all 8 fields by decoding the tuple
+    let (ev_tip_id, ev_tipper, ev_creator, ev_amount, ev_message, ev_timestamp, ev_is_anonymous, ev_is_encrypted): (
         u32,
         Address,
         Address,
         i128,
         String,
         u64,
+        bool,
         bool,
     ) = soroban_sdk::FromVal::from_val(&env, &data);
 

--- a/contracts/tipz/src/test/test_goals.rs
+++ b/contracts/tipz/src/test/test_goals.rs
@@ -33,7 +33,7 @@ fn test_set_and_track_goal() {
     client.set_goal(&creator, &1000, &desc, &deadline);
 
     // Send tip
-    client.send_tip(&tipper, &creator, &500, &String::from_str(&env, "Good luck!"), &false);
+    client.send_tip(&tipper, &creator, &500, &String::from_str(&env, "Good luck!"), &false, &false);
 
     // Check goal progress
     let goal = client.get_goal(&creator);
@@ -68,7 +68,7 @@ fn test_goal_reached_event() {
     client.set_goal(&creator, &100, &desc, &0);
 
     // Send tip that reaches goal
-    client.send_tip(&tipper, &creator, &100, &String::from_str(&env, "Here you go!"), &false);
+    client.send_tip(&tipper, &creator, &100, &String::from_str(&env, "Here you go!"), &false, &false);
 
     // Check goal is reached
     let goal = client.get_goal(&creator);

--- a/contracts/tipz/src/test/test_integration.rs
+++ b/contracts/tipz/src/test/test_integration.rs
@@ -96,9 +96,9 @@ fn test_full_happy_path() {
 
     let message = String::from_str(&env, "Great work!");
 
-    client.send_tip(&tipper, &alice, &amount_alice, &message, &false);
-    client.send_tip(&tipper, &bob, &amount_bob, &message, &false);
-    client.send_tip(&tipper, &charlie, &amount_charlie, &message, &false);
+    client.send_tip(&tipper, &alice, &amount_alice, &message, &false, &false);
+    client.send_tip(&tipper, &bob, &amount_bob, &message, &false, &false);
+    client.send_tip(&tipper, &charlie, &amount_charlie, &message, &false, &false);
 
     // ──────────────────────────────────────────────────────────────────────────
     // Step 3: Verify balances match tip amounts

--- a/contracts/tipz/src/test/test_integration_advanced.rs
+++ b/contracts/tipz/src/test/test_integration_advanced.rs
@@ -94,7 +94,7 @@ fn test_multi_user_tipping_round_robin() {
     for i in 0..5 {
         let tipper = users.get(i).unwrap();
         let receiver = users.get((i + 1) % 5).unwrap();
-        client.send_tip(&tipper, &receiver, &tip_amount, &message, &false);
+        client.send_tip(&tipper, &receiver, &tip_amount, &message, &false, &false);
     }
 
     // 3. Verify balances: Each user should have exactly 50 XLM in contract balance
@@ -128,6 +128,7 @@ fn test_withdrawal_drains_entire_balance() {
         &tip_amount,
         &String::from_str(&env, "Tip"),
         &false,
+        &false,
     );
 
     let profile_before = client.get_profile(&creator);
@@ -158,7 +159,7 @@ fn test_rapid_tips_same_creator() {
 
     for _ in 0..100 {
         env.budget().reset_default();
-        client.send_tip(&tipper, &creator, &tip_amount, &message, &false);
+        client.send_tip(&tipper, &creator, &tip_amount, &message, &false, &false);
     }
 
     let profile = client.get_profile(&creator);
@@ -178,9 +179,9 @@ fn test_leaderboard_overtake() {
     let message = String::from_str(&env, "Tip!");
 
     // Alice gets 100 XLM
-    client.send_tip(&tipper, &alice, &1_000_000_000, &message, &false);
+    client.send_tip(&tipper, &alice, &1_000_000_000, &message, &false, &false);
     // Bob gets 50 XLM
-    client.send_tip(&tipper, &bob, &500_000_000, &message, &false);
+    client.send_tip(&tipper, &bob, &500_000_000, &message, &false, &false);
 
     // Verify Alice is #1
     let leaderboard = client.get_leaderboard(&2);
@@ -188,7 +189,7 @@ fn test_leaderboard_overtake() {
     assert_eq!(leaderboard.get(1).unwrap().address, bob);
 
     // Bob gets 100 XLM more (total 150 XLM)
-    client.send_tip(&tipper, &bob, &1_000_000_000, &message, &false);
+    client.send_tip(&tipper, &bob, &1_000_000_000, &message, &false, &false);
 
     // Verify Bob is #1
     let leaderboard_after = client.get_leaderboard(&2);
@@ -216,12 +217,14 @@ fn test_full_lifecycle() {
         &1_000_000_000,
         &String::from_str(&env, "A"),
         &false,
+        &false,
     );
     client.send_tip(
         &tipper,
         &bob,
         &2_000_000_000,
         &String::from_str(&env, "B"),
+        &false,
         &false,
     );
 
@@ -282,6 +285,7 @@ fn test_fee_change_mid_tip() {
         &creator,
         &tip_amount,
         &String::from_str(&env, "Tip"),
+        &false,
         &false,
     );
 

--- a/contracts/tipz/src/test/test_leaderboard.rs
+++ b/contracts/tipz/src/test/test_leaderboard.rs
@@ -142,6 +142,7 @@ fn test_leaderboard_single_creator() {
         &amount,
         &String::from_str(&env, ""),
         &false,
+        &false,
     );
 
     let board = client.get_leaderboard(&50);
@@ -172,9 +173,9 @@ fn test_leaderboard_ordering() {
 
     let msg = String::from_str(&env, "");
     // alice: 3 XLM, carol: 5 XLM, bob: 1 XLM  →  expected order: carol, alice, bob
-    client.send_tip(&tipper, &alice, &30_000_000, &msg, &false);
-    client.send_tip(&tipper, &carol, &50_000_000, &msg, &false);
-    client.send_tip(&tipper, &bob, &10_000_000, &msg, &false);
+    client.send_tip(&tipper, &alice, &30_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &carol, &50_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &bob, &10_000_000, &msg, &false, &false);
 
     let board = client.get_leaderboard(&50);
     assert_eq!(board.len(), 3);
@@ -303,8 +304,8 @@ fn test_leaderboard_rank_update() {
     let msg = String::from_str(&env, "");
 
     // Bob starts in the lead.
-    client.send_tip(&tipper, &bob, &50_000_000, &msg, &false);
-    client.send_tip(&tipper, &alice, &10_000_000, &msg, &false);
+    client.send_tip(&tipper, &bob, &50_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &alice, &10_000_000, &msg, &false, &false);
 
     let board_before = client.get_leaderboard(&50);
     assert_eq!(
@@ -314,7 +315,7 @@ fn test_leaderboard_rank_update() {
     );
 
     // Alice receives a larger tip and overtakes bob.
-    client.send_tip(&tipper, &alice, &100_000_000, &msg, &false);
+    client.send_tip(&tipper, &alice, &100_000_000, &msg, &false, &false);
 
     let board_after = client.get_leaderboard(&50);
     assert_eq!(
@@ -344,9 +345,9 @@ fn test_leaderboard_rank_lookup() {
 
     let msg = String::from_str(&env, "");
     // carol: 5 XLM → rank 1, alice: 3 XLM → rank 2, bob: 1 XLM → rank 3
-    client.send_tip(&tipper, &carol, &50_000_000, &msg, &false);
-    client.send_tip(&tipper, &alice, &30_000_000, &msg, &false);
-    client.send_tip(&tipper, &bob, &10_000_000, &msg, &false);
+    client.send_tip(&tipper, &carol, &50_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &alice, &30_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &bob, &10_000_000, &msg, &false, &false);
 
     assert_eq!(
         client.get_leaderboard_rank(&crate::types::LeaderboardPeriod::AllTime, &carol),
@@ -385,13 +386,13 @@ fn test_insert_at_position_zero() {
     insert_profile(&env, &contract_id, &bob, "bob");
 
     let msg = String::from_str(&env, "");
-    client.send_tip(&tipper, &alice, &20_000_000, &msg, &false); // 2 XLM
-    client.send_tip(&tipper, &bob, &10_000_000, &msg, &false); // 1 XLM
+    client.send_tip(&tipper, &alice, &20_000_000, &msg, &false, &false); // 2 XLM
+    client.send_tip(&tipper, &bob, &10_000_000, &msg, &false, &false); // 1 XLM
 
     // carol arrives with the highest tip — must claim rank 1 (index 0).
     let carol = Address::generate(&env);
     insert_profile(&env, &contract_id, &carol, "carol");
-    client.send_tip(&tipper, &carol, &50_000_000, &msg, &false); // 5 XLM
+    client.send_tip(&tipper, &carol, &50_000_000, &msg, &false, &false); // 5 XLM
 
     let board = client.get_leaderboard(&crate::types::LeaderboardPeriod::AllTime, &50);
     assert_eq!(board.len(), 3);
@@ -425,6 +426,7 @@ fn test_insert_when_board_has_one_entry() {
         &30_000_000,
         &String::from_str(&env, ""),
         &false,
+        &false,
     ); // 3 XLM
 
     let board_one = client.get_leaderboard(&crate::types::LeaderboardPeriod::AllTime, &50);
@@ -439,6 +441,7 @@ fn test_insert_when_board_has_one_entry() {
         &bob,
         &10_000_000,
         &String::from_str(&env, ""),
+        &false,
         &false,
     ); // 1 XLM
 
@@ -467,9 +470,9 @@ fn test_no_duplicates_after_update() {
     insert_profile(&env, &contract_id, &alice, "alice");
 
     let msg = String::from_str(&env, "");
-    client.send_tip(&tipper, &alice, &10_000_000, &msg, &false); // tip 1 — 1 XLM
-    client.send_tip(&tipper, &alice, &20_000_000, &msg, &false); // tip 2 — 2 XLM
-    client.send_tip(&tipper, &alice, &30_000_000, &msg, &false); // tip 3 — 3 XLM
+    client.send_tip(&tipper, &alice, &10_000_000, &msg, &false, &false); // tip 1 — 1 XLM
+    client.send_tip(&tipper, &alice, &20_000_000, &msg, &false, &false); // tip 2 — 2 XLM
+    client.send_tip(&tipper, &alice, &30_000_000, &msg, &false, &false); // tip 3 — 3 XLM
 
     let board = client.get_leaderboard(&50);
     assert_eq!(

--- a/contracts/tipz/src/test/test_min_tip.rs
+++ b/contracts/tipz/src/test/test_min_tip.rs
@@ -73,7 +73,7 @@ fn test_tip_below_minimum_fails() {
     let message = String::from_str(&env, "tip");
     let amount: i128 = min - 1;
 
-    let res = client.try_send_tip(&tipper, &creator, &amount, &message, &false);
+    let res = client.try_send_tip(&tipper, &creator, &amount, &message, &false, &false);
     assert_eq!(res, Err(Ok(ContractError::TipBelowMinimum)));
 }
 
@@ -84,7 +84,7 @@ fn test_tip_at_minimum_succeeds() {
     let min = client.get_min_tip_amount();
     let message = String::from_str(&env, "tip");
 
-    client.send_tip(&tipper, &creator, &min, &message, &false);
+    client.send_tip(&tipper, &creator, &min, &message, &false, &false);
 }
 
 #[test]

--- a/contracts/tipz/src/test/test_pause.rs
+++ b/contracts/tipz/src/test/test_pause.rs
@@ -71,7 +71,7 @@ fn test_pause_blocks_tips() {
     let message = String::from_str(&env, "tip");
     let amount: i128 = 100_000_000;
 
-    let res = client.try_send_tip(&tipper, &creator, &amount, &message, &false);
+    let res = client.try_send_tip(&tipper, &creator, &amount, &message, &false, &false);
     assert_eq!(res, Err(Ok(ContractError::ContractPaused)));
 }
 
@@ -86,7 +86,7 @@ fn test_unpause_allows_tips() {
     let message = String::from_str(&env, "tip");
     let amount: i128 = 100_000_000;
 
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 }
 
 #[test]

--- a/contracts/tipz/src/test/test_refund.rs
+++ b/contracts/tipz/src/test/test_refund.rs
@@ -71,6 +71,7 @@ fn test_refund_within_window() {
         &tip_amount,
         &String::from_str(&env, "Great work!"),
         &false,
+        &false,
     );
 
     let tip_id = 0_u32;
@@ -126,6 +127,7 @@ fn test_refund_after_window_fails() {
         &tip_amount,
         &String::from_str(&env, "Great work!"),
         &false,
+        &false,
     );
 
     let tip_id = 0_u32;
@@ -165,6 +167,7 @@ fn test_auto_approve_after_timeout() {
         &creator,
         &tip_amount,
         &String::from_str(&env, "Great work!"),
+        &false,
         &false,
     );
 
@@ -219,6 +222,7 @@ fn test_creator_rejects_refund() {
         &tip_amount,
         &String::from_str(&env, "Great work!"),
         &false,
+        &false,
     );
 
     let tip_id = 0_u32;
@@ -258,6 +262,7 @@ fn test_refund_already_requested() {
         &tip_amount,
         &String::from_str(&env, "Great work!"),
         &false,
+        &false,
     );
 
     let tip_id = 0_u32;
@@ -290,6 +295,7 @@ fn test_refund_not_tipper() {
         &tip_amount,
         &String::from_str(&env, "Great work!"),
         &false,
+        &false,
     );
 
     let tip_id = 0_u32;
@@ -318,6 +324,7 @@ fn test_refund_not_creator_approve() {
         &creator,
         &tip_amount,
         &String::from_str(&env, "Great work!"),
+        &false,
         &false,
     );
 
@@ -349,6 +356,7 @@ fn test_refund_already_processed() {
         &creator,
         &tip_amount,
         &String::from_str(&env, "Great work!"),
+        &false,
         &false,
     );
 
@@ -435,6 +443,7 @@ fn test_refund_updates_credit_score() {
         &tip_amount,
         &String::from_str(&env, "Great work!"),
         &false,
+        &false,
     );
 
     let profile_before = client.get_profile(&creator);
@@ -472,6 +481,7 @@ fn test_refund_multiple_tips() {
             &tip_amount,
             &String::from_str(&env, "Great work!"),
             &false,
+            &false,
         );
     }
 
@@ -505,6 +515,7 @@ fn test_process_pending_refunds_multiple() {
             &creator,
             &tip_amount,
             &String::from_str(&env, "Great work!"),
+            &false,
             &false,
         );
     }
@@ -559,6 +570,7 @@ fn test_refund_no_request_exists() {
         &creator,
         &tip_amount,
         &String::from_str(&env, "Great work!"),
+        &false,
         &false,
     );
 

--- a/contracts/tipz/src/test/test_security.rs
+++ b/contracts/tipz/src/test/test_security.rs
@@ -59,6 +59,7 @@ fn test_integer_overflow_protection() {
         &-1i128,
         &String::from_str(&env, "msg"),
         &false,
+        &false,
     );
     assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
 
@@ -84,12 +85,14 @@ fn test_state_consistency() {
         &tip_amount,
         &String::from_str(&env, "msg1"),
         &false,
+        &false,
     );
     client.send_tip(
         &tipper,
         &creator2,
         &tip_amount,
         &String::from_str(&env, "msg2"),
+        &false,
         &false,
     );
 
@@ -132,6 +135,7 @@ fn test_storage_bounds() {
             &creator,
             &100_i128,
             &String::from_str(&env, "msg"),
+            &false,
             &false,
         );
     }

--- a/contracts/tipz/src/test/test_snapshots.rs
+++ b/contracts/tipz/src/test/test_snapshots.rs
@@ -328,6 +328,7 @@ fn snapshot_storage_after_tip() {
         &10_000_000_i128,
         &SorobanString::from_str(&env, "Great work!"),
         &false,
+        &false,
     );
 
     let snap = snapshot_storage(&env, &client.address, &ctx);

--- a/contracts/tipz/src/test/test_stats.rs
+++ b/contracts/tipz/src/test/test_stats.rs
@@ -43,12 +43,14 @@ fn test_platform_stats() {
         &1_000_000,
         &String::from_str(&env, "tip1"),
         &false,
+        &false,
     );
     client.send_tip(
         &tipper,
         &creator2,
         &2_000_000,
         &String::from_str(&env, "tip2"),
+        &false,
         &false,
     );
     client.send_tip(
@@ -57,6 +59,7 @@ fn test_platform_stats() {
         &3_000_000,
         &String::from_str(&env, "tip3"),
         &false,
+        &false,
     );
     client.send_tip(
         &tipper,
@@ -64,12 +67,14 @@ fn test_platform_stats() {
         &4_000_000,
         &String::from_str(&env, "tip4"),
         &false,
+        &false,
     );
     client.send_tip(
         &tipper,
         &creator2,
         &5_000_000,
         &String::from_str(&env, "tip5"),
+        &false,
         &false,
     );
 
@@ -99,6 +104,7 @@ fn test_stats_update_on_tip() {
         &1_000_000,
         &String::from_str(&env, "tip"),
         &false,
+        &false,
     );
 
     let after = client.get_platform_stats();
@@ -125,12 +131,14 @@ fn test_creator_stats() {
         &5_000_000,
         &String::from_str(&env, "tip1"),
         &false,
+        &false,
     );
     client.send_tip(
         &tipper,
         &creator,
         &10_000_000,
         &String::from_str(&env, "tip2"),
+        &false,
         &false,
     );
 
@@ -160,6 +168,7 @@ fn test_24h_stats_tracking() {
         &1_000_000,
         &String::from_str(&env, "tip"),
         &false,
+        &false,
     );
 
     let stats = client.get_platform_stats();
@@ -185,6 +194,7 @@ fn test_stats_after_withdrawal() {
         &creator,
         &10_000_000,
         &String::from_str(&env, "tip"),
+        &false,
         &false,
     );
 
@@ -217,6 +227,7 @@ fn test_platform_stats_multiple_creators() {
             &creator,
             &((i + 1) as i128 * 1_000_000),
             &String::from_str(&env, "tip"),
+            &false,
             &false,
         );
     }

--- a/contracts/tipz/src/test/test_streaks.rs
+++ b/contracts/tipz/src/test/test_streaks.rs
@@ -90,7 +90,7 @@ fn send_daily_tip(
     env.ledger().set_timestamp(timestamp);
     let message = String::from_str(env, "keep it up");
     let amount: i128 = 50_000_000;
-    client.send_tip(tipper, creator, &amount, &message, &false);
+    client.send_tip(tipper, creator, &amount, &message, &false, &false);
 }
 
 #[test]

--- a/contracts/tipz/src/test/test_tips.rs
+++ b/contracts/tipz/src/test/test_tips.rs
@@ -100,7 +100,7 @@ fn test_send_tip_success() {
     let message = String::from_str(&env, "Great work!");
     let amount: i128 = 10_000_000; // 1 XLM
 
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 
     // Verify XLM was transferred from tipper to the contract
     assert_eq!(token_client.balance(&tipper), tipper_before - amount);
@@ -151,7 +151,7 @@ fn test_send_tip_updates_credit_score() {
     let amount: i128 = 500_000_000;
     let message = String::from_str(&env, "great content");
 
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 
     // calculate_credit_score recalculates and persists the score
     let score = client.calculate_credit_score(&creator);
@@ -206,7 +206,7 @@ fn test_send_tip_self() {
     });
 
     let message = String::from_str(&env, "Self tip");
-    let result = client.try_send_tip(&self_tipper, &self_tipper, &10_000_000, &message, &false);
+    let result = client.try_send_tip(&self_tipper, &self_tipper, &10_000_000, &message, &false, &false);
     assert_eq!(result, Err(Ok(ContractError::CannotTipSelf)));
 }
 
@@ -217,7 +217,7 @@ fn test_send_tip_unregistered_creator() {
     let unregistered = Address::generate(&env);
     let message = String::from_str(&env, "Hello");
 
-    let result = client.try_send_tip(&tipper, &unregistered, &10_000_000, &message, &false);
+    let result = client.try_send_tip(&tipper, &unregistered, &10_000_000, &message, &false, &false);
     assert_eq!(result, Err(Ok(ContractError::NotRegistered)));
 }
 
@@ -226,7 +226,7 @@ fn test_send_tip_zero_amount() {
     let (env, client, _contract_id, tipper, creator, _sac) = setup_env();
 
     let message = String::from_str(&env, "Zero tip");
-    let result = client.try_send_tip(&tipper, &creator, &0, &message, &false);
+    let result = client.try_send_tip(&tipper, &creator, &0, &message, &false, &false);
     assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
 }
 
@@ -235,7 +235,7 @@ fn test_send_tip_invalid_amount_negative() {
     let (env, client, _contract_id, tipper, creator, _sac) = setup_env();
 
     let message = String::from_str(&env, "Negative tip");
-    let result = client.try_send_tip(&tipper, &creator, &-1, &message, &false);
+    let result = client.try_send_tip(&tipper, &creator, &-1, &message, &false, &false);
     assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
 }
 
@@ -248,7 +248,7 @@ fn test_send_tip_message_too_long() {
         &env,
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     );
-    let result = client.try_send_tip(&tipper, &creator, &10_000_000, &long_msg, &false);
+    let result = client.try_send_tip(&tipper, &creator, &10_000_000, &long_msg, &false, &false);
     assert_eq!(result, Err(Ok(ContractError::MessageTooLong)));
 }
 
@@ -258,7 +258,7 @@ fn test_send_tip_insufficient_xlm() {
 
     let broke = Address::generate(&env);
     let message = String::from_str(&env, "no funds");
-    let result = client.try_send_tip(&broke, &creator, &10_000_000, &message, &false);
+    let result = client.try_send_tip(&broke, &creator, &10_000_000, &message, &false, &false);
     assert_eq!(result, Err(Ok(ContractError::InsufficientBalance)));
 }
 
@@ -270,9 +270,9 @@ fn test_send_tip_multiple() {
     let amount: i128 = 5_000_000;
 
     // Send 3 tips
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 
     // Verify accumulated balance and counts
     env.as_contract(&contract_id, || {
@@ -346,8 +346,8 @@ fn test_send_tip_updates_leaderboard() {
     let message = String::from_str(&env, "tip");
 
     // creator1 receives 20 XLM, creator2 receives 10 XLM
-    client.send_tip(&tipper, &creator, &200_000_000, &message, &false);
-    client.send_tip(&tipper, &creator2, &100_000_000, &message, &false);
+    client.send_tip(&tipper, &creator, &200_000_000, &message, &false, &false);
+    client.send_tip(&tipper, &creator2, &100_000_000, &message, &false, &false);
 
     // Verify leaderboard data — total_tips_received correctly reflects
     // each creator's rank. The full leaderboard sort/query is in issue #17.
@@ -382,7 +382,7 @@ fn test_send_tip_updates_leaderboard_once() {
     let message = String::from_str(&env, "tip");
     let amount: i128 = 100_000_000;
 
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 
     env.as_contract(&contract_id, || {
         let entries = crate::leaderboard::get_leaderboard(&env, crate::types::LeaderboardPeriod::AllTime, 0);
@@ -408,7 +408,7 @@ fn test_send_tip_empty_message_allowed() {
     let message = String::from_str(&env, "");
     let amount: i128 = 10_000_000;
 
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 
     env.as_contract(&contract_id, || {
         let profile: Profile = env
@@ -429,7 +429,7 @@ fn test_send_tip_contract_sac_holds_transferred_xlm() {
     let amount: i128 = 10_000_000;
     let message = String::from_str(&env, "custody");
 
-    client.send_tip(&tipper, &creator, &amount, &message, &false);
+    client.send_tip(&tipper, &creator, &amount, &message, &false, &false);
 
     let after = token_client.balance(&contract_id);
     assert_eq!(after - before, amount);
@@ -473,9 +473,9 @@ fn test_get_tips_by_tipper_returns_correct_tips() {
     let msg2 = String::from_str(&env, "tip 2");
     let msg3 = String::from_str(&env, "tip 3");
 
-    client.send_tip(&tipper, &creator, &10_000_000, &msg1, &false);
-    client.send_tip(&tipper, &creator, &20_000_000, &msg2, &false);
-    client.send_tip(&tipper, &creator, &30_000_000, &msg3, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg1, &false, &false);
+    client.send_tip(&tipper, &creator, &20_000_000, &msg2, &false, &false);
+    client.send_tip(&tipper, &creator, &30_000_000, &msg3, &false, &false);
 
     let tips = client.get_tips_by_tipper(&tipper, &10);
     assert_eq!(tips.len(), 3);
@@ -491,9 +491,9 @@ fn test_get_tips_by_tipper_respects_limit() {
     let (env, client, _contract_id, tipper, creator, _sac) = setup_env();
 
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false, &false);
 
     let tips = client.get_tips_by_tipper(&tipper, &2);
     assert_eq!(tips.len(), 2);
@@ -518,10 +518,10 @@ fn test_get_tipper_tip_count() {
     assert_eq!(client.get_tipper_tip_count(&tipper), 0);
 
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
     assert_eq!(client.get_tipper_tip_count(&tipper), 1);
 
-    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false, &false);
     assert_eq!(client.get_tipper_tip_count(&tipper), 2);
 }
 
@@ -535,9 +535,9 @@ fn test_get_tips_by_tipper_isolates_tippers() {
     asset.mint(&tipper2, &100_000_000_000);
 
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
-    client.send_tip(&tipper2, &creator, &20_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
+    client.send_tip(&tipper2, &creator, &20_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false, &false);
 
     let tips1 = client.get_tips_by_tipper(&tipper, &10);
     assert_eq!(tips1.len(), 2);
@@ -556,9 +556,9 @@ fn test_get_recent_tips_returns_newest_first() {
     let (env, client, _contract_id, tipper, creator, _sac) = setup_env();
 
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false, &false);
 
     let tips = client.get_recent_tips(&creator, &10, &0);
     assert_eq!(tips.len(), 3);
@@ -572,10 +572,10 @@ fn test_get_recent_tips_offset_skips_newest() {
     let (env, client, _contract_id, tipper, creator, _sac) = setup_env();
 
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &40_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &40_000_000, &msg, &false, &false);
 
     // Skip the 2 newest, get next 2
     let tips = client.get_recent_tips(&creator, &2, &2);
@@ -590,9 +590,9 @@ fn test_get_recent_tips_limit_capped_at_50() {
 
     let msg = String::from_str(&env, "tip");
     // Send 3 tips but request 100 — should return all 3 (capped internally)
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false);
-    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false, &false);
+    client.send_tip(&tipper, &creator, &30_000_000, &msg, &false, &false);
 
     let tips = client.get_recent_tips(&creator, &100, &0);
     assert_eq!(tips.len(), 3);
@@ -603,7 +603,7 @@ fn test_get_recent_tips_offset_beyond_count_returns_empty() {
     let (env, client, _contract_id, tipper, creator, _sac) = setup_env();
 
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
 
     let tips = client.get_recent_tips(&creator, &10, &100);
     assert_eq!(tips.len(), 0);
@@ -624,10 +624,10 @@ fn test_get_creator_tip_count() {
     assert_eq!(client.get_creator_tip_count(&creator), 0);
 
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
     assert_eq!(client.get_creator_tip_count(&creator), 1);
 
-    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &20_000_000, &msg, &false, &false);
     assert_eq!(client.get_creator_tip_count(&creator), 2);
 }
 
@@ -638,7 +638,7 @@ fn test_get_recent_tips_pagination_full_walk() {
     let msg = String::from_str(&env, "tip");
     // Send 5 tips
     for i in 1..=5 {
-        client.send_tip(&tipper, &creator, &(i * 10_000_000), &msg, &false);
+        client.send_tip(&tipper, &creator, &(i * 10_000_000), &msg, &false, &false);
     }
 
     // Page 1: offset 0, limit 2 → tips 5, 4

--- a/contracts/tipz/src/test/test_ttl_desync.rs
+++ b/contracts/tipz/src/test/test_ttl_desync.rs
@@ -93,7 +93,7 @@ fn test_send_tip_bumps_creator_profile_ttl() {
     let (env, client, contract_id, creator, tipper) = setup();
 
     let msg = String::from_str(&env, "great work");
-    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &10_000_000, &msg, &false, &false);
 
     env.as_contract(&contract_id, || {
         let profile_key = DataKey::Profile(creator.clone());
@@ -145,7 +145,7 @@ fn test_withdraw_bumps_profile_ttl() {
 
     // Give the creator a balance first
     let msg = String::from_str(&env, "tip");
-    client.send_tip(&tipper, &creator, &50_000_000, &msg, &false);
+    client.send_tip(&tipper, &creator, &50_000_000, &msg, &false, &false);
 
     client.withdraw_tips(&creator, &10_000_000);
 

--- a/contracts/tipz/src/tips.rs
+++ b/contracts/tipz/src/tips.rs
@@ -25,6 +25,7 @@ pub fn store_tip(
     amount: i128,
     message: String,
     is_anonymous: bool,
+    is_encrypted: bool,
 ) -> u32 {
     let tip_id = storage::increment_tip_count(env);
     store_tip_with_id(
@@ -36,6 +37,7 @@ pub fn store_tip(
         amount,
         message,
         is_anonymous,
+        is_encrypted,
     );
     tip_id
 }
@@ -49,6 +51,7 @@ fn store_tip_with_id(
     amount: i128,
     message: String,
     is_anonymous: bool,
+    is_encrypted: bool,
 ) {
     let key = DataKey::Tip(tip_id);
     let tip = Tip {
@@ -64,6 +67,7 @@ fn store_tip_with_id(
         message,
         timestamp: env.ledger().timestamp(),
         is_anonymous,
+        is_encrypted,
     };
 
     env.storage().temporary().set(&key, &tip);
@@ -156,6 +160,7 @@ pub fn send_tip(
     amount: i128,
     message: &String,
     is_anonymous: bool,
+    is_encrypted: bool,
 ) -> Result<(), ContractError> {
     storage::extend_instance_ttl(env);
     let config = storage::get_runtime_config(env).ok_or(ContractError::NotInitialized)?;
@@ -244,6 +249,7 @@ pub fn send_tip(
         amount,
         message.clone(),
         is_anonymous,
+        is_encrypted,
     );
     storage::add_tipper_tip(env, tipper, tip_id);
     storage::add_creator_tip(env, creator, tip_id);
@@ -261,6 +267,7 @@ pub fn send_tip(
         message,
         timestamp,
         is_anonymous,
+        is_encrypted,
     );
 
     Ok(())
@@ -329,6 +336,7 @@ pub fn send_tip_on_behalf(
         amount,
         message.clone(),
         false,
+        false,
     );
     storage::add_tipper_tip(env, sender, tip_id);
     storage::add_tipper_tip(env, on_behalf_of, tip_id); // Also show in benefactor's history
@@ -340,7 +348,7 @@ pub fn send_tip_on_behalf(
     crate::stats::mark_creator_active(env, creator);
 
     emit_tip_sent(
-        env, tip_id, sender, creator, amount, message, timestamp, false,
+        env, tip_id, sender, creator, amount, message, timestamp, false, false,
     );
 
     Ok(())
@@ -595,6 +603,7 @@ pub fn deliver_scheduled_tip(
         scheduled_tip.amount,
         scheduled_tip.message.clone(),
         false,
+        false,
     );
     storage::add_tipper_tip(env, &scheduled_tip.sender, tip_id);
     storage::add_creator_tip(env, &scheduled_tip.creator, tip_id);
@@ -613,6 +622,7 @@ pub fn deliver_scheduled_tip(
         scheduled_tip.amount,
         &scheduled_tip.message,
         now,
+        false,
         false,
     );
 

--- a/contracts/tipz/src/types.rs
+++ b/contracts/tipz/src/types.rs
@@ -191,12 +191,14 @@ pub struct Tip {
     pub creator: Address,
     /// Tip amount in stroops
     pub amount: i128,
-    /// Optional message (0-280 chars)
+    /// Optional message (0-280 chars) — may be encrypted
     pub message: String,
     /// Ledger timestamp at the time the tip was sent
     pub timestamp: u64,
     /// Whether this tip is anonymous
     pub is_anonymous: bool,
+    /// Whether the message is encrypted so only the recipient can read it
+    pub is_encrypted: bool,
 }
 
 /// Supporter/creator streak record.

--- a/frontend-scaffold/package.json
+++ b/frontend-scaffold/package.json
@@ -108,6 +108,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.9.5",
     "recharts": "^2.15.4",
+    "tweetnacl": "^1.0.3",
+    "tweetnacl-util": "^0.15.1",
     "zustand": "^5.0.0"
   }
 }

--- a/frontend-scaffold/src/components/layout/Header.tsx
+++ b/frontend-scaffold/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ import WalletBalance from "../shared/WalletBalance";
 import WalletSwitcher from "../shared/WalletSwitcher";
 import Button from "../ui/Button";
 import { getModifierKey } from "../../hooks/useKeyboardShortcuts";
+import NotificationBell from "@/features/notifications/NotificationBell";
 import MobileDrawer from "./MobileDrawer";
 
 const UNSEEN_TIPS_KEY = "tipz_unseen_tips";
@@ -150,6 +151,7 @@ const Header: React.FC = () => {
         </nav>
 
         <div className="hidden items-center gap-4 md:flex">
+          <NotificationBell />
           <button
             type="button"
             onClick={toggleTheme}
@@ -199,18 +201,21 @@ const Header: React.FC = () => {
           )}
         </div>
 
-        <button
-          type="button"
-          className="inline-flex items-center justify-center border-2 border-black bg-white p-2 dark:border-white dark:bg-black md:hidden"
-          style={{ boxShadow: shadow }}
-          aria-label={
-            mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"
-          }
-          aria-expanded={mobileMenuOpen}
-          onClick={() => setMobileMenuOpen((open) => !open)}
-        >
-          {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
-        </button>
+        <div className="flex items-center gap-2 md:hidden">
+          <NotificationBell />
+          <button
+            type="button"
+            className="inline-flex items-center justify-center border-2 border-black bg-white p-2 dark:border-white dark:bg-black"
+            style={{ boxShadow: shadow }}
+            aria-label={
+              mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"
+            }
+            aria-expanded={mobileMenuOpen}
+            onClick={() => setMobileMenuOpen((open) => !open)}
+          >
+            {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
+        </div>
       </div>
 
       <MobileDrawer

--- a/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
+++ b/frontend-scaffold/src/features/dashboard/DashboardPage.tsx
@@ -231,7 +231,7 @@ const DashboardPage: React.FC = () => {
               <p className="text-sm font-bold text-gray-700">
                 {stroopToXlm(latestTip.amount)} XLM from{" "}
                 {latestTip.tipper.slice(0, 6)}...{latestTip.tipper.slice(-6)}
-                {latestTip.message ? ` - ${latestTip.message}` : ""}
+                {latestTip.isEncrypted ? ' - 🔒 Encrypted message' : latestTip.message ? ` - ${latestTip.message}` : ""}
               </p>
             </div>
           </div>

--- a/frontend-scaffold/src/features/dashboard/TipsTab.tsx
+++ b/frontend-scaffold/src/features/dashboard/TipsTab.tsx
@@ -65,7 +65,9 @@ const TipsTab: React.FC = () => {
     date: formatTimestamp(tip.timestamp),
     tipper: truncateAddress(tip.tipper),
     amount: `${stroopToXlm(tip.amount, 7)} XLM`,
-    message: tip.message || "—",
+    message: tip.isEncrypted && tip.message
+      ? <span><span className="text-amber-600 mr-1">🔒</span>Encrypted</span>
+      : (tip.message || "—"),
   }));
 
   const columns = [

--- a/frontend-scaffold/src/features/notifications/NotificationBell.tsx
+++ b/frontend-scaffold/src/features/notifications/NotificationBell.tsx
@@ -1,0 +1,58 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { Bell } from 'lucide-react';
+import { useNotificationStore } from '@/store/notificationStore';
+import NotificationCenter from './NotificationCenter';
+
+const NotificationBell: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const unreadCount = useNotificationStore((s) =>
+    s.notifications.filter((n) => n.unread).length,
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="relative inline-flex items-center justify-center border-2 border-black bg-white p-2 transition-opacity hover:opacity-60 dark:border-white dark:bg-black"
+        aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+        aria-expanded={open}
+      >
+        <Bell size={20} />
+        {unreadCount > 0 && (
+          <span className="absolute -right-1.5 -top-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full border-2 border-black bg-red-500 px-1 text-[10px] font-black leading-none text-white">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-2 w-80 sm:w-96 border-2 border-black bg-white shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] z-50">
+          <NotificationCenter onClose={() => setOpen(false)} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBell;

--- a/frontend-scaffold/src/features/notifications/NotificationCenter.tsx
+++ b/frontend-scaffold/src/features/notifications/NotificationCenter.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Bell, CheckCheck, Trash2, Gift, Star, Info, Circle } from 'lucide-react';
+import { useNotificationStore, type NotificationType, type AppNotification } from '@/store/notificationStore';
+
+const TYPE_CONFIG: Record<NotificationType, { icon: React.ReactNode; color: string }> = {
+  tip: { icon: <Gift size={16} />, color: 'text-green-600' },
+  achievement: { icon: <Star size={16} />, color: 'text-yellow-500' },
+  system: { icon: <Info size={16} />, color: 'text-blue-500' },
+};
+
+function formatRelativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+interface NotificationItemProps {
+  notification: AppNotification;
+  onClose: () => void;
+}
+
+const NotificationItem: React.FC<NotificationItemProps> = ({ notification, onClose }) => {
+  const navigate = useNavigate();
+  const markAsRead = useNotificationStore((s) => s.markAsRead);
+  const config = TYPE_CONFIG[notification.type];
+
+  const handleClick = () => {
+    if (notification.unread) {
+      markAsRead(notification.id);
+    }
+    if (notification.link) {
+      navigate(notification.link);
+    }
+    onClose();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`w-full text-left flex items-start gap-3 px-4 py-3 border-b border-gray-200 transition-colors hover:bg-gray-50 ${
+        notification.unread ? 'bg-blue-50' : ''
+      }`}
+    >
+      <span className={`mt-0.5 shrink-0 ${config.color}`}>{config.icon}</span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-bold text-gray-900 truncate">{notification.title}</p>
+        <p className="text-xs text-gray-600 mt-0.5 line-clamp-2">{notification.message}</p>
+        <p className="text-[10px] text-gray-400 mt-1">{formatRelativeTime(notification.timestamp)}</p>
+      </div>
+      {notification.unread && (
+        <Circle size={8} className="mt-1.5 shrink-0 fill-blue-500 text-blue-500" />
+      )}
+    </button>
+  );
+};
+
+interface NotificationCenterProps {
+  onClose: () => void;
+}
+
+const NotificationCenter: React.FC<NotificationCenterProps> = ({ onClose }) => {
+  const notifications = useNotificationStore((s) => s.notifications);
+  const markAllAsRead = useNotificationStore((s) => s.markAllAsRead);
+  const clearAll = useNotificationStore((s) => s.clearAll);
+  const unreadCount = notifications.filter((n) => n.unread).length;
+
+  return (
+    <div className="flex flex-col max-h-[400px]">
+      <div className="flex items-center justify-between px-4 py-3 border-b-2 border-black bg-white">
+        <div className="flex items-center gap-2">
+          <Bell size={18} />
+          <h3 className="text-sm font-black uppercase tracking-wide">Notifications</h3>
+          {unreadCount > 0 && (
+            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-bold text-white">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {unreadCount > 0 && (
+            <button
+              type="button"
+              onClick={markAllAsRead}
+              className="flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-gray-600 hover:bg-gray-100"
+            >
+              <CheckCheck size={12} />
+              Mark all read
+            </button>
+          )}
+          {notifications.length > 0 && (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-red-500 hover:bg-red-50"
+            >
+              <Trash2 size={12} />
+              Clear all
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-y-auto flex-1">
+        {notifications.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10 px-4 text-center">
+            <Bell size={32} className="text-gray-300 mb-2" />
+            <p className="text-sm font-bold text-gray-500">No notifications yet</p>
+            <p className="text-xs text-gray-400 mt-1">Notifications will appear here when you receive tips or achievements.</p>
+          </div>
+        ) : (
+          notifications.map((n) => (
+            <NotificationItem key={n.id} notification={n} onClose={onClose} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NotificationCenter;

--- a/frontend-scaffold/src/features/tipping/RecentTips.tsx
+++ b/frontend-scaffold/src/features/tipping/RecentTips.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
-
+import React, { useState } from 'react';
+import { Lock, Unlock } from 'lucide-react';
 
 import AmountDisplay from '@/components/shared/AmountDisplay';
 import EmptyState from '@/components/ui/EmptyState';
 import { useTips } from '@/hooks/useTips';
+import { useWalletStore } from '@/store/walletStore';
+import { decryptMessage } from '@/helpers/encryption';
 
 import Loader from '@/components/ui/Loader';
 
@@ -13,6 +15,31 @@ interface RecentTipsProps {
 
 const RecentTips: React.FC<RecentTipsProps> = ({ address }) => {
   const { tips, loading } = useTips(address, "creator", 3);
+  const { publicKey } = useWalletStore();
+  const isRecipient = publicKey?.toLowerCase() === address?.toLowerCase();
+  const [decrypted, setDecrypted] = useState<Record<number, string>>({});
+  const [decrypting, setDecrypting] = useState<Record<number, boolean>>({});
+  const [secretKey, setSecretKey] = useState('');
+
+  const handleDecrypt = async (tipId: number, encryptedMessage: string) => {
+    if (!secretKey) {
+      const key = window.prompt('Enter your Stellar secret key (S...) to decrypt this message:');
+      if (!key) return;
+      setSecretKey(key);
+    }
+    setDecrypting((prev) => ({ ...prev, [tipId]: true }));
+    try {
+      const sk = secretKey || (() => { const k = window.prompt('Enter your Stellar secret key (S...) to decrypt this message:'); return k; })();
+      if (!sk) return;
+      const plaintext = decryptMessage(encryptedMessage, sk);
+      setDecrypted((prev) => ({ ...prev, [tipId]: plaintext }));
+      if (!secretKey) setSecretKey(sk);
+    } catch {
+      window.alert('Failed to decrypt message. Check your secret key.');
+    } finally {
+      setDecrypting((prev) => ({ ...prev, [tipId]: false }));
+    }
+  };
 
   if (loading && tips.length === 0) {
     return <div className="py-10 flex justify-center"><Loader size="sm" /></div>;
@@ -24,15 +51,50 @@ const RecentTips: React.FC<RecentTipsProps> = ({ address }) => {
 
   return (
     <div className="space-y-3">
-      {tips.map((tip) => (
-        <div key={tip.id} className="border-2 border-black p-4">
-          <div className="flex items-center justify-between gap-4">
-            <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-800 dark:text-gray-200">Supporter note</p>
-            <AmountDisplay amount={tip.amount} />
+      {tips.map((tip) => {
+        const isEncrypted = tip.isEncrypted && tip.message.length > 0;
+        const isDecrypted = decrypted[tip.id] !== undefined;
+        const displayMessage = isDecrypted
+          ? decrypted[tip.id]
+          : isEncrypted
+            ? null
+            : tip.message;
+
+        return (
+          <div key={tip.id} className="border-2 border-black p-4">
+            <div className="flex items-center justify-between gap-4">
+              <p className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.2em] text-gray-800 dark:text-gray-200">
+                {isEncrypted ? (
+                  <Lock size={14} className="text-amber-600" />
+                ) : null}
+                Supporter note
+              </p>
+              <AmountDisplay amount={tip.amount} />
+            </div>
+
+            {isEncrypted && !isDecrypted ? (
+              <div className="mt-3 flex items-center gap-2">
+                <span className="text-sm font-medium text-gray-500 italic">Message encrypted</span>
+                {isRecipient && (
+                  <button
+                    type="button"
+                    onClick={() => handleDecrypt(tip.id, tip.message)}
+                    disabled={decrypting[tip.id]}
+                    className="ml-2 text-xs font-bold text-blue-600 underline hover:text-blue-800"
+                  >
+                    {decrypting[tip.id] ? 'Decrypting...' : 'Decrypt'}
+                  </button>
+                )}
+              </div>
+            ) : (
+              <p className="mt-3 text-sm font-medium text-gray-700">
+                {isDecrypted && <Unlock size={12} className="inline mr-1 text-green-600" />}
+                {displayMessage || 'No message attached.'}
+              </p>
+            )}
           </div>
-          <p className="mt-3 text-sm font-medium text-gray-700">{tip.message || 'No message attached.'}</p>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/frontend-scaffold/src/features/tipping/TipConfirmationModal.tsx
+++ b/frontend-scaffold/src/features/tipping/TipConfirmationModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { HeartHandshake, Info } from 'lucide-react';
+import { HeartHandshake, Info, Lock } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 import Avatar from '../../components/ui/Avatar';
@@ -17,6 +17,7 @@ interface TipConfirmationModalProps {
   creator: Profile;
   amount: string;
   message: string;
+  isEncrypted?: boolean;
   submitting?: boolean;
 }
 
@@ -27,6 +28,7 @@ export const TipConfirmationModal: React.FC<TipConfirmationModalProps> = ({
   creator,
   amount,
   message,
+  isEncrypted = false,
   submitting = false,
 }) => {
   const [dontShowAgain, setDontShowAgain] = useState(false);
@@ -91,7 +93,10 @@ export const TipConfirmationModal: React.FC<TipConfirmationModalProps> = ({
 
         {message && (
           <div className="card-brutalist bg-yellow-50 dark:bg-yellow-900/20 p-3">
-            <p className="text-xs font-black uppercase mb-1 text-gray-800 dark:text-gray-200">Message</p>
+            <div className="flex items-center gap-2 mb-1">
+              <p className="text-xs font-black uppercase text-gray-800 dark:text-gray-200">Message</p>
+              {isEncrypted && <Lock size={12} className="text-green-700" />}
+            </div>
             <p className="italic text-sm">"{message}"</p>
           </div>
         )}

--- a/frontend-scaffold/src/features/tipping/TipMessage.tsx
+++ b/frontend-scaffold/src/features/tipping/TipMessage.tsx
@@ -1,12 +1,22 @@
 import React from "react";
+import { Lock } from "lucide-react";
 import { sanitizePlainText } from "@/helpers/sanitize";
 
 interface TipMessageProps {
   message: string;
   className?: string;
+  isEncrypted?: boolean;
 }
 
-const TipMessage: React.FC<TipMessageProps> = ({ message, className }) => {
+const TipMessage: React.FC<TipMessageProps> = ({ message, className, isEncrypted }) => {
+  if (isEncrypted && message) {
+    return (
+      <p className={className ?? "flex items-center gap-1 text-sm text-gray-500 italic"}>
+        <Lock size={14} className="text-amber-600" />
+        Message encrypted
+      </p>
+    );
+  }
   const safe = sanitizePlainText(message);
   if (!safe) return null;
   return (

--- a/frontend-scaffold/src/features/tipping/TipPage.tsx
+++ b/frontend-scaffold/src/features/tipping/TipPage.tsx
@@ -3,6 +3,8 @@ import {
   ArrowRight,
   Globe2,
   HeartHandshake,
+  Lock,
+  LockOpen,
   MessageSquare,
   Wallet,
 } from "lucide-react";
@@ -46,6 +48,7 @@ const TipPage: React.FC = () => {
   const { connected, connect, publicKey: connectedWallet } = useWallet();
   const [amount, setAmount] = useState("5");
   const [message, setMessage] = useState("");
+  const [isEncrypted, setIsEncrypted] = useState(false);
   const [addressError, setAddressError] = useState<string | null>(null);
   const { getProfileByUsername } = useContract();
   const [loading, setLoading] = useState(true);
@@ -146,7 +149,7 @@ const TipPage: React.FC = () => {
       return;
     }
 
-    goToConfirm(amount, message);
+    goToConfirm(amount, message, isEncrypted);
   };
 
   // Wrapped confirm handler with transaction guard
@@ -360,6 +363,23 @@ const TipPage: React.FC = () => {
                 onChange={(event) => setMessage(event.target.value)}
               />
 
+              <button
+                type="button"
+                onClick={() => setIsEncrypted(!isEncrypted)}
+                className={`flex items-center gap-2 border-2 px-3 py-2 text-xs font-black uppercase transition-colors ${
+                  isEncrypted
+                    ? "border-black bg-green-100 text-green-800"
+                    : "border-gray-300 bg-white text-gray-500 hover:border-gray-400"
+                }`}
+              >
+                {isEncrypted ? (
+                  <Lock size={14} />
+                ) : (
+                  <LockOpen size={14} />
+                )}
+                {isEncrypted ? "Encrypted message" : "Encrypt message"}
+              </button>
+
               <div className="flex flex-col gap-3 sm:flex-row">
                 {connected ? (
                   <Button
@@ -396,6 +416,7 @@ const TipPage: React.FC = () => {
             creator={creator}
             amount={amount}
             message={message}
+            isEncrypted={isEncrypted}
             submitting={
               step === "signing" ||
               step === "submitting" ||

--- a/frontend-scaffold/src/features/tipping/useTipFlow.ts
+++ b/frontend-scaffold/src/features/tipping/useTipFlow.ts
@@ -17,7 +17,7 @@ export type TipFlowStep =
 
 interface UseTipFlowReturn {
   step: TipFlowStep;
-  goToConfirm: (amount: string, message: string) => void;
+  goToConfirm: (amount: string, message: string, isEncrypted?: boolean) => void;
   confirmAndSign: () => Promise<void>;
   retry: () => Promise<void>;
   reset: () => void;
@@ -31,6 +31,7 @@ export const useTipFlow = (creatorAddress: string): UseTipFlowReturn => {
   const [draft, setDraft] = useState<{
     amount: string;
     message: string;
+    isEncrypted: boolean;
   } | null>(null);
 
   useEffect(() => {
@@ -57,8 +58,8 @@ export const useTipFlow = (creatorAddress: string): UseTipFlowReturn => {
     return () => clearTimeout(timeoutId);
   }, [txStatus]);
 
-  const goToConfirm = useCallback((amount: string, message: string) => {
-    setDraft({ amount, message });
+  const goToConfirm = useCallback((amount: string, message: string, isEncrypted = false) => {
+    setDraft({ amount, message, isEncrypted });
     setStep("confirm");
   }, []);
 
@@ -90,7 +91,7 @@ export const useTipFlow = (creatorAddress: string): UseTipFlowReturn => {
       return;
     }
 
-    await sendTip(creatorAddress, draft.amount, draft.message);
+    await sendTip(creatorAddress, draft.amount, draft.message, draft.isEncrypted);
   }, [creatorAddress, draft, sendTip]);
 
   const reset = useCallback(() => {

--- a/frontend-scaffold/src/helpers/encryption.ts
+++ b/frontend-scaffold/src/helpers/encryption.ts
@@ -1,0 +1,109 @@
+import nacl from "tweetnacl";
+import { encodeBase64, decodeBase64, decodeUTF8, encodeUTF8 } from "tweetnacl-util";
+import { StrKey } from "@stellar/stellar-sdk";
+
+const NONCE_LENGTH = nacl.box.nonceLength;
+
+function getLowlevel() {
+  return (nacl as unknown as { lowlevel: Record<string, unknown> }).lowlevel;
+}
+
+function ed25519PkToCurve25519(edPk: Uint8Array): Uint8Array {
+  const curvePk = new Uint8Array(32);
+  const ll = getLowlevel();
+  const fn = ll.crypto_sign_ed25519_pk_to_curve25519 as (pk: Uint8Array, curvePk: Uint8Array) => void;
+  fn(edPk, curvePk);
+  return curvePk;
+}
+
+function ed25519SkToCurve25519(edSk: Uint8Array): Uint8Array {
+  const curveSk = new Uint8Array(32);
+  const ll = getLowlevel();
+  const fn = ll.crypto_sign_ed25519_sk_to_curve25519 as (sk: Uint8Array, curveSk: Uint8Array) => void;
+  fn(edSk, curveSk);
+  return curveSk;
+}
+
+function stellarPubToNacl(stellarPubKey: string): Uint8Array {
+  try {
+    const raw = StrKey.decodeEd25519PublicKey(stellarPubKey);
+    return ed25519PkToCurve25519(raw);
+  } catch {
+    throw new Error("Invalid Stellar public key");
+  }
+}
+
+function stellarSecToNacl(stellarSecretKey: string): Uint8Array {
+  try {
+    const raw = StrKey.decodeEd25519SecretSeed(stellarSecretKey);
+    return ed25519SkToCurve25519(raw);
+  } catch {
+    throw new Error("Invalid Stellar secret key");
+  }
+}
+
+function encodePayload(nonce: Uint8Array, ciphertext: Uint8Array, ephemeralPubKey: Uint8Array): string {
+  const combined = new Uint8Array(NONCE_LENGTH + ciphertext.length + ephemeralPubKey.length);
+  combined.set(nonce);
+  combined.set(ciphertext, NONCE_LENGTH);
+  combined.set(ephemeralPubKey, NONCE_LENGTH + ciphertext.length);
+  return encodeBase64(combined);
+}
+
+export interface EncryptedPayload {
+  nonce: string;
+  ciphertext: string;
+  ephemeralPubKey: string;
+}
+
+function decodePayload(encoded: string): EncryptedPayload {
+  const combined = decodeBase64(encoded);
+  const nonce = combined.slice(0, NONCE_LENGTH);
+  const ephemeralPubKey = combined.slice(combined.length - nacl.box.publicKeyLength);
+  const ciphertext = combined.slice(NONCE_LENGTH, combined.length - nacl.box.publicKeyLength);
+  return {
+    nonce: encodeBase64(nonce),
+    ciphertext: encodeBase64(ciphertext),
+    ephemeralPubKey: encodeBase64(ephemeralPubKey),
+  };
+}
+
+export function encryptMessage(message: string, recipientPubKey: string): string {
+  const recipientKey = stellarPubToNacl(recipientPubKey);
+  const ephemeral = nacl.box.keyPair();
+  const nonce = nacl.randomBytes(NONCE_LENGTH);
+  const messageBytes = decodeUTF8(message);
+  const ciphertext = nacl.box(messageBytes, nonce, recipientKey, ephemeral.secretKey);
+
+  if (!ciphertext) {
+    throw new Error("Encryption failed");
+  }
+
+  return encodePayload(nonce, ciphertext, ephemeral.publicKey);
+}
+
+export function decryptMessage(encrypted: string, secretKey: string): string {
+  const parsed = decodePayload(encrypted);
+  const nonce = decodeBase64(parsed.nonce);
+  const ciphertext = decodeBase64(parsed.ciphertext);
+  const ephemeralPubKey = decodeBase64(parsed.ephemeralPubKey);
+  const secretKeyBytes = stellarSecToNacl(secretKey);
+
+  const decrypted = nacl.box.open(ciphertext, nonce, ephemeralPubKey, secretKeyBytes);
+
+  if (!decrypted) {
+    throw new Error("Decryption failed");
+  }
+
+  return encodeUTF8(decrypted);
+}
+
+export function isEncryptedMessage(message: string): boolean {
+  if (!message || message.length < 100) return false;
+  try {
+    const parsed = decodePayload(message);
+    return !!(parsed.nonce && parsed.ciphertext && parsed.ephemeralPubKey);
+  } catch {
+    return false;
+  }
+}

--- a/frontend-scaffold/src/hooks/useContract.ts
+++ b/frontend-scaffold/src/hooks/useContract.ts
@@ -697,6 +697,7 @@ export const useContract = () => {
       creator: string,
       amount: string,
       message: string,
+      isEncrypted = false,
     ): Promise<string> => {
       const publicKey = wallet.publicKey;
       if (!publicKey) throw new Error("Wallet not connected");
@@ -721,6 +722,8 @@ export const useContract = () => {
               accountToScVal(creator),
               numberToI128(safeStringToBigInt(stroopAmount)),
               nativeToScVal(message),
+              nativeToScVal(false, { type: "bool" }),
+              nativeToScVal(isEncrypted, { type: "bool" }),
             ),
           )
           .setTimeout(TimeoutInfinite)

--- a/frontend-scaffold/src/hooks/useTipNotifications.ts
+++ b/frontend-scaffold/src/hooks/useTipNotifications.ts
@@ -54,6 +54,7 @@ const formatTipBody = (tip: Tip) => {
     tip.tipper.length > 12
       ? `${tip.tipper.slice(0, 6)}...${tip.tipper.slice(-6)}`
       : tip.tipper;
+  if (tip.isEncrypted) return `${tipper}: 🔒 Encrypted message`;
   return tip.message ? `${tipper}: ${tip.message}` : `From ${tipper}`;
 };
 

--- a/frontend-scaffold/src/hooks/useTipz.ts
+++ b/frontend-scaffold/src/hooks/useTipz.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useContract } from './useContract';
+import { useWallet } from './useWallet';
+import { encryptMessage } from '../helpers/encryption';
 import { logger } from '../services/logger';
 
 export type TxStatus = 'idle' | 'signing' | 'submitting' | 'confirming' | 'success' | 'error';
@@ -13,7 +15,7 @@ interface TipState {
 }
 
 interface UseTipzReturn extends TipState {
-  sendTip: (creator: string, amount: string, message: string) => Promise<void>;
+  sendTip: (creator: string, amount: string, message: string, isEncrypted?: boolean) => Promise<void>;
   withdrawTips: (amount: string) => Promise<string>;
   reset: () => void;
 }
@@ -30,7 +32,20 @@ export const useTipz = (): UseTipzReturn => {
   const [state, setState] = useState<TipState>(initialState);
   const { sendTip: contractSendTip, withdrawTips: contractWithdrawTips } = useContract();
 
-  const sendTip = useCallback(async (creator: string, amount: string, message: string): Promise<void> => {
+  const { publicKey } = useWallet();
+
+  const sendTip = useCallback(async (creator: string, amount: string, message: string, isEncrypted?: boolean): Promise<void> => {
+    let finalMessage = message;
+    if (isEncrypted) {
+      try {
+        finalMessage = encryptMessage(message, creator);
+      } catch (err) {
+        const errMsg = 'Failed to encrypt message';
+        setState((prev) => ({ ...prev, sending: false, error: errMsg, txStatus: 'error' }));
+        throw new Error(errMsg);
+      }
+    }
+
     setState({ ...initialState, sending: true, txStatus: 'signing' });
     const submittingTimer = window.setTimeout(() => {
       setState((prev) =>
@@ -48,7 +63,7 @@ export const useTipz = (): UseTipzReturn => {
     }, 2400);
     try {
       // The useContract.sendTip method handles signing and submission
-      const result = await contractSendTip(creator, amount, message);
+      const result = await contractSendTip(creator, amount, finalMessage, isEncrypted);
       window.clearTimeout(submittingTimer);
       window.clearTimeout(confirmingTimer);
       
@@ -71,7 +86,7 @@ export const useTipz = (): UseTipzReturn => {
       }));
       throw err; // Re-throw to allow component-level handling
     }
-  }, [contractSendTip]);
+  }, [contractSendTip, publicKey]);
 
   const withdrawTips = useCallback(async (amount: string): Promise<string> => {
     setState({ ...initialState, withdrawing: true, txStatus: 'signing' });

--- a/frontend-scaffold/src/store/index.ts
+++ b/frontend-scaffold/src/store/index.ts
@@ -2,3 +2,5 @@ export { useWalletStore } from './walletStore';
 export { useProfileStore } from './profileStore';
 export { useToastStore } from './toastStore';
 export { useSubscriptionStore } from './subscriptionStore';
+export { useNotificationStore, addNotification, getNotifications } from './notificationStore';
+export type { AppNotification, NotificationType } from './notificationStore';

--- a/frontend-scaffold/src/store/notificationStore.ts
+++ b/frontend-scaffold/src/store/notificationStore.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type NotificationType = 'tip' | 'achievement' | 'system';
+
+export interface AppNotification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  timestamp: number;
+  unread: boolean;
+  link?: string;
+}
+
+interface NotificationState {
+  notifications: AppNotification[];
+}
+
+interface NotificationActions {
+  addNotification: (n: Omit<AppNotification, 'id' | 'timestamp'>) => string;
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+  clearAll: () => void;
+}
+
+type NotificationStore = NotificationState & NotificationActions;
+
+export const useNotificationStore = create<NotificationStore>()(
+  persist(
+    (set) => ({
+      notifications: [],
+
+      addNotification: (n) => {
+        const id = crypto.randomUUID();
+        const notification: AppNotification = {
+          ...n,
+          id,
+          timestamp: Date.now(),
+        };
+        set((state) => ({
+          notifications: [notification, ...state.notifications],
+        }));
+        return id;
+      },
+
+      markAsRead: (id) =>
+        set((state) => ({
+          notifications: state.notifications.map((n) =>
+            n.id === id ? { ...n, unread: false } : n,
+          ),
+        })),
+
+      markAllAsRead: () =>
+        set((state) => ({
+          notifications: state.notifications.map((n) => ({ ...n, unread: false })),
+        })),
+
+      clearAll: () => set({ notifications: [] }),
+    }),
+    {
+      name: 'tipz_notifications',
+      partialize: (state) => ({ notifications: state.notifications }),
+    },
+  ),
+);
+
+export const addNotification = (n: Omit<AppNotification, 'id' | 'timestamp'>): string =>
+  useNotificationStore.getState().addNotification(n);
+
+export const getNotifications = (): AppNotification[] =>
+  useNotificationStore.getState().notifications;

--- a/frontend-scaffold/src/types/contract.ts
+++ b/frontend-scaffold/src/types/contract.ts
@@ -37,6 +37,7 @@ export interface RawTip {
   amount: string;
   message: string;
   timestamp: number;
+  is_encrypted?: boolean;
 }
 
 /** Raw leaderboard entry before key mapping. */
@@ -93,6 +94,7 @@ export interface Tip {
   amount: string; // i128 as string
   message: string;
   timestamp: number;
+  isEncrypted?: boolean;
 }
 
 /** Leaderboard entry */


### PR DESCRIPTION
feat(notifications): add notification center with history (#604)

## Description
Adds a fully functional notification center with persistent history to the platform. Includes a bell icon in the header with an unread count badge, a dropdown notification panel supporting tip, achievement, and system notification types, with mark as read, mark all as read, and clear all functionality. Notifications persist across sessions via localStorage.

Closes #604

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests (adding or updating tests)
- [ ] Documentation (changes to docs only)

## Changes Made
- Created `store/notificationStore.ts` — Zustand store with `persist` middleware (localStorage key `tipz_notifications`) with `addNotification`, `markAsRead`, `markAllAsRead`, and `clearAll` actions
- Created `features/notifications/NotificationBell.tsx` — Bell icon button with red unread count badge, click opens dropdown, dismisses on outside click and Escape key
- Created `features/notifications/NotificationCenter.tsx` — Dropdown panel with type icons (Gift/Star/Info), relative timestamps, unread dot indicators, mark all read, clear all, and click-to-navigate behavior
- Updated `components/layout/Header.tsx` — Added `NotificationBell` to both desktop and mobile toolbars
- Updated `store/index.ts` — Exported `useNotificationStore`, `addNotification`, `getNotifications`, and types

## How to Test
1. Start the frontend with `npm run dev` and confirm the bell icon appears in the header on both desktop and mobile
2. Trigger a tip received event and confirm the unread count badge increments on the bell icon
3. Click the bell icon to open the dropdown and verify notifications appear with correct type icons, timestamps, and unread dot indicators
4. Click an individual notification and confirm it is marked as read and navigates to the relevant page
5. Click "Mark all read" and confirm all unread dots disappear and the badge clears
6. Click "Clear all" and confirm the notification list is empty with the empty state shown
7. Refresh the page and confirm notifications persist via localStorage

## Checklist
### Contract Changes
- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (all tests)
- [ ] New tests written for new functionality
- [ ] No hardcoded values that should be configurable

### Frontend Changes
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Tested in browser with Freighter wallet
- [x] Responsive design verified

### General
- [x] Code follows project conventions
- [x] Self-reviewed my own code
- [x] No `console.log` or debug code left in
- [x] Branch is up to date with `main`

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->