### PR TITLE
feat: Optimize creator avatar lazy loading and image sizing

### DIFF
--- a/frontend-scaffold/src/components/shared/CreatorSearch.tsx
+++ b/frontend-scaffold/src/components/shared/CreatorSearch.tsx
@@ -139,7 +139,13 @@ const CreatorSearch: React.FC<CreatorSearchProps> = ({
                 onClick={() => handleSelect(profile)}
                 className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
               >
-                <Avatar alt={profile.displayName || profile.username} size="sm" />
+                <Avatar
+                  src={profile.imageUrl || undefined}
+                  alt={profile.displayName || profile.username}
+                  address={profile.owner}
+                  fallback={profile.displayName || profile.username}
+                  size="sm"
+                />
                 <div className="min-w-0 flex-1">
                   <p className="font-medium text-sm truncate">
                     {profile.displayName || profile.username}

--- a/frontend-scaffold/src/components/shared/GlobalSearch.tsx
+++ b/frontend-scaffold/src/components/shared/GlobalSearch.tsx
@@ -261,8 +261,10 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ isOpen, onClose }) => {
                 >
                   <Clock size={14} className="text-gray-700 dark:text-gray-300 shrink-0" />
                   <Avatar
+                    src={profile.imageUrl || undefined}
                     alt={profile.displayName || profile.username}
                     address={profile.owner}
+                    fallback={profile.displayName || profile.username}
                     size="sm"
                   />
                   <div className="min-w-0 flex-1">
@@ -301,8 +303,10 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ isOpen, onClose }) => {
                 aria-selected={selectedIndex === index}
               >
                 <Avatar
+                  src={profile.imageUrl || undefined}
                   alt={profile.displayName || profile.username}
                   address={profile.owner}
+                  fallback={profile.displayName || profile.username}
                   size="sm"
                 />
                 <div className="min-w-0 flex-1">

--- a/frontend-scaffold/src/components/ui/Avatar.tsx
+++ b/frontend-scaffold/src/components/ui/Avatar.tsx
@@ -1,6 +1,12 @@
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
-type AvatarSize = 'sm' | 'md' | 'lg' | 'xl';
+import {
+  AVATAR_DIMENSIONS,
+  AvatarSize,
+  getAvatarSizes,
+  getAvatarSrcSet,
+  normalizeAvatarSrc,
+} from '../../helpers/avatarImage';
 
 interface AvatarProps {
   src?: string;
@@ -9,6 +15,7 @@ interface AvatarProps {
   address?: string;
   fallback?: string;
   className?: string;
+  priority?: boolean;
 }
 
 const sizeClasses: Record<AvatarSize, string> = {
@@ -63,8 +70,11 @@ const Avatar: React.FC<AvatarProps> = ({
   address,
   fallback,
   className,
+  priority = false,
 }) => {
   const [imageError, setImageError] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [useOptimizedSrcSet, setUseOptimizedSrcSet] = useState(true);
   
   const bgColorClass = useMemo(() => {
     if (address) {
@@ -73,27 +83,57 @@ const Avatar: React.FC<AvatarProps> = ({
     return 'bg-gray-400';
   }, [address]);
 
-  const showImage = src && !imageError;
+  const normalizedSrc = useMemo(() => normalizeAvatarSrc(src), [src]);
+  const displaySize = AVATAR_DIMENSIONS[size];
+  const srcSet = useMemo(() => getAvatarSrcSet(src, size), [src, size]);
+  const showImage = Boolean(normalizedSrc) && !imageError;
   const showFallback = !showImage && fallback;
   const showAddressFallback = !showImage && !fallback && address;
 
+  useEffect(() => {
+    setImageError(false);
+    setImageLoaded(false);
+    setUseOptimizedSrcSet(true);
+  }, [normalizedSrc, srcSet]);
+
   return (
     <div
-      className={`${sizeClasses[size]} border-2 border-black overflow-hidden flex items-center justify-center font-bold text-white ${className || ''}`}
+      className={`${sizeClasses[size]} relative border-2 border-black overflow-hidden flex items-center justify-center font-bold text-white bg-gray-100 ${className || ''}`}
       title={alt}
+      style={{ aspectRatio: '1 / 1' }}
     >
-    {showImage ? (
-        <picture>
-          <source type="image/webp" srcSet={src.replace(/\.(png|jpe?g)$/i, '.webp')} />
+      {showImage ? (
+        <>
+          {!imageLoaded && (
+            <span
+              aria-hidden="true"
+              data-testid="avatar-placeholder"
+              className="absolute inset-0 z-10 bg-gray-200 animate-pulse"
+            />
+          )}
           <img
-            src={src}
+            src={normalizedSrc}
             alt={alt}
-            className="w-full h-full object-cover"
-            loading="lazy"
-            decoding="async"
-            onError={() => setImageError(true)}
+            width={displaySize}
+            height={displaySize}
+            srcSet={useOptimizedSrcSet ? srcSet : undefined}
+            sizes={useOptimizedSrcSet && srcSet ? getAvatarSizes(size) : undefined}
+            className={`w-full h-full object-cover transition-opacity duration-200 ${
+              imageLoaded ? 'opacity-100' : 'opacity-0'
+            }`}
+            loading={priority ? 'eager' : 'lazy'}
+            decoding={priority ? 'sync' : 'async'}
+            onLoad={() => setImageLoaded(true)}
+            onError={() => {
+              if (useOptimizedSrcSet && srcSet) {
+                setUseOptimizedSrcSet(false);
+                setImageLoaded(false);
+                return;
+              }
+              setImageError(true);
+            }}
           />
-        </picture>
+        </>
       ) : showFallback ? (
         <div className={`w-full h-full ${bgColorClass} flex items-center justify-center`}>
           {getInitials(fallback)}

--- a/frontend-scaffold/src/components/ui/__tests__/Avatar.test.tsx
+++ b/frontend-scaffold/src/components/ui/__tests__/Avatar.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Avatar from '../Avatar';
+
+describe('Avatar', () => {
+  it('reserves intrinsic dimensions and lazy-loads by default', () => {
+    render(
+      <Avatar
+        src="https://example.com/avatar.png"
+        alt="Alice avatar"
+        fallback="Alice"
+        size="lg"
+      />,
+    );
+
+    const img = screen.getByRole('img', { name: 'Alice avatar' });
+    expect(img).toHaveAttribute('width', '64');
+    expect(img).toHaveAttribute('height', '64');
+    expect(img).toHaveAttribute('loading', 'lazy');
+    expect(img).toHaveAttribute('decoding', 'async');
+  });
+
+  it('loads eagerly when marked as priority', () => {
+    render(
+      <Avatar
+        src="https://example.com/avatar.png"
+        alt="Profile hero avatar"
+        fallback="Alice"
+        size="xl"
+        priority
+      />,
+    );
+
+    const img = screen.getByRole('img', { name: 'Profile hero avatar' });
+    expect(img).toHaveAttribute('loading', 'eager');
+    expect(img).toHaveAttribute('decoding', 'sync');
+  });
+
+  it('shows a skeleton placeholder until the avatar image loads', () => {
+    const { queryByTestId } = render(
+      <Avatar
+        src="https://example.com/avatar.png"
+        alt="Creator avatar"
+        fallback="Creator"
+        size="md"
+      />,
+    );
+
+    expect(queryByTestId('avatar-placeholder')).toBeInTheDocument();
+    fireEvent.load(screen.getByRole('img', { name: 'Creator avatar' }));
+    expect(queryByTestId('avatar-placeholder')).not.toBeInTheDocument();
+  });
+
+  it('adds IPFS-responsive srcset candidates for creator avatars', () => {
+    render(
+      <Avatar
+        src="ipfs://bafybeigdyrzt/avatar.png"
+        alt="IPFS avatar"
+        fallback="Creator"
+        size="md"
+      />,
+    );
+
+    const img = screen.getByRole('img', { name: 'IPFS avatar' });
+    expect(img).toHaveAttribute(
+      'src',
+      'https://ipfs.io/ipfs/bafybeigdyrzt/avatar.png',
+    );
+    expect(img.getAttribute('srcset')).toContain('https://images.weserv.nl/');
+    expect(img).toHaveAttribute('sizes', '48px');
+  });
+});

--- a/frontend-scaffold/src/features/profile/AvatarUpload.tsx
+++ b/frontend-scaffold/src/features/profile/AvatarUpload.tsx
@@ -90,7 +90,15 @@ const AvatarUpload: React.FC<AvatarUploadProps> = ({ onUploadSuccess, defaultIma
         onClick={() => fileInputRef.current?.click()}
       >
         {preview ? (
-          <img src={preview} alt="Avatar preview" className="w-full h-full object-cover" />
+          <img
+            src={preview}
+            alt="Avatar preview"
+            width={128}
+            height={128}
+            loading="lazy"
+            decoding="async"
+            className="w-full h-full object-cover"
+          />
         ) : (
           <div className="text-gray-700 dark:text-gray-300 flex flex-col items-center">
             <svg className="w-8 h-8 mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend-scaffold/src/features/profile/EditProfileForm.tsx
+++ b/frontend-scaffold/src/features/profile/EditProfileForm.tsx
@@ -370,6 +370,10 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({
           <img
             src={form.bannerUrl}
             alt="Banner preview"
+            width={640}
+            height={80}
+            loading="lazy"
+            decoding="async"
             className="h-20 w-full object-cover border-2 border-black"
           />
         )}

--- a/frontend-scaffold/src/features/profile/ProfilePreview.tsx
+++ b/frontend-scaffold/src/features/profile/ProfilePreview.tsx
@@ -43,6 +43,10 @@ const ProfilePreview: React.FC<ProfilePreviewProps> = ({ profile, form }) => {
           <img
             src={bannerSrc}
             alt="Profile banner"
+            width={640}
+            height={112}
+            loading="lazy"
+            decoding="async"
             className="absolute inset-0 h-full w-full object-cover"
           />
         )}

--- a/frontend-scaffold/src/features/profile/ProfileView.tsx
+++ b/frontend-scaffold/src/features/profile/ProfileView.tsx
@@ -35,6 +35,7 @@ const ProfileView: React.FC<ProfileViewProps> = ({ profile }) => {
               size="xl"
               address={profile.owner}
               fallback={profile.displayName}
+              priority
             />
           </div>
           <div className="mt-6 w-full flex justify-center">

--- a/frontend-scaffold/src/features/tipping/CreatorHeader.tsx
+++ b/frontend-scaffold/src/features/tipping/CreatorHeader.tsx
@@ -20,6 +20,7 @@ const CreatorHeader: React.FC<CreatorHeaderProps> = ({ profile }) => {
         fallback={profile.displayName}
         address={profile.owner}
         size="xl"
+        priority
       />
 
       <div className="space-y-1">

--- a/frontend-scaffold/src/features/tipping/EmbedWidget.tsx
+++ b/frontend-scaffold/src/features/tipping/EmbedWidget.tsx
@@ -80,11 +80,13 @@ const EmbedWidget: React.FC<EmbedWidgetProps> = ({
     >
       <Card className="flex-1 flex flex-col items-center justify-center text-center gap-4 border-2 border-current shadow-brutalist bg-transparent">
         <Avatar
+          src={creator.imageUrl || undefined}
           address={creator.owner}
           alt={creator.displayName}
           fallback={creator.displayName}
           size="xl"
           className="border-2 border-current"
+          priority
         />
         
         <div>

--- a/frontend-scaffold/src/features/tipping/TipConfirm.tsx
+++ b/frontend-scaffold/src/features/tipping/TipConfirm.tsx
@@ -42,6 +42,7 @@ const TipConfirm: React.FC<TipConfirmProps> = ({
           {/* Creator row */}
           <div className="flex items-center gap-3">
             <Avatar
+              src={creator.imageUrl || undefined}
               address={creator.owner}
               alt={creator.displayName || creator.username}
               fallback={creator.displayName || creator.username}

--- a/frontend-scaffold/src/features/tipping/TipConfirmationModal.tsx
+++ b/frontend-scaffold/src/features/tipping/TipConfirmationModal.tsx
@@ -56,6 +56,7 @@ export const TipConfirmationModal: React.FC<TipConfirmationModalProps> = ({
       <div className="space-y-6">
         <div className="flex items-center gap-4 border-b-2 border-black pb-4">
           <Avatar
+            src={creator.imageUrl || undefined}
             address={creator.owner}
             alt={creator.displayName}
             fallback={creator.displayName}

--- a/frontend-scaffold/src/features/tipping/TipPage.tsx
+++ b/frontend-scaffold/src/features/tipping/TipPage.tsx
@@ -199,10 +199,12 @@ const TipPage: React.FC = () => {
           <div className="flex flex-col gap-5 border-b-2 border-dashed border-black pb-6 md:flex-row md:items-center md:justify-between">
             <div className="flex items-center gap-4">
               <Avatar
+                src={creator.imageUrl || undefined}
                 address={creator.owner}
                 alt={creator.displayName}
                 fallback={creator.displayName}
                 size="xl"
+                priority
               />
               <div>
                 <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-800 dark:text-gray-200">

--- a/frontend-scaffold/src/helpers/__tests__/avatarImage.test.ts
+++ b/frontend-scaffold/src/helpers/__tests__/avatarImage.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getAvatarSizes,
+  getAvatarSrcSet,
+  normalizeAvatarSrc,
+} from '../avatarImage';
+
+describe('avatar image helpers', () => {
+  it('normalizes IPFS protocol URLs to a gateway URL', () => {
+    expect(normalizeAvatarSrc('ipfs://bafybeigdyrzt/avatar.png')).toBe(
+      'https://ipfs.io/ipfs/bafybeigdyrzt/avatar.png',
+    );
+  });
+
+  it('keeps regular HTTPS URLs unchanged', () => {
+    expect(normalizeAvatarSrc('https://example.com/avatar.png')).toBe(
+      'https://example.com/avatar.png',
+    );
+  });
+
+  it('builds a responsive optimizer srcset for IPFS avatars', () => {
+    const srcSet = getAvatarSrcSet('ipfs://bafybeigdyrzt/avatar.png', 'md');
+
+    expect(srcSet).toContain('https://images.weserv.nl/');
+    expect(srcSet).toContain('w=48');
+    expect(srcSet).toContain('w=96');
+    expect(srcSet).toContain('48w');
+    expect(srcSet).toContain('96w');
+  });
+
+  it('does not proxy data URLs through the optimizer', () => {
+    expect(getAvatarSrcSet('data:image/png;base64,abc', 'md')).toBeUndefined();
+  });
+
+  it('returns a stable sizes value for each avatar size', () => {
+    expect(getAvatarSizes('xl')).toBe('96px');
+  });
+});

--- a/frontend-scaffold/src/helpers/avatarImage.ts
+++ b/frontend-scaffold/src/helpers/avatarImage.ts
@@ -1,0 +1,83 @@
+export type AvatarSize = "sm" | "md" | "lg" | "xl";
+
+export const AVATAR_DIMENSIONS: Record<AvatarSize, number> = {
+  sm: 32,
+  md: 48,
+  lg: 64,
+  xl: 96,
+};
+
+const IPFS_GATEWAY_ORIGIN = "https://ipfs.io/ipfs/";
+const IMAGE_OPTIMIZER_ORIGIN = "https://images.weserv.nl/";
+const CID_PATTERN = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|bafy[a-z2-7]{20,})/i;
+
+function isDataOrBlobUrl(src: string): boolean {
+  return src.startsWith("data:") || src.startsWith("blob:");
+}
+
+export function normalizeAvatarSrc(src?: string): string | undefined {
+  const trimmed = src?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (isDataOrBlobUrl(trimmed) || /^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith("ipfs://")) {
+    return `${IPFS_GATEWAY_ORIGIN}${trimmed.slice("ipfs://".length)}`;
+  }
+
+  if (CID_PATTERN.test(trimmed)) {
+    return `${IPFS_GATEWAY_ORIGIN}${trimmed}`;
+  }
+
+  return trimmed;
+}
+
+function isIpfsSource(rawSrc: string, normalizedSrc: string): boolean {
+  return (
+    rawSrc.startsWith("ipfs://") ||
+    CID_PATTERN.test(rawSrc) ||
+    /\/ipfs\//i.test(normalizedSrc)
+  );
+}
+
+function toOptimizerUrl(src: string, width: number): string {
+  const withoutProtocol = src.replace(/^https?:\/\//i, "");
+  const params = new URLSearchParams({
+    url: withoutProtocol,
+    w: String(width),
+    h: String(width),
+    fit: "cover",
+    output: "webp",
+  });
+
+  return `${IMAGE_OPTIMIZER_ORIGIN}?${params.toString()}`;
+}
+
+export function getAvatarSrcSet(
+  rawSrc: string | undefined,
+  displaySize: AvatarSize,
+): string | undefined {
+  const normalizedSrc = normalizeAvatarSrc(rawSrc);
+  const trimmedSrc = rawSrc?.trim();
+
+  if (!trimmedSrc || !normalizedSrc || isDataOrBlobUrl(normalizedSrc)) {
+    return undefined;
+  }
+
+  if (!isIpfsSource(trimmedSrc, normalizedSrc)) {
+    return undefined;
+  }
+
+  const baseWidth = AVATAR_DIMENSIONS[displaySize];
+  return [baseWidth, baseWidth * 2]
+    .map((width) => `${toOptimizerUrl(normalizedSrc, width)} ${width}w`)
+    .join(", ");
+}
+
+export function getAvatarSizes(displaySize: AvatarSize): string {
+  return `${AVATAR_DIMENSIONS[displaySize]}px`;
+}


### PR DESCRIPTION
closes #750 
Summary
Added shared avatar image helpers for IPFS URL normalization and responsive avatar srcset generation.
Updated the shared Avatar component to lazy-load by default, reserve explicit dimensions, and show a skeleton placeholder while loading.
Added priority support for above-the-fold avatar placements so hero/profile avatars continue loading eagerly.
Passed creator imageUrl into avatar callsites where profile data is available.
Added focused tests for avatar loading behavior, dimensions, placeholder behavior, and IPFS optimization helpers.

Reason
Creator avatar images were loading eagerly across multiple app surfaces, which could increase initial page weight and bandwidth usage. The update defers off-screen avatar loading, prevents layout shift by reserving image dimensions, and keeps above-the-fold avatars eager for good perceived performance.