### PR TITLE
feat: add leaderboard pagination — 25 entries per page with user rank…

### DIFF
--- a/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useRef } from "react";
+import React, { useMemo } from "react";
 import { Crown, Medal, Trophy, Loader2 } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -7,6 +7,7 @@ import AmountDisplay from "../../components/shared/AmountDisplay";
 import CreditBadge from "../../components/shared/CreditBadge";
 import Avatar from "../../components/ui/Avatar";
 import Card from "../../components/ui/Card";
+import EmptyState from "../../components/ui/EmptyState";
 
 import ErrorState from "../../components/shared/ErrorState";
 import PullToRefresh from "../../components/shared/PullToRefresh";
@@ -14,40 +15,14 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { useLeaderboard } from "@/hooks/useLeaderboard";
 import { categorizeError } from "@/helpers/error";
 import LeaderboardSkeleton from "./LeaderboardSkeleton";
-
-
-const PAGE_SIZE = 20;
+import LeaderboardTable from "./LeaderboardTable";
 
 const LeaderboardPage: React.FC = () => {
-  usePageTitle('Leaderboard');
+  usePageTitle("Leaderboard");
 
-  const { entries, loading, hasMore, error, loadMore } = useLeaderboard(PAGE_SIZE);
-  const observerRef = useRef<HTMLDivElement>(null);
+  const { entries, loading, error, refetch } = useLeaderboard();
 
-  useEffect(() => {
-    const target = observerRef.current;
-    if (!target || !hasMore) {
-      return;
-    }
-
-    if (typeof window === "undefined" || typeof window.IntersectionObserver === "undefined") {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (observerEntries) => {
-        if (observerEntries[0]?.isIntersecting) {
-          loadMore();
-        }
-      },
-      { threshold: 0.1 },
-    );
-
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [hasMore, loadMore]);
-
-  // Top 3 entries for podium display
+  // Top 3 entries for podium display; ranks 4+ go to the paginated table.
   const topThree = useMemo(() => entries.slice(0, 3), [entries]);
   const remainingEntries = useMemo(() => entries.slice(3), [entries]);
 
@@ -58,97 +33,126 @@ const LeaderboardPage: React.FC = () => {
     : `Leaderboard loaded with ${entries.length} creators.`;
 
   if (loading && entries.length === 0 && !error) {
-    return <LeaderboardSkeleton count={PAGE_SIZE} />;
+    return <LeaderboardSkeleton count={25} />;
   }
 
   return (
     <PullToRefresh onRefresh={refetch}>
-    <PageContainer maxWidth="xl" className="space-y-8 py-10">
-      <section aria-labelledby="leaderboard-heading" className="grid gap-6 lg:grid-cols-[0.95fr_1.05fr]">
-        <Card className="space-y-5 bg-yellow-100" padding="lg" hover>
-          <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-600">
-            Leaderboard
-          </p>
-          <h1 id="leaderboard-heading" className="flex items-center gap-3 text-4xl font-black uppercase">
-            <Trophy size={34} />
-            Top creators
-          </h1>
-          <p className="max-w-2xl text-base leading-7 text-gray-700">
-            A real-time snapshot of creators earning the most support on Stellar Tipz. These rankings are fetched directly from the Tipz Soroban contract.
-          </p>
-        </Card>
+      <PageContainer maxWidth="xl" className="space-y-8 py-10">
+        <section
+          aria-labelledby="leaderboard-heading"
+          className="grid gap-6 lg:grid-cols-[0.95fr_1.05fr]"
+        >
+          <Card className="space-y-5 bg-yellow-100" padding="lg" hover>
+            <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-600">
+              Leaderboard
+            </p>
+            <h1
+              id="leaderboard-heading"
+              className="flex items-center gap-3 text-4xl font-black uppercase"
+            >
+              <Trophy size={34} />
+              Top creators
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-gray-700">
+              A real-time snapshot of creators earning the most support on
+              Stellar Tipz. These rankings are fetched directly from the Tipz
+              Soroban contract.
+            </p>
+          </Card>
 
-        <div className="grid gap-4 sm:grid-cols-3">
-          {error ? (
-            <div className="sm:col-span-3">
-              <ErrorState category={categorizeError(error).category} onRetry={() => window.location.reload()} />
-            </div>
-          ) : (
-            topThree.map((entry, index) => {
-              const icons = [<Crown key="crown" size={18} />, <Medal key="silver" size={18} />, <Medal key="bronze" size={18} />];
-              const labels = ["1st", "2nd", "3rd"];
+          <div className="grid gap-4 sm:grid-cols-3">
+            {error ? (
+              <div className="sm:col-span-3">
+                <ErrorState
+                  category={categorizeError(error).category}
+                  onRetry={refetch}
+                />
+              </div>
+            ) : (
+              topThree.map((entry, index) => {
+                const icons = [
+                  <Crown key="crown" size={18} />,
+                  <Medal key="silver" size={18} />,
+                  <Medal key="bronze" size={18} />,
+                ];
+                const labels = ["1st", "2nd", "3rd"];
 
-              return (
-                <Card key={entry.address} className="space-y-4" padding="lg" hover>
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="inline-flex items-center gap-2 text-sm font-black uppercase">
-                      {icons[index]}
-                      {labels[index]}
-                    </span>
-                    <CreditBadge score={entry.creditScore} showScore={false} />
-                  </div>
-                  <Link to={`/@${entry.username}`} className="flex items-center gap-3">
-                    <Avatar address={entry.address} alt={entry.username} fallback={entry.username} size="lg" />
-                    <div>
-                      <p className="text-lg font-black uppercase truncate max-w-[120px]">{entry.username}</p>
-                      <AmountDisplay amount={entry.totalTipsReceived} className="text-sm" />
+                return (
+                  <Card key={entry.address} className="space-y-4" padding="lg" hover>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="inline-flex items-center gap-2 text-sm font-black uppercase">
+                        {icons[index]}
+                        {labels[index]}
+                      </span>
+                      <CreditBadge score={entry.creditScore} showScore={false} />
                     </div>
-                  </Link>
-                </Card>
-              );
-            })
-          )}
-        </div>
-      </section>
-
-      <section role="region" aria-labelledby="full-rankings-heading">
-        <Card className="space-y-6" padding="lg">
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <h2 id="full-rankings-heading" className="text-2xl font-black uppercase">Full rankings</h2>
-            <Link to="/dashboard" className="text-sm font-black uppercase underline">
-              Open your dashboard
-            </Link>
+                    <Link
+                      to={`/@${entry.username}`}
+                      className="flex items-center gap-3"
+                    >
+                      <Avatar
+                        address={entry.address}
+                        alt={entry.username}
+                        fallback={entry.username}
+                        size="lg"
+                      />
+                      <div>
+                        <p className="max-w-[120px] truncate text-lg font-black uppercase">
+                          {entry.username}
+                        </p>
+                        <AmountDisplay
+                          amount={entry.totalTipsReceived}
+                          className="text-sm"
+                        />
+                      </div>
+                    </Link>
+                  </Card>
+                );
+              })
+            )}
           </div>
+        </section>
 
-
-              {/* Loading indicator */}
-              {loading && (
-                <div className="flex items-center justify-center gap-2 p-8 text-gray-600">
-                  <Loader2 size={20} className="animate-spin" />
-                  <span className="text-sm font-bold uppercase">Loading more creators...</span>
-                </div>
-              )}
-
-              {/* End of list indicator */}
-              {!hasMore && entries.length > 0 && (
-                <div className="text-center p-8 border-t-2 border-dashed border-gray-300">
-                  <p className="text-sm font-bold text-gray-600 uppercase">
-                    🎉 You've reached the end of the leaderboard!
-                  </p>
-                </div>
-              )}
-
-              {/* Intersection observer target */}
-              <div ref={observerRef} className="h-4" />
+        <section role="region" aria-labelledby="full-rankings-heading">
+          <Card className="space-y-6" padding="lg">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <h2
+                id="full-rankings-heading"
+                className="text-2xl font-black uppercase"
+              >
+                Full rankings
+              </h2>
+              <Link
+                to="/dashboard"
+                className="text-sm font-black uppercase underline"
+              >
+                Open your dashboard
+              </Link>
             </div>
-          )}
-        </Card>
-      </section>
 
-      <div role="status" aria-live="polite" className="sr-only">
-        {leaderboardAnnouncement}
-      </div>
-    </PageContainer>
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 p-8 text-gray-600">
+                <Loader2 size={20} className="animate-spin" />
+                <span className="text-sm font-bold uppercase">
+                  Loading rankings...
+                </span>
+              </div>
+            ) : entries.length === 0 ? (
+              <EmptyState
+                title="No creators found on the leaderboard yet"
+                description="Be the first to register and receive tips on Stellar Tipz."
+              />
+            ) : (
+              <LeaderboardTable entries={remainingEntries} />
+            )}
+          </Card>
+        </section>
+
+        <div role="status" aria-live="polite" className="sr-only">
+          {leaderboardAnnouncement}
+        </div>
+      </PageContainer>
     </PullToRefresh>
   );
 };

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardTable.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import EmptyState from "../../components/ui/EmptyState";
 import Pagination from "../../components/ui/Pagination";
@@ -29,26 +29,30 @@ const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ entries }) => {
   const safeCurrentPage = Math.min(currentPage, totalPages);
 
   // Find the current user's position in this sub-list (entries start at rank 4).
+  // Guard typeof publicKey === 'string' because test mocks may pass the full
+  // state object when they don't apply the selector.
   const userIndex = useMemo(() => {
-    if (!connected || !publicKey) return -1;
+    if (!connected || typeof publicKey !== "string") return -1;
     return entries.findIndex(
       (e) => e.address.toLowerCase() === publicKey.toLowerCase(),
     );
   }, [entries, publicKey, connected]);
 
-  // Global rank (1-based); null if not in this list.
+  // Global rank (1-based); null when the user is not in this sub-list.
   const userGlobalRank = userIndex >= 0 ? userIndex + 4 : null;
 
   // Which page the user is on (1-based).
   const userPage = userIndex >= 0 ? Math.floor(userIndex / PAGE_SIZE) + 1 : null;
 
-  // On initial load, jump straight to the user's page so their rank is visible.
+  // Jump to the user's page on first load. Using a ref so the effect is
+  // idempotent — it fires at most once regardless of re-renders.
+  const hasAutoJumpedRef = useRef(false);
   useEffect(() => {
-    if (userPage !== null) {
+    if (!hasAutoJumpedRef.current && userPage !== null) {
+      hasAutoJumpedRef.current = true;
       setCurrentPage(userPage);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // intentionally run only on mount
+  }, [userPage]);
 
   const pageEntries = useMemo(() => {
     const start = (safeCurrentPage - 1) * PAGE_SIZE;
@@ -70,15 +74,15 @@ const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ entries }) => {
   return (
     <div className="space-y-4">
       {/* Current-user rank banner — always visible regardless of current page */}
-      {userGlobalRank !== null && (
+      {userGlobalRank !== null && userPage !== null && (
         <div className="flex flex-wrap items-center justify-between gap-3 rounded border-2 border-black bg-yellow-100 px-4 py-3">
           <span className="text-sm font-black uppercase">
             Your rank: #{userGlobalRank}
           </span>
-          {safeCurrentPage !== userPage && userPage !== null && (
+          {safeCurrentPage !== userPage && (
             <button
               type="button"
-              onClick={() => setCurrentPage(userPage)}
+              onClick={() => setCurrentPage(userPage!)}
               className="border-2 border-black bg-black px-3 py-1 text-xs font-black uppercase text-white transition hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]"
             >
               Jump to my rank

--- a/frontend-scaffold/src/features/leaderboard/LeaderboardTable.tsx
+++ b/frontend-scaffold/src/features/leaderboard/LeaderboardTable.tsx
@@ -1,11 +1,12 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import EmptyState from "../../components/ui/EmptyState";
 import Pagination from "../../components/ui/Pagination";
+import { useWalletStore } from "../../store/walletStore";
 import type { LeaderboardEntry } from "../../types/contract";
 import LeaderboardRow from "./LeaderboardRow";
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 25;
 
 // ---------------------------------------------------------------------------
 // LeaderboardTable
@@ -21,8 +22,33 @@ export interface LeaderboardTableProps {
 const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ entries }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
+  const publicKey = useWalletStore((state) => state.publicKey);
+  const connected = useWalletStore((state) => state.connected);
+
   const totalPages = Math.max(1, Math.ceil(entries.length / PAGE_SIZE));
   const safeCurrentPage = Math.min(currentPage, totalPages);
+
+  // Find the current user's position in this sub-list (entries start at rank 4).
+  const userIndex = useMemo(() => {
+    if (!connected || !publicKey) return -1;
+    return entries.findIndex(
+      (e) => e.address.toLowerCase() === publicKey.toLowerCase(),
+    );
+  }, [entries, publicKey, connected]);
+
+  // Global rank (1-based); null if not in this list.
+  const userGlobalRank = userIndex >= 0 ? userIndex + 4 : null;
+
+  // Which page the user is on (1-based).
+  const userPage = userIndex >= 0 ? Math.floor(userIndex / PAGE_SIZE) + 1 : null;
+
+  // On initial load, jump straight to the user's page so their rank is visible.
+  useEffect(() => {
+    if (userPage !== null) {
+      setCurrentPage(userPage);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally run only on mount
 
   const pageEntries = useMemo(() => {
     const start = (safeCurrentPage - 1) * PAGE_SIZE;
@@ -43,6 +69,24 @@ const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ entries }) => {
 
   return (
     <div className="space-y-4">
+      {/* Current-user rank banner — always visible regardless of current page */}
+      {userGlobalRank !== null && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded border-2 border-black bg-yellow-100 px-4 py-3">
+          <span className="text-sm font-black uppercase">
+            Your rank: #{userGlobalRank}
+          </span>
+          {safeCurrentPage !== userPage && userPage !== null && (
+            <button
+              type="button"
+              onClick={() => setCurrentPage(userPage)}
+              className="border-2 border-black bg-black px-3 py-1 text-xs font-black uppercase text-white transition hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]"
+            >
+              Jump to my rank
+            </button>
+          )}
+        </div>
+      )}
+
       <div className="overflow-x-auto border-2 border-black">
         <table className="min-w-full border-collapse">
           <thead>

--- a/frontend-scaffold/src/features/leaderboard/__tests__/LeaderboardPage.test.tsx
+++ b/frontend-scaffold/src/features/leaderboard/__tests__/LeaderboardPage.test.tsx
@@ -32,13 +32,24 @@ vi.mock('@/hooks/usePageTitle', () => ({
 }));
 
 const mockUseWalletStore = vi.fn();
+
+// These mocks apply the selector when provided so that components that call
+// useWalletStore((state) => state.publicKey) receive the selected primitive
+// value rather than the full state object (which would cause .toLowerCase()
+// to throw a TypeError in LeaderboardRow / LeaderboardTable).
 vi.mock('@/store/walletStore', () => ({
-  useWalletStore: () => mockUseWalletStore(),
+  useWalletStore: (selector?: (s: unknown) => unknown) => {
+    const state = mockUseWalletStore();
+    return typeof selector === 'function' ? selector(state) : state;
+  },
 }));
 
 // Also mock via barrel store path (LeaderboardRow imports from '../../store')
 vi.mock('../../store', () => ({
-  useWalletStore: () => mockUseWalletStore(),
+  useWalletStore: (selector?: (s: unknown) => unknown) => {
+    const state = mockUseWalletStore();
+    return typeof selector === 'function' ? selector(state) : state;
+  },
 }));
 
 const mockIsFavorite = vi.fn().mockReturnValue(false);

--- a/frontend-scaffold/src/hooks/useLeaderboard.ts
+++ b/frontend-scaffold/src/hooks/useLeaderboard.ts
@@ -9,10 +9,8 @@ import { useWalletStore } from "../store/walletStore";
 import {
   getServer,
   getLeaderboard,
-  paginateLeaderboard,
   mergeLeaderboardEntries,
   invalidateLeaderboardCache,
-  LEADERBOARD_DEFAULT_PAGE_SIZE,
   LEADERBOARD_CACHE_TTL_MS,
   type LeaderboardFetchContext,
 } from "../services/soroban";
@@ -24,27 +22,26 @@ export interface LeaderboardData {
   entries: LeaderboardEntry[];
   loading: boolean;
   error: string | null;
+  /** @deprecated Pagination is now handled by LeaderboardTable. Always false. */
   hasMore: boolean;
+  /** @deprecated Pagination is now handled by LeaderboardTable. No-op. */
   loadMore: () => void;
   refetch: () => void;
 }
 
 /**
- * Fetches leaderboard data with RPC batching, TTL cache, and client pagination.
+ * Fetches the full leaderboard in a single RPC batch with TTL caching and
+ * background refresh. Client-side pagination is delegated to LeaderboardTable.
  */
-export const useLeaderboard = (
-  pageSize: number = LEADERBOARD_DEFAULT_PAGE_SIZE,
-): LeaderboardData => {
+export const useLeaderboard = (): LeaderboardData => {
   const wallet = useWallet();
   const { network } = useWalletStore();
 
   const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
 
   const fullBatchRef = useRef<LeaderboardEntry[]>([]);
-  const nextOffsetRef = useRef(0);
   const isFetchingRef = useRef(false);
   const hasDataRef = useRef(false);
 
@@ -72,25 +69,6 @@ export const useLeaderboard = (
     };
   }, [network, networkDetails.networkPassphrase, wallet.publicKey]);
 
-  const applyPage = useCallback(
-    (batch: LeaderboardEntry[], reset: boolean) => {
-      fullBatchRef.current = batch;
-
-      if (reset) {
-        const page = paginateLeaderboard(batch, 0, pageSize);
-        setEntries(page.items);
-        nextOffsetRef.current = page.nextOffset ?? batch.length;
-        setHasMore(page.hasMore);
-        return;
-      }
-
-      const visibleCount = Math.max(nextOffsetRef.current, pageSize);
-      setEntries(batch.slice(0, visibleCount));
-      setHasMore(visibleCount < batch.length);
-    },
-    [pageSize],
-  );
-
   const fetchLeaderboard = useCallback(
     async (options?: { background?: boolean; reset?: boolean }) => {
       if (isFetchingRef.current) {
@@ -98,7 +76,8 @@ export const useLeaderboard = (
       }
 
       if (env.useMockData) {
-        applyPage(mockLeaderboard, true);
+        fullBatchRef.current = mockLeaderboard;
+        setEntries(mockLeaderboard);
         setLoading(false);
         setError(null);
         return;
@@ -106,7 +85,6 @@ export const useLeaderboard = (
 
       if (!env.contractId) {
         setEntries([]);
-        setHasMore(false);
         setLoading(false);
         setError("Contract ID is not configured");
         return;
@@ -126,7 +104,8 @@ export const useLeaderboard = (
           ? batch
           : mergeLeaderboardEntries(fullBatchRef.current, batch);
 
-        applyPage(merged, shouldReset);
+        fullBatchRef.current = merged;
+        setEntries(merged);
         hasDataRef.current = true;
       } catch (err) {
         setError(
@@ -139,7 +118,7 @@ export const useLeaderboard = (
         isFetchingRef.current = false;
       }
     },
-    [applyPage, buildFetchContext],
+    [buildFetchContext],
   );
 
   useEffect(() => {
@@ -161,32 +140,14 @@ export const useLeaderboard = (
   }, [fetchLeaderboard]);
 
   const loadMore = useCallback(() => {
-    if (!hasMore || loading) {
-      return;
-    }
-
-    const page = paginateLeaderboard(
-      fullBatchRef.current,
-      nextOffsetRef.current,
-      pageSize,
-    );
-
-    if (page.items.length === 0) {
-      setHasMore(false);
-      return;
-    }
-
-    setEntries((prev) => [...prev, ...page.items]);
-    nextOffsetRef.current = page.nextOffset ?? fullBatchRef.current.length;
-    setHasMore(page.hasMore);
-  }, [hasMore, loading, pageSize]);
+    // No-op: pagination is now handled entirely by LeaderboardTable.
+  }, []);
 
   const refetch = useCallback(() => {
     invalidateLeaderboardCache();
-    nextOffsetRef.current = 0;
     hasDataRef.current = false;
     void fetchLeaderboard({ reset: true });
   }, [fetchLeaderboard]);
 
-  return { entries, loading, error, hasMore, loadMore, refetch };
+  return { entries, loading, error, hasMore: false, loadMore, refetch };
 };

--- a/frontend-scaffold/src/services/soroban.ts
+++ b/frontend-scaffold/src/services/soroban.ts
@@ -51,7 +51,7 @@ export const LEADERBOARD_CACHE_TTL_MS = Number(
 export const LEADERBOARD_PERF_BUDGET_MS = 2_000;
 
 /** Default page size for client-side leaderboard pagination. */
-export const LEADERBOARD_DEFAULT_PAGE_SIZE = 20;
+export const LEADERBOARD_DEFAULT_PAGE_SIZE = 25;
 
 export interface LeaderboardFetchContext {
   contractId: string;


### PR DESCRIPTION
close #755 


feat: add leaderboard pagination — 25 entries per page with user rank visibility (#755)

## Summary

- Leaderboard now displays at most 25 entries at a time via `Pagination`
  controls in `LeaderboardTable` (client-side windowing over the full
  cached batch — no extra RPC calls as the dataset grows).
- `useLeaderboard` now exposes the complete fetched batch in `entries`
  instead of a page slice, keeping all existing caching and background-
  refresh behaviour intact.
- `LeaderboardTable` shows a persistent "Your rank: #X" banner for
  connected users, plus a "Jump to my rank" button when they are on a
  different page — rank is always visible without requiring manual
  navigation.
- `LeaderboardPage` JSX has been repaired (orphaned closing tags, missing
  `refetch` destructuring, never-rendered `LeaderboardTable`).

## How pagination works

The contract's `get_leaderboard` call already returns the full board in
one RPC batch, which is cached with a configurable TTL. `LeaderboardTable`
slices that in-memory array at 25 rows per page, so initial load time is
unchanged as creator count grows.

## Test plan

- [ ] Visit `/leaderboard` — top 3 podium renders, full rankings table
  shows page 1 (25 rows max)
- [ ] Verify `Prev / Next / First / Last` buttons navigate pages correctly
- [ ] Connect a wallet that is ranked #4 or later — confirm "Your rank: #X"
  banner appears and the table auto-jumps to that page on load
- [ ] Connect a wallet on a different page, navigate away, and click
  "Jump to my rank" — confirm it returns to the correct page
- [ ] Verify existing unit tests (`LeaderboardPage.test.tsx`,
  `useLeaderboard.optimization.test.tsx`) still pass
