### PR TITLE
feat: add keyboard shortcuts for power users (#596)

### DIFF
--- a/frontend-scaffold/src/components/shared/GlobalSearch.tsx
+++ b/frontend-scaffold/src/components/shared/GlobalSearch.tsx
@@ -128,6 +128,8 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ isOpen, onClose }) => {
       const totalItems =
         displayResults.length > 0 ? displayResults.length : recentSearches.length;
 
+      if (totalItems === 0) return;
+
       if (e.key === "ArrowDown") {
         e.preventDefault();
         setSelectedIndex((prev) => (prev + 1) % totalItems);
@@ -183,7 +185,11 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ isOpen, onClose }) => {
         aria-modal="true"
         aria-label="Global search"
       >
-        <div className="flex items-center border-b-[3px] border-black px-4 py-3">
+        <div
+          className="flex items-center border-b-[3px] border-black px-4 py-3"
+          role="search"
+          aria-label="Global creator search"
+        >
           <Search size={16} className="text-gray-800 dark:text-gray-200 shrink-0" />
           <span className="ml-2 mr-2 text-xs font-black uppercase tracking-[0.2em] text-gray-800 dark:text-gray-200">
             Search

--- a/frontend-scaffold/src/components/shared/KeyboardShortcutsProvider.tsx
+++ b/frontend-scaffold/src/components/shared/KeyboardShortcutsProvider.tsx
@@ -52,6 +52,17 @@ const KeyboardShortcutsProvider: React.FC = () => {
     }
   }, [location.pathname]);
 
+  const openTipForm = useCallback(() => {
+    setHelpOpen(false);
+
+    if (/^\/@/.test(location.pathname)) {
+      focusTipAmount();
+      return;
+    }
+
+    setSearchOpen(true);
+  }, [focusTipAmount, location.pathname]);
+
   useKeyboardShortcuts([
     {
       key: "k",
@@ -74,19 +85,17 @@ const KeyboardShortcutsProvider: React.FC = () => {
       },
     },
     {
-      key: "d",
-      ctrl: true,
-      meta: true,
-      description: "Go to Dashboard",
+      key: "h",
+      sequence: ["g", "h"],
+      description: "Go to Home",
       action: () => {
         closeAll();
-        navigate("/dashboard");
+        navigate("/");
       },
     },
     {
       key: "l",
-      ctrl: true,
-      meta: true,
+      sequence: ["g", "l"],
       description: "Go to Leaderboard",
       action: () => {
         closeAll();
@@ -94,9 +103,18 @@ const KeyboardShortcutsProvider: React.FC = () => {
       },
     },
     {
+      key: "d",
+      sequence: ["g", "d"],
+      description: "Go to Dashboard",
+      action: () => {
+        closeAll();
+        navigate("/dashboard");
+      },
+    },
+    {
       key: "t",
-      description: "Focus tip amount input",
-      action: focusTipAmount,
+      description: "Open tip form",
+      action: openTipForm,
     },
     {
       key: "Escape",

--- a/frontend-scaffold/src/components/shared/ShortcutsModal.tsx
+++ b/frontend-scaffold/src/components/shared/ShortcutsModal.tsx
@@ -6,15 +6,24 @@ import { getModifierKey } from "@/hooks/useKeyboardShortcuts";
 interface ShortcutRowProps {
   keys: string[];
   description: string;
+  joiner?: "plus" | "then";
 }
 
-const ShortcutRow: React.FC<ShortcutRowProps> = ({ keys, description }) => (
+const ShortcutRow: React.FC<ShortcutRowProps> = ({
+  keys,
+  description,
+  joiner = "plus",
+}) => (
   <div className="flex items-center justify-between gap-4 border-b-2 border-black py-3 last:border-b-0">
     <span className="text-sm font-medium text-gray-700">{description}</span>
     <div className="flex shrink-0 items-center gap-1">
       {keys.map((k, i) => (
         <React.Fragment key={k}>
-          {i > 0 && <span className="text-xs font-bold text-gray-700 dark:text-gray-300">+</span>}
+          {i > 0 && (
+            <span className="text-xs font-bold text-gray-700 dark:text-gray-300">
+              {joiner === "then" ? "then" : "+"}
+            </span>
+          )}
           <kbd className="inline-flex items-center justify-center border-2 border-black bg-white px-2 py-0.5 font-mono text-xs font-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
             {k}
           </kbd>
@@ -37,13 +46,14 @@ const ShortcutsModal: React.FC<ShortcutsModalProps> = ({ isOpen, onClose }) => {
       heading: "Navigation",
       shortcuts: [
         { keys: [mod, "K"], description: "Quick search creators" },
-        { keys: [mod, "D"], description: "Go to Dashboard" },
-        { keys: [mod, "L"], description: "Go to Leaderboard" },
+        { keys: ["G", "H"], joiner: "then", description: "Go to Home" },
+        { keys: ["G", "L"], joiner: "then", description: "Go to Leaderboard" },
+        { keys: ["G", "D"], joiner: "then", description: "Go to Dashboard" },
       ],
     },
     {
       heading: "Tip page",
-      shortcuts: [{ keys: ["T"], description: "Focus tip amount input" }],
+      shortcuts: [{ keys: ["T"], description: "Open tip form" }],
     },
     {
       heading: "General",

--- a/frontend-scaffold/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend-scaffold/src/hooks/useKeyboardShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef } from "react";
 
 export interface KeyboardShortcut {
   key: string;
+  sequence?: string[];
   ctrl?: boolean;
   meta?: boolean;
   shift?: boolean;
@@ -41,6 +42,25 @@ function normalizeKey(key: string): string {
   return keyMap[key] || key;
 }
 
+function matchesKey(event: KeyboardEvent, shortcut: KeyboardShortcut): boolean {
+  const key = normalizeKey(event.key);
+  const ctrlMatch = shortcut.ctrl ? event.ctrlKey : !event.ctrlKey;
+  const metaMatch = shortcut.meta ? event.metaKey : !event.metaKey;
+  const shiftMatch = shortcut.shift ? event.shiftKey : !event.shiftKey;
+  const altMatch = shortcut.alt ? event.altKey : !event.altKey;
+
+  // Handle Cmd/Ctrl as interchangeable for shortcuts that opt into either.
+  const modifierMatch =
+    (shortcut.ctrl || shortcut.meta) && (event.ctrlKey || event.metaKey);
+
+  return (
+    key.toLowerCase() === shortcut.key.toLowerCase() &&
+    (modifierMatch || (ctrlMatch && metaMatch)) &&
+    shiftMatch &&
+    altMatch
+  );
+}
+
 /**
  * Hook that registers global keyboard shortcuts.
  * Automatically prevents shortcuts from firing when typing in input fields
@@ -48,45 +68,96 @@ function normalizeKey(key: string): string {
  */
 export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]): void {
   const shortcutsRef = useRef(shortcuts);
+  const sequenceRef = useRef<string[]>([]);
+  const sequenceTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     shortcutsRef.current = shortcuts;
   }, [shortcuts]);
 
+  const resetSequence = useCallback(() => {
+    sequenceRef.current = [];
+    if (sequenceTimeoutRef.current !== null) {
+      window.clearTimeout(sequenceTimeoutRef.current);
+      sequenceTimeoutRef.current = null;
+    }
+  }, []);
+
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
     const typing = isTypingInInput();
 
+    if (event.key === "Escape") {
+      resetSequence();
+    }
+
+    if (!typing && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      const key = normalizeKey(event.key).toLowerCase();
+      const sequenceShortcuts = shortcutsRef.current.filter(
+        (shortcut) => shortcut.sequence && shortcut.sequence.length > 0,
+      );
+
+      if (sequenceShortcuts.length > 0 && key.length === 1) {
+        const nextSequence = [...sequenceRef.current, key].slice(-2);
+        const matchingSequence = sequenceShortcuts.find((shortcut) => {
+          const sequence = shortcut.sequence?.map((item) => item.toLowerCase());
+          return (
+            sequence?.length === nextSequence.length &&
+            sequence.every((item, index) => item === nextSequence[index])
+          );
+        });
+
+        const canContinueSequence = sequenceShortcuts.some((shortcut) => {
+          const sequence = shortcut.sequence?.map((item) => item.toLowerCase());
+          return (
+            sequence &&
+            nextSequence.length < sequence.length &&
+            nextSequence.every((item, index) => item === sequence[index])
+          );
+        });
+
+        if (matchingSequence) {
+          event.preventDefault();
+          resetSequence();
+          matchingSequence.action();
+          return;
+        }
+
+        if (canContinueSequence) {
+          event.preventDefault();
+          sequenceRef.current = nextSequence;
+          if (sequenceTimeoutRef.current !== null) {
+            window.clearTimeout(sequenceTimeoutRef.current);
+          }
+          sequenceTimeoutRef.current = window.setTimeout(resetSequence, 1000);
+          return;
+        }
+
+        resetSequence();
+      }
+    }
+
     for (const shortcut of shortcutsRef.current) {
+      if (shortcut.sequence) continue;
+
       // Skip if typing in input and shortcut doesn't allow it
       if (typing && !shortcut.allowInInput) continue;
 
-      const key = normalizeKey(event.key);
-      const ctrlMatch = shortcut.ctrl ? event.ctrlKey : !event.ctrlKey;
-      const metaMatch = shortcut.meta ? event.metaKey : !event.metaKey;
-      const shiftMatch = shortcut.shift ? event.shiftKey : !event.shiftKey;
-      const altMatch = shortcut.alt ? event.altKey : !event.altKey;
-
-      // Handle Cmd/Ctrl as interchangeable
-      const modifierMatch =
-        (shortcut.ctrl || shortcut.meta) && (event.ctrlKey || event.metaKey);
-
-      if (
-        key === shortcut.key &&
-        (modifierMatch || (ctrlMatch && metaMatch)) &&
-        shiftMatch &&
-        altMatch
-      ) {
+      if (matchesKey(event, shortcut)) {
         event.preventDefault();
+        resetSequence();
         shortcut.action();
         break;
       }
     }
-  }, []);
+  }, [resetSequence]);
 
   useEffect(() => {
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      resetSequence();
+    };
+  }, [handleKeyDown, resetSequence]);
 }
 
 /**


### PR DESCRIPTION
Closes #596

Changes
Added global keyboard shortcut handling for multi-key sequences like G then H, G then L, and G then D.
Changed the tip shortcut so T opens the tip flow instead of only focusing an existing input.
Updated the keyboard shortcuts help modal to show the new sequence-based navigation shortcuts clearly.
Added a role="search" landmark to the global search header for better accessibility.
Kept Cmd/Ctrl+K for global search and Cmd/Ctrl+/ for shortcuts help.

Notes
Removed the old Cmd/Ctrl+D and Cmd/Ctrl+L navigation bindings to avoid conflicts with browser behavior.
The keyboard shortcut hook now supports simple multi-key sequences with a short timeout and reset on Escape.
