### PR TITLE
feat: typed config, Redis singleton, graceful shutdown, AuthChallenge model

### DIFF
--- a/backend/prisma/migrations/20260623200000_add_auth_challenge/migration.sql
+++ b/backend/prisma/migrations/20260623200000_add_auth_challenge/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "AuthChallenge" (
+    "id"        TEXT         NOT NULL,
+    "address"   TEXT         NOT NULL,
+    "nonce"     TEXT         NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuthChallenge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuthChallenge_nonce_key" ON "AuthChallenge"("nonce");
+
+-- CreateIndex
+CREATE INDEX "AuthChallenge_address_idx" ON "AuthChallenge"("address");
+
+-- CreateIndex
+CREATE INDEX "AuthChallenge_expiresAt_idx" ON "AuthChallenge"("expiresAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -97,3 +97,20 @@ model Streak {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 }
+
+/// Short-lived wallet authentication challenge.
+/// Created when a wallet requests a sign-in nonce; deleted (or expired) after verification.
+/// TTL is enforced by the application layer via AUTH_CHALLENGE_TTL_SECONDS.
+model AuthChallenge {
+  id        String   @id @default(cuid())
+  /// The wallet address this challenge was issued for.
+  address   String
+  /// Random nonce the wallet must sign to prove ownership.
+  nonce     String   @unique
+  /// UTC timestamp after which the challenge is no longer valid.
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([address])
+  @@index([expiresAt])
+}

--- a/backend/src/common/utils/lifecycle.ts
+++ b/backend/src/common/utils/lifecycle.ts
@@ -1,0 +1,30 @@
+import { logger } from './logger.js';
+
+export interface Closable {
+  close(): Promise<void>;
+  name: string;
+}
+
+const registry: Closable[] = [];
+
+/** Register a resource for graceful shutdown. */
+export function registerClosable(closable: Closable): void {
+  registry.push(closable);
+}
+
+/**
+ * Close all registered resources in reverse registration order.
+ * Errors from individual resources are logged but do not prevent others from closing.
+ */
+export async function closeAll(): Promise<void> {
+  const toClose = [...registry].reverse();
+  for (const resource of toClose) {
+    try {
+      logger.info(`Closing ${resource.name}...`);
+      await resource.close();
+      logger.info(`${resource.name} closed`);
+    } catch (err) {
+      logger.error({ err }, `Error closing ${resource.name}`);
+    }
+  }
+}

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -1,0 +1,63 @@
+import { env } from './env.js';
+
+/**
+ * Typed, domain-grouped config object.
+ * Modules should import `config` from here rather than `env` directly.
+ *
+ * @example
+ *   import { config } from '../config/index.js';
+ *   const rpc = config.stellar.rpcUrl;
+ */
+export const config = {
+  server: {
+    nodeEnv: env.NODE_ENV,
+    port: env.PORT,
+    apiBasePath: env.API_BASE_PATH,
+    corsOrigin: env.CORS_ORIGIN,
+  },
+
+  db: {
+    databaseUrl: env.DATABASE_URL,
+  },
+
+  redis: {
+    redisUrl: env.REDIS_URL,
+  },
+
+  auth: {
+    jwtSecret: env.JWT_SECRET,
+    jwtExpiresIn: env.JWT_EXPIRES_IN,
+    refreshTokenExpiresIn: env.REFRESH_TOKEN_EXPIRES_IN,
+    challengeTtlSeconds: env.AUTH_CHALLENGE_TTL_SECONDS,
+  },
+
+  stellar: {
+    network: env.STELLAR_NETWORK,
+    rpcUrl: env.SOROBAN_RPC_URL,
+    horizonUrl: env.HORIZON_URL,
+    networkPassphrase: env.NETWORK_PASSPHRASE,
+    contractId: env.CONTRACT_ID,
+  },
+
+  indexer: {
+    pollIntervalMs: env.INDEXER_POLL_INTERVAL_MS,
+    startLedger: env.INDEXER_START_LEDGER,
+  },
+
+  twitter: {
+    bearerToken: env.X_API_BEARER_TOKEN,
+    baseUrl: env.X_API_BASE_URL,
+  },
+
+  ipfs: {
+    apiUrl: env.IPFS_API_URL,
+    gatewayUrl: env.IPFS_GATEWAY_URL,
+  },
+
+  logging: {
+    level: env.LOG_LEVEL,
+    sentryDsn: env.SENTRY_DSN,
+  },
+} as const;
+
+export type Config = typeof config;

--- a/backend/src/db/redis.ts
+++ b/backend/src/db/redis.ts
@@ -1,0 +1,35 @@
+import Redis from 'ioredis';
+import { config } from '../config/index.js';
+import { logger } from '../common/utils/logger.js';
+
+/**
+ * Shared ioredis singleton.
+ * Import `redis` wherever you need cache, rate-limiting, pub/sub or queues.
+ *
+ * Connection is established lazily on first use; errors are logged and the
+ * process is not killed — callers should handle `null` returns gracefully.
+ */
+export const redis = new Redis(config.redis.redisUrl, {
+  maxRetriesPerRequest: null, // required by BullMQ
+  enableReadyCheck: false,
+});
+
+redis.on('connect', () => {
+  logger.info('Redis connected');
+});
+
+redis.on('ready', () => {
+  logger.info('Redis ready');
+});
+
+redis.on('error', (err) => {
+  logger.error({ err }, 'Redis connection error');
+});
+
+redis.on('close', () => {
+  logger.warn('Redis connection closed');
+});
+
+redis.on('reconnecting', () => {
+  logger.info('Redis reconnecting...');
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,11 +2,26 @@ import { createServer } from 'node:http';
 import { createApp } from './app.js';
 import { env } from './config/env.js';
 import { logger } from './common/utils/logger.js';
+import { prisma } from './db/prisma.js';
+import { redis } from './db/redis.js';
+import { registerClosable, closeAll } from './common/utils/lifecycle.js';
 
 /** Process entry point: starts the HTTP server (and, later, the WebSocket + indexer). */
 async function bootstrap(): Promise<void> {
   const app = createApp();
   const httpServer = createServer(app);
+
+  // Register Prisma and Redis for graceful shutdown.
+  registerClosable({
+    name: 'Prisma',
+    close: () => prisma.$disconnect(),
+  });
+  registerClosable({
+    name: 'Redis',
+    close: async () => {
+      await redis.quit();
+    },
+  });
 
   // The realtime gateway (Socket.IO) attaches to this httpServer — see the realtime issues.
   // initRealtime(httpServer);
@@ -15,12 +30,17 @@ async function bootstrap(): Promise<void> {
     logger.info(`🚀 Stellar Tipz backend listening on http://localhost:${env.PORT}`);
   });
 
-  const shutdown = (signal: string) => {
+  const shutdown = async (signal: string) => {
     logger.info(`${signal} received, shutting down...`);
-    httpServer.close(() => process.exit(0));
+    httpServer.close(async () => {
+      await closeAll();
+      logger.info('Graceful shutdown complete');
+      process.exit(0);
+    });
   };
-  process.on('SIGINT', () => shutdown('SIGINT'));
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
 }
 
 bootstrap().catch((err) => {

--- a/backend/tests/config.test.ts
+++ b/backend/tests/config.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+describe('config/index', () => {
+  it('exports grouped config domains', async () => {
+    process.env.DATABASE_URL = 'postgresql://u:p@localhost:5432/db';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    process.env.JWT_SECRET = 'supersecretkey';
+    process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org';
+    process.env.NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+    const { config } = await import('../src/config/index.js');
+
+    expect(config.server).toBeDefined();
+    expect(config.db).toBeDefined();
+    expect(config.redis).toBeDefined();
+    expect(config.auth).toBeDefined();
+    expect(config.stellar).toBeDefined();
+    expect(config.indexer).toBeDefined();
+    expect(config.twitter).toBeDefined();
+    expect(config.ipfs).toBeDefined();
+    expect(config.logging).toBeDefined();
+  });
+
+  it('exposes config.stellar.rpcUrl', async () => {
+    const { config } = await import('../src/config/index.js');
+    expect(typeof config.stellar.rpcUrl).toBe('string');
+  });
+
+  it('exposes config.auth.jwtSecret', async () => {
+    const { config } = await import('../src/config/index.js');
+    expect(typeof config.auth.jwtSecret).toBe('string');
+  });
+});

--- a/backend/tests/lifecycle.test.ts
+++ b/backend/tests/lifecycle.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('lifecycle registry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('closes all registered resources in reverse order', async () => {
+    const { registerClosable, closeAll } = await import('../src/common/utils/lifecycle.js');
+
+    const order: string[] = [];
+    registerClosable({ name: 'A', close: async () => { order.push('A'); } });
+    registerClosable({ name: 'B', close: async () => { order.push('B'); } });
+
+    await closeAll();
+
+    expect(order).toEqual(['B', 'A']);
+  });
+
+  it('continues closing other resources if one throws', async () => {
+    const { registerClosable, closeAll } = await import('../src/common/utils/lifecycle.js');
+
+    const closed: string[] = [];
+    registerClosable({ name: 'Good', close: async () => { closed.push('Good'); } });
+    registerClosable({ name: 'Bad',  close: async () => { throw new Error('fail'); } });
+
+    await expect(closeAll()).resolves.toBeUndefined();
+    expect(closed).toContain('Good');
+  });
+});


### PR DESCRIPTION
## Summary

Resolves four backend setup issues in one atomic PR. All changes target the `test-implement-drips` branch.

Closes #800
Closes #799
Closes #798
Closes #816

---

## Changes

### `backend/src/config/index.ts` — typed config object (closes #800)

Wraps the validated `env` into a `config` object grouped by domain:

```ts
import { config } from '../config/index.js';
config.stellar.rpcUrl      // SOROBAN_RPC_URL
config.auth.jwtSecret      // JWT_SECRET
config.redis.redisUrl      // REDIS_URL
```

All nine domains are exported: `server`, `db`, `redis`, `auth`, `stellar`, `indexer`, `twitter`, `ipfs`, `logging`.

---

### `backend/src/db/redis.ts` — ioredis singleton (closes #799)

```ts
import { redis } from './db/redis.js';
```

- Connects using `config.redis.redisUrl` (REDIS_URL)
- Logs `connect`, `ready`, `error`, `close`, `reconnecting` events via the shared `pino` logger
- `maxRetriesPerRequest: null` required by BullMQ

---

### `backend/src/common/utils/lifecycle.ts` + `backend/src/server.ts` — graceful shutdown (closes #798)

New `lifecycle.ts` registry:
```ts
registerClosable({ name: 'Prisma', close: () => prisma.$disconnect() });
registerClosable({ name: 'Redis',  close: async () => { await redis.quit(); } });
```

`server.ts` registers both and calls `closeAll()` in the SIGINT/SIGTERM handler. Closables are closed **in reverse registration order**; errors in one resource do not prevent others from closing.

On clean shutdown the process logs:
```
SIGTERM received, shutting down...
Closing Redis...
Redis closed
Closing Prisma...
Prisma closed
Graceful shutdown complete
```

---

### `backend/prisma/schema.prisma` + migration — AuthChallenge model (closes #816)

```prisma
model AuthChallenge {
  id        String   @id @default(cuid())
  address   String
  nonce     String   @unique
  expiresAt DateTime
  createdAt DateTime @default(now())

  @@index([address])
  @@index([expiresAt])
}
```

Migration: `prisma/migrations/20260623200000_add_auth_challenge/migration.sql`

TTL is enforced at the application layer via `AUTH_CHALLENGE_TTL_SECONDS` (already in `env.ts`). The `expiresAt` index enables an efficient sweep to delete stale challenges.

---

## Test plan

- [x] `tests/config.test.ts` — asserts all nine domains exported and key fields typed correctly
- [x] `tests/lifecycle.test.ts` — asserts reverse-order close and error resilience
- [ ] `prisma validate` — run against a fresh DB to confirm schema compiles
- [ ] `npm run typecheck && npm run lint && npm run test` — all pass