### PR TITLE
feat(auth): fix issues #847, #830, #839, #837

### DIFF
--- a/PR_DESCRIPTION_341.md
+++ b/PR_DESCRIPTION_341.md
@@ -1,0 +1,71 @@
+# PR: Fix Issues #847, #830, #839, #837
+
+Closes #847 | Closes #830 | Closes #839 | Closes #837
+
+---
+
+## Summary
+
+This PR implements four backend issues from the `test-implement-drips` track, all in `backend/src/modules/auth/` and supporting modules.
+
+---
+
+## Issues Fixed
+
+### #847 — Auth: configurable token TTLs via env
+
+Added a `durationString` Zod validator in `backend/src/config/env.ts` that enforces the format `<positive-integer><unit>` where unit is one of `s`, `m`, `h`, `d`. Both `JWT_EXPIRES_IN` and `REFRESH_TOKEN_EXPIRES_IN` now use this validator instead of a plain `z.string()`.
+
+- Invalid values like `"15 m"`, `"7D"`, `"-1d"`, or `"abc"` are rejected at startup with a clear Zod error.
+- Defaults (`"15m"` and `"7d"`) are still valid and unchanged.
+
+### #830 — DB: Add Prisma enum types module
+
+Created `backend/src/types/enums.ts` which re-exports all Prisma-generated enums (`Period`, `TipStatus`, `WithdrawalStatus`) from a single location. App code can now import enums from `@/types/enums.js` rather than directly from `@prisma/client`.
+
+### #839 — Auth: optionalAuth middleware
+
+Added `optionalAuth` to `backend/src/modules/auth/auth.middleware.ts`. It:
+- Attaches `req.auth` if a valid Bearer token is present.
+- Never calls `next(error)` — silently ignores missing, malformed, or invalid tokens.
+- Allows routes to serve both authenticated and anonymous users from the same handler.
+
+### #837 — Auth: Logout endpoint (revoke refresh token)
+
+`POST /auth/logout` was already implemented in the upstream merge:
+- `revokeRefreshToken` in `auth.service.ts` — idempotent (returns early if already revoked).
+- `logoutController` in `auth.controller.ts` — validates input with Zod, uses `AppError`.
+- Route registered in `auth.routes.ts`.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/config/env.ts` | Added `durationString` Zod validator for TTL env vars |
+| `backend/src/modules/auth/auth.middleware.ts` | Added `optionalAuth` middleware |
+| `backend/src/types/enums.ts` | New file — centralised Prisma enum re-exports |
+| `backend/tests/ttl-validation.test.ts` | New — tests for duration string validation (#847) |
+| `backend/tests/auth.test.ts` | Added `optionalAuth` tests (#839) |
+
+---
+
+## Verification
+
+All files pass `getDiagnostics` (TypeScript + lint) with zero errors.
+
+Tests added:
+- `backend/tests/ttl-validation.test.ts` — success + failure cases for duration format validation
+- `backend/tests/auth.test.ts` — 4 new tests for `optionalAuth` (no token, malformed header, invalid token, valid token)
+
+---
+
+## Acceptance Criteria
+
+- [x] Inputs validated; errors use `AppError` (or Zod at env parse time for #847)
+- [x] Tests cover success + failure paths
+- [x] Typecheck passes (`getDiagnostics` clean)
+- [x] `optionalAuth` never throws/rejects
+- [x] Logout is idempotent
+- [x] Enum types centralised in `src/types/enums.ts`

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -6,6 +6,15 @@ import { z } from 'zod';
  * Every module should import `env` from here rather than reading process.env directly.
  * See backend/.env.example for the full list of variables.
  */
+
+/**
+ * Validates a duration string like "15m", "7d", "30s", "2h".
+ * Accepted units: s (seconds), m (minutes), h (hours), d (days).
+ */
+const durationString = z
+  .string()
+  .regex(/^\d+[smhd]$/, 'Must be a positive integer followed by s, m, h, or d (e.g. "15m", "7d")');
+
 const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().default(4000),
@@ -16,8 +25,10 @@ const envSchema = z.object({
   REDIS_URL: z.string().url(),
 
   JWT_SECRET: z.string().min(8),
-  JWT_EXPIRES_IN: z.string().default('15m'),
-  REFRESH_TOKEN_EXPIRES_IN: z.string().default('7d'),
+  /** Access token TTL — must be a duration string like "15m" or "1h". */
+  JWT_EXPIRES_IN: durationString.default('15m'),
+  /** Refresh token TTL — must be a duration string like "7d" or "30d". */
+  REFRESH_TOKEN_EXPIRES_IN: durationString.default('7d'),
   AUTH_CHALLENGE_TTL_SECONDS: z.coerce.number().default(300),
 
   STELLAR_NETWORK: z.enum(['TESTNET', 'FUTURENET', 'MAINNET']).default('TESTNET'),

--- a/backend/src/modules/auth/auth.middleware.ts
+++ b/backend/src/modules/auth/auth.middleware.ts
@@ -33,3 +33,28 @@ export function authMiddleware(req: Request, _res: Response, next: NextFunction)
 
 /** Alias kept for backward compat with any code referencing requireAuth. */
 export const requireAuth = authMiddleware;
+
+/**
+ * #839 — optionalAuth middleware.
+ * Attaches `req.auth` if a valid Bearer token is present, but never rejects.
+ * Routes that call this can check `req.auth` to distinguish authenticated
+ * from anonymous requests.
+ */
+export function optionalAuth(req: Request, _res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return next();
+  }
+
+  const token = authHeader.substring(7);
+
+  try {
+    const payload = verifyAccessToken(token);
+    req.auth = payload;
+  } catch {
+    // Invalid/expired token — silently ignore, leave req.auth undefined
+  }
+
+  next();
+}

--- a/backend/src/types/enums.ts
+++ b/backend/src/types/enums.ts
@@ -1,0 +1,9 @@
+/**
+ * #830 — DB: Add Prisma enum types module
+ *
+ * Centralised re-export of Prisma-generated enum types so application code
+ * imports from here rather than directly from `@prisma/client`.
+ * This keeps enum usage consistent and makes future migrations easier.
+ */
+
+export { Period, TipStatus, WithdrawalStatus } from '@prisma/client';

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -1,5 +1,6 @@
 import request from 'supertest';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Request, Response, NextFunction } from 'express';
 import { createApp } from '../src/app.js';
 import { UnauthorizedError } from '../src/common/errors/AppError.js';
 import { prisma } from '../src/db/prisma.js';
@@ -327,5 +328,58 @@ describe('Auth Flow End-to-End', () => {
 
       expect(logoutRes.status).toBe(200);
     });
+  });
+});
+
+// ── #839 optionalAuth middleware ──────────────────────────────────────────────
+
+import express from 'express';
+import { optionalAuth } from '../src/modules/auth/auth.middleware.js';
+
+describe('optionalAuth middleware (issue #839)', () => {
+  // Build a minimal test app that uses optionalAuth and echoes req.auth
+  const miniApp = express();
+  miniApp.use(express.json());
+  miniApp.get('/optional', optionalAuth, (req, res) => {
+    res.json({ auth: req.auth ?? null });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not reject when Authorization header is missing', async () => {
+    const res = await request(miniApp).get('/optional');
+    expect(res.status).toBe(200);
+    expect(res.body.auth).toBeNull();
+  });
+
+  it('does not reject when Authorization header is malformed', async () => {
+    const res = await request(miniApp)
+      .get('/optional')
+      .set('Authorization', 'NotBearer abc');
+    expect(res.status).toBe(200);
+    expect(res.body.auth).toBeNull();
+  });
+
+  it('does not reject when token is invalid', async () => {
+    vi.mocked(verifyAccessToken).mockImplementation(() => {
+      throw new UnauthorizedError('bad token');
+    });
+    const res = await request(miniApp)
+      .get('/optional')
+      .set('Authorization', 'Bearer bad.token.here');
+    expect(res.status).toBe(200);
+    expect(res.body.auth).toBeNull();
+  });
+
+  it('attaches req.auth when token is valid', async () => {
+    const payload = { userId: 'user_42', stellarAddress: 'GABC' };
+    vi.mocked(verifyAccessToken).mockReturnValue(payload);
+    const res = await request(miniApp)
+      .get('/optional')
+      .set('Authorization', 'Bearer valid.token.here');
+    expect(res.status).toBe(200);
+    expect(res.body.auth).toEqual(payload);
   });
 });

--- a/backend/tests/ttl-validation.test.ts
+++ b/backend/tests/ttl-validation.test.ts
@@ -1,0 +1,42 @@
+/**
+ * #847 — Auth: configurable token TTLs via env
+ *
+ * Tests that JWT_EXPIRES_IN and REFRESH_TOKEN_EXPIRES_IN are validated
+ * as duration strings (e.g. "15m", "7d") and reject invalid formats.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// Re-create the duration validator exactly as in env.ts so we can unit-test it
+// in isolation without triggering the full env parse (which needs DB/Redis URLs).
+const durationString = z
+  .string()
+  .regex(/^\d+[smhd]$/, 'Must be a positive integer followed by s, m, h, or d (e.g. "15m", "7d")');
+
+describe('duration string validation (issue #847)', () => {
+  // ── success cases ──────────────────────────────────────────────────────────
+
+  it.each(['15m', '7d', '30s', '2h', '1d', '60m', '24h'])(
+    'accepts valid duration "%s"',
+    (value) => {
+      expect(() => durationString.parse(value)).not.toThrow();
+    },
+  );
+
+  // ── failure cases ─────────────────────────────────────────────────────────
+
+  it.each([
+    '15 m',   // space between number and unit
+    '7D',     // uppercase unit
+    '-1d',    // negative
+    '0.5h',   // decimal
+    'abc',    // no number
+    '15',     // no unit
+    '',       // empty
+    '7weeks', // invalid unit
+  ])('rejects invalid duration "%s"', (value) => {
+    const result = durationString.safeParse(value);
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
# PR: Fix Issues #847, #830, #839, #837

Closes #847 | Closes #830 | Closes #839 | Closes #837

---

## Summary

This PR implements four backend issues from the `test-implement-drips` track, all in `backend/src/modules/auth/` and supporting modules.

---

## Issues Fixed

### #847 — Auth: configurable token TTLs via env

Added a `durationString` Zod validator in `backend/src/config/env.ts` that enforces the format `<positive-integer><unit>` where unit is one of `s`, `m`, `h`, `d`. Both `JWT_EXPIRES_IN` and `REFRESH_TOKEN_EXPIRES_IN` now use this validator instead of a plain `z.string()`.

- Invalid values like `"15 m"`, `"7D"`, `"-1d"`, or `"abc"` are rejected at startup with a clear Zod error.
- Defaults (`"15m"` and `"7d"`) are still valid and unchanged.

### #830 — DB: Add Prisma enum types module

Created `backend/src/types/enums.ts` which re-exports all Prisma-generated enums (`Period`, `TipStatus`, `WithdrawalStatus`) from a single location. App code can now import enums from `@/types/enums.js` rather than directly from `@prisma/client`.

### #839 — Auth: optionalAuth middleware

Added `optionalAuth` to `backend/src/modules/auth/auth.middleware.ts`. It:
- Attaches `req.auth` if a valid Bearer token is present.
- Never calls `next(error)` — silently ignores missing, malformed, or invalid tokens.
- Allows routes to serve both authenticated and anonymous users from the same handler.

### #837 — Auth: Logout endpoint (revoke refresh token)

`POST /auth/logout` was already implemented in the upstream merge:
- `revokeRefreshToken` in `auth.service.ts` — idempotent (returns early if already revoked).
- `logoutController` in `auth.controller.ts` — validates input with Zod, uses `AppError`.
- Route registered in `auth.routes.ts`.

---

## Files Changed

| File | Change |
|------|--------|
| `backend/src/config/env.ts` | Added `durationString` Zod validator for TTL env vars |
| `backend/src/modules/auth/auth.middleware.ts` | Added `optionalAuth` middleware |
| `backend/src/types/enums.ts` | New file — centralised Prisma enum re-exports |
| `backend/tests/ttl-validation.test.ts` | New — tests for duration string validation (#847) |
| `backend/tests/auth.test.ts` | Added `optionalAuth` tests (#839) |

---

## Verification

All files pass `getDiagnostics` (TypeScript + lint) with zero errors.

Tests added:
- `backend/tests/ttl-validation.test.ts` — success + failure cases for duration format validation
- `backend/tests/auth.test.ts` — 4 new tests for `optionalAuth` (no token, malformed header, invalid token, valid token)

---

## Acceptance Criteria

- [x] Inputs validated; errors use `AppError` (or Zod at env parse time for #847)
- [x] Tests cover success + failure paths
- [x] Typecheck passes (`getDiagnostics` clean)
- [x] `optionalAuth` never throws/rejects
- [x] Logout is idempotent
- [x] Enum types centralised in `src/types/enums.ts`
