### PR TITLE
feat: implement auth signature verification, role/scope middleware, and profiles module

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,6 +23,8 @@ model User {
   imageUrl       String?
   avatarCid      String?
   xHandle        String?
+  role           String   @default("user")
+  scopes         String[] @default([])
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
@@ -35,6 +37,7 @@ model User {
   creditScore          CreditScore?
   creditScoreHistory   CreditScoreHistory[]
   withdrawals          Withdrawal[]
+  refreshTokens        RefreshToken[]
 }
 
 /// API key for service/admin access and webhook integrations.
@@ -149,17 +152,35 @@ model Streak {
 /// Created when a wallet requests a sign-in nonce; deleted (or expired) after verification.
 /// TTL is enforced by the application layer via AUTH_CHALLENGE_TTL_SECONDS.
 model AuthChallenge {
-  id        String   @id @default(cuid())
+  id              String   @id @default(cuid())
   /// The wallet address this challenge was issued for.
-  address   String
+  stellarAddress  String
   /// Random nonce the wallet must sign to prove ownership.
-  nonce     String   @unique
+  challenge       String   @unique
+  /// Network this challenge is bound to (TESTNET, FUTURENET, MAINNET).
+  network         String
   /// UTC timestamp after which the challenge is no longer valid.
-  expiresAt DateTime
-  createdAt DateTime @default(now())
+  expiresAt       DateTime
+  /// UTC timestamp when the challenge was successfully used (null if unused).
+  usedAt          DateTime?
+  createdAt       DateTime @default(now())
 
-  @@index([address])
+  @@index([stellarAddress])
   @@index([expiresAt])
+}
+
+/// Refresh token for token rotation.
+model RefreshToken {
+  id        String    @id @default(cuid())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  token     String    @unique
+  expiresAt DateTime
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([userId])
+  @@index([token])
 }
 
 enum TipStatus {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,12 +1,17 @@
-import cors from 'cors';
-import express, { type Express } from 'express';
-import helmet from 'helmet';
-import pinoHttp from 'pino-http';
-import swaggerUi from 'swagger-ui-express';
-import { env } from './config/env.js';
-import { errorHandler, notFoundHandler } from './common/middleware/errorHandler.js';
-import { logger } from './common/utils/logger.js';
-import { openApiDocument } from './docs/openapi.js';
+import cors from "cors";
+import express, { type Express } from "express";
+import helmet from "helmet";
+import pinoHttp from "pino-http";
+import swaggerUi from "swagger-ui-express";
+import { env } from "./config/env.js";
+import {
+  errorHandler,
+  notFoundHandler,
+} from "./common/middleware/errorHandler.js";
+import { logger } from "./common/utils/logger.js";
+import { openApiDocument } from "./docs/openapi.js";
+import { authRouter } from "./modules/auth/auth.routes.js";
+import { profilesRouter } from "./modules/profiles/profiles.routes.js";
 
 /**
  * Builds and configures the Express application (no listening here — see server.ts).
@@ -25,14 +30,14 @@ export function createApp(): Express {
       contentSecurityPolicy: {
         directives: {
           ...helmet.contentSecurityPolicy.getDefaultDirectives(),
-          'script-src': ["'self'", "'unsafe-inline'"],
-          'style-src': ["'self'", "'unsafe-inline'"],
+          "script-src": ["'self'", "'unsafe-inline'"],
+          "style-src": ["'self'", "'unsafe-inline'"],
         },
       },
     }),
   );
-  app.use(cors({ origin: env.CORS_ORIGIN.split(','), credentials: true }));
-  app.use(express.json({ limit: '1mb' }));
+  app.use(cors({ origin: env.CORS_ORIGIN.split(","), credentials: true }));
+  app.use(express.json({ limit: "1mb" }));
   app.use(pinoHttp({ logger }));
 
   const docsPath = `${env.API_BASE_PATH}/docs`;
@@ -42,13 +47,17 @@ export function createApp(): Express {
   app.use(docsPath, swaggerUi.serve, swaggerUi.setup(openApiDocument));
 
   // Health check (implemented in the health module issue; basic version inline for scaffolding).
-  app.get('/health', (_req, res) => {
-    res.json({ status: 'ok', service: 'stellar-tipz-backend', time: new Date().toISOString() });
+  app.get("/health", (_req, res) => {
+    res.json({
+      status: "ok",
+      service: "stellar-tipz-backend",
+      time: new Date().toISOString(),
+    });
   });
 
   // ── Feature routers mount here ───────────────────────────────
   app.use(`${env.API_BASE_PATH}/auth`, authRouter);
-  // app.use(`${env.API_BASE_PATH}/profiles`, profilesRouter);
+  app.use(`${env.API_BASE_PATH}/profiles`, profilesRouter);
   // app.use(`${env.API_BASE_PATH}/tips`, tipsRouter);
   // ... (one issue per module)
   // ─────────────────────────────────────────────────────────────

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,32 +1,32 @@
-import { Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
-import { BadRequestError } from '../../common/errors/AppError.js';
-import { prisma } from '../../db/prisma.js';
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { BadRequestError } from "../../common/errors/AppError.js";
+import { prisma } from "../../db/prisma.js";
 import {
   createChallenge,
   verifyChallenge,
   refreshToken as refreshTokens,
   revokeRefreshToken,
-} from './auth.service.js';
-import {
-  challengeSchema,
-  verifySchema,
-  refreshSchema,
-} from './auth.schema.js';
-import type { AuthPayload } from './auth.types.js';
+} from "./auth.service.js";
+import { challengeSchema, verifySchema, refreshSchema } from "./auth.schema.js";
+import type { AuthPayload } from "./auth.types.js";
 
 /**
  * POST /auth/challenge
  * Creates an authentication challenge for a Stellar wallet address.
  */
-export async function challengeController(req: Request, res: Response, next: NextFunction) {
+export async function challengeController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
-    const { stellarAddress } = challengeSchema.parse(req.body);
-    const response = await createChallenge(stellarAddress);
+    const { stellarAddress, network } = challengeSchema.parse(req.body);
+    const response = await createChallenge(stellarAddress, network);
     res.json(response);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      next(new BadRequestError('Invalid request body', error.errors));
+      next(new BadRequestError("Invalid request body", error.issues));
     } else {
       next(error);
     }
@@ -37,14 +37,24 @@ export async function challengeController(req: Request, res: Response, next: Nex
  * POST /auth/verify
  * Verifies a signed challenge and returns JWT tokens.
  */
-export async function verifyController(req: Request, res: Response, next: NextFunction) {
+export async function verifyController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
-    const { stellarAddress, signature, challenge } = verifySchema.parse(req.body);
-    const tokens = await verifyChallenge(stellarAddress, signature, challenge);
+    const { stellarAddress, signature, challenge, network } =
+      verifySchema.parse(req.body);
+    const tokens = await verifyChallenge(
+      stellarAddress,
+      signature,
+      challenge,
+      network,
+    );
     res.json(tokens);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      next(new BadRequestError('Invalid request body', error.errors));
+      next(new BadRequestError("Invalid request body", error.issues));
     } else {
       next(error);
     }
@@ -55,7 +65,11 @@ export async function verifyController(req: Request, res: Response, next: NextFu
  * GET /auth/me
  * Returns the current authenticated user's information.
  */
-export async function meController(req: Request, res: Response, next: NextFunction) {
+export async function meController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
     const auth = req.auth as AuthPayload;
     const user = await prisma.user.findUnique({
@@ -64,18 +78,22 @@ export async function meController(req: Request, res: Response, next: NextFuncti
         id: true,
         stellarAddress: true,
         username: true,
+        role: true,
+        scopes: true,
         createdAt: true,
       },
     });
 
     if (!user) {
-      throw new BadRequestError('User not found');
+      throw new BadRequestError("User not found");
     }
 
     res.json({
       id: user.id,
       stellarAddress: user.stellarAddress,
       username: user.username,
+      role: user.role,
+      scopes: user.scopes,
       createdAt: user.createdAt.toISOString(),
     });
   } catch (error) {
@@ -87,14 +105,18 @@ export async function meController(req: Request, res: Response, next: NextFuncti
  * POST /auth/refresh
  * Refreshes an access token using a refresh token.
  */
-export async function refreshController(req: Request, res: Response, next: NextFunction) {
+export async function refreshController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
     const { refreshToken } = refreshSchema.parse(req.body);
     const tokens = await refreshTokens(refreshToken);
     res.json(tokens);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      next(new BadRequestError('Invalid request body', error.errors));
+      next(new BadRequestError("Invalid request body", error.issues));
     } else {
       next(error);
     }
@@ -105,14 +127,18 @@ export async function refreshController(req: Request, res: Response, next: NextF
  * POST /auth/logout
  * Revokes the current refresh token.
  */
-export async function logoutController(req: Request, res: Response, next: NextFunction) {
+export async function logoutController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
     const { refreshToken } = refreshSchema.parse(req.body);
     await revokeRefreshToken(refreshToken);
-    res.json({ message: 'Logged out successfully' });
+    res.json({ message: "Logged out successfully" });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      next(new BadRequestError('Invalid request body', error.errors));
+      next(new BadRequestError("Invalid request body", error.issues));
     } else {
       next(error);
     }

--- a/backend/src/modules/auth/auth.middleware.ts
+++ b/backend/src/modules/auth/auth.middleware.ts
@@ -1,9 +1,13 @@
-import { Request, Response, NextFunction } from 'express';
-import { verifyAccessToken } from './auth.service.js';
-import { UnauthorizedError } from '../../common/errors/AppError.js';
-import type { AuthPayload } from './auth.types.js';
+import { Request, Response, NextFunction } from "express";
+import { verifyAccessToken } from "./auth.service.js";
+import {
+  UnauthorizedError,
+  ForbiddenError,
+} from "../../common/errors/AppError.js";
+import type { AuthPayload } from "./auth.types.js";
+import { z } from "zod";
 
-declare module 'express' {
+declare module "express" {
   interface Request {
     auth?: AuthPayload;
   }
@@ -13,11 +17,15 @@ declare module 'express' {
  * Middleware to verify JWT access token and attach auth payload to request.
  * Extracts token from Authorization header: "Bearer <token>"
  */
-export function authMiddleware(req: Request, _res: Response, next: NextFunction) {
+export function authMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) {
   const authHeader = req.headers.authorization;
 
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    throw new UnauthorizedError('Missing or invalid authorization header');
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    throw new UnauthorizedError("Missing or invalid authorization header");
   }
 
   const token = authHeader.substring(7); // Remove "Bearer " prefix
@@ -29,4 +37,112 @@ export function authMiddleware(req: Request, _res: Response, next: NextFunction)
   } catch (error) {
     next(error);
   }
+}
+
+/**
+ * Middleware to require authentication.
+ * Alias for authMiddleware for clarity.
+ */
+export const requireAuth = authMiddleware;
+
+/**
+ * Schema for role validation.
+ */
+const roleSchema = z.string().min(1);
+
+/**
+ * Middleware factory to require a specific role.
+ * Returns 403 Forbidden if the user doesn't have the required role.
+ *
+ * @param role - The required role (e.g., 'admin', 'moderator')
+ * @returns Express middleware function
+ */
+export function requireRole(role: string) {
+  // Validate role input with Zod
+  const validationResult = roleSchema.safeParse(role);
+  if (!validationResult.success) {
+    throw new Error("Invalid role parameter");
+  }
+
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const auth = req.auth;
+
+    if (!auth) {
+      throw new UnauthorizedError("Authentication required");
+    }
+
+    if (auth.role !== role) {
+      throw new ForbiddenError(`Requires role: ${role}`);
+    }
+
+    next();
+  };
+}
+
+/**
+ * Schema for scope validation.
+ */
+const scopeSchema = z.string().min(1);
+
+/**
+ * Middleware factory to require a specific scope.
+ * Returns 403 Forbidden if the user doesn't have the required scope.
+ *
+ * @param scope - The required scope (e.g., 'read:tips', 'write:profile')
+ * @returns Express middleware function
+ */
+export function requireScope(scope: string) {
+  // Validate scope input with Zod
+  const validationResult = scopeSchema.safeParse(scope);
+  if (!validationResult.success) {
+    throw new Error("Invalid scope parameter");
+  }
+
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const auth = req.auth;
+
+    if (!auth) {
+      throw new UnauthorizedError("Authentication required");
+    }
+
+    if (!auth.scopes || !auth.scopes.includes(scope)) {
+      throw new ForbiddenError(`Requires scope: ${scope}`);
+    }
+
+    next();
+  };
+}
+
+/**
+ * Middleware factory to require any of the specified scopes.
+ * Returns 403 Forbidden if the user doesn't have at least one of the required scopes.
+ *
+ * @param scopes - Array of acceptable scopes
+ * @returns Express middleware function
+ */
+export function requireAnyScope(...scopes: string[]) {
+  // Validate scopes input with Zod
+  const scopesArraySchema = z.array(scopeSchema).min(1);
+  const validationResult = scopesArraySchema.safeParse(scopes);
+  if (!validationResult.success) {
+    throw new Error("Invalid scopes parameter");
+  }
+
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const auth = req.auth;
+
+    if (!auth) {
+      throw new UnauthorizedError("Authentication required");
+    }
+
+    const hasRequiredScope = scopes.some(
+      (scope) => auth.scopes && auth.scopes.includes(scope),
+    );
+
+    if (!hasRequiredScope) {
+      throw new ForbiddenError(`Requires one of: ${scopes.join(", ")}`);
+    }
+
+    next();
+  };
 }

--- a/backend/src/modules/auth/auth.schema.ts
+++ b/backend/src/modules/auth/auth.schema.ts
@@ -1,21 +1,23 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 /**
  * Zod validation schemas for auth endpoints.
  */
 
 export const challengeSchema = z.object({
-  stellarAddress: z.string().min(1, 'Stellar address is required'),
+  stellarAddress: z.string().min(1, "Stellar address is required"),
+  network: z.enum(["TESTNET", "FUTURENET", "MAINNET"]).optional(),
 });
 
 export const verifySchema = z.object({
-  stellarAddress: z.string().min(1, 'Stellar address is required'),
-  signature: z.string().min(1, 'Signature is required'),
-  challenge: z.string().min(1, 'Challenge is required'),
+  stellarAddress: z.string().min(1, "Stellar address is required"),
+  signature: z.string().min(1, "Signature is required"),
+  challenge: z.string().min(1, "Challenge is required"),
+  network: z.enum(["TESTNET", "FUTURENET", "MAINNET"]).optional(),
 });
 
 export const refreshSchema = z.object({
-  refreshToken: z.string().min(1, 'Refresh token is required'),
+  refreshToken: z.string().min(1, "Refresh token is required"),
 });
 
 export type ChallengeInput = z.infer<typeof challengeSchema>;

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,16 +1,25 @@
-import jwt from 'jsonwebtoken';
-import { randomBytes } from 'crypto';
-import { prisma } from '../../db/prisma.js';
-import { env } from '../../config/env.js';
-import { logger } from '../../common/utils/logger.js';
-import { BadRequestError, UnauthorizedError, ConflictError } from '../../common/errors/AppError.js';
-import type { AuthPayload, TokenPair, ChallengeResponse } from './auth.types.js';
+import jwt from "jsonwebtoken";
+import { randomBytes } from "crypto";
+import { prisma } from "../../db/prisma.js";
+import { env } from "../../config/env.js";
+import { logger } from "../../common/utils/logger.js";
+import {
+  BadRequestError,
+  UnauthorizedError,
+  ConflictError,
+} from "../../common/errors/AppError.js";
+import type {
+  AuthPayload,
+  TokenPair,
+  ChallengeResponse,
+} from "./auth.types.js";
+import { verifyEd25519Signature } from "./signature.js";
 
 /**
  * Generates a random challenge string for wallet signature verification.
  */
 function generateChallenge(): string {
-  return randomBytes(32).toString('hex');
+  return randomBytes(32).toString("hex");
 }
 
 /**
@@ -26,8 +35,10 @@ function generateAccessToken(payload: AuthPayload): string {
  * Creates a refresh token and stores it in the database.
  */
 async function generateRefreshToken(userId: string): Promise<string> {
-  const token = randomBytes(32).toString('hex');
-  const expiresAt = new Date(Date.now() + parseDuration(env.REFRESH_TOKEN_EXPIRES_IN));
+  const token = randomBytes(32).toString("hex");
+  const expiresAt = new Date(
+    Date.now() + parseDuration(env.REFRESH_TOKEN_EXPIRES_IN),
+  );
 
   await prisma.refreshToken.create({
     data: {
@@ -64,9 +75,14 @@ function parseDuration(duration: string): number {
 
 /**
  * Creates an authentication challenge for a Stellar wallet address.
- * The challenge must be signed by the wallet and verified within the TTL.
+ * The challenge is bound to the address and network to prevent cross-address/network replay attacks.
  */
-export async function createChallenge(stellarAddress: string): Promise<ChallengeResponse> {
+export async function createChallenge(
+  stellarAddress: string,
+  network?: string,
+): Promise<ChallengeResponse> {
+  const boundNetwork = network || env.STELLAR_NETWORK;
+
   // Clean up expired challenges for this address
   await prisma.authChallenge.deleteMany({
     where: {
@@ -75,78 +91,103 @@ export async function createChallenge(stellarAddress: string): Promise<Challenge
     },
   });
 
-  // Check for existing unused challenge
+  // Check for existing unused challenge for this address and network
   const existingChallenge = await prisma.authChallenge.findFirst({
     where: {
       stellarAddress,
+      network: boundNetwork,
       usedAt: null,
       expiresAt: { gt: new Date() },
     },
   });
 
   if (existingChallenge) {
-    logger.info({ stellarAddress }, 'Returning existing challenge');
+    logger.info(
+      { stellarAddress, network: boundNetwork },
+      "Returning existing challenge",
+    );
     return {
       challenge: existingChallenge.challenge,
       expiresAt: existingChallenge.expiresAt.toISOString(),
+      network: existingChallenge.network,
     };
   }
 
   // Create new challenge
   const challenge = generateChallenge();
-  const expiresAt = new Date(Date.now() + env.AUTH_CHALLENGE_TTL_SECONDS * 1000);
+  const expiresAt = new Date(
+    Date.now() + env.AUTH_CHALLENGE_TTL_SECONDS * 1000,
+  );
 
   await prisma.authChallenge.create({
     data: {
       stellarAddress,
       challenge,
+      network: boundNetwork,
       expiresAt,
     },
   });
 
-  logger.info({ stellarAddress }, 'Created new auth challenge');
+  logger.info(
+    { stellarAddress, network: boundNetwork },
+    "Created new auth challenge",
+  );
 
   return {
     challenge,
     expiresAt: expiresAt.toISOString(),
+    network: boundNetwork,
   };
 }
 
 /**
  * Verifies a signed challenge and returns JWT tokens.
- * This is a simplified verification - in production, you would verify the
- * actual Stellar signature against the challenge.
+ * Uses ed25519 signature verification to prove wallet ownership.
  */
 export async function verifyChallenge(
   stellarAddress: string,
   signature: string,
   challenge: string,
+  network?: string,
 ): Promise<TokenPair> {
+  const expectedNetwork = network || env.STELLAR_NETWORK;
+
   // Find the challenge
   const authChallenge = await prisma.authChallenge.findUnique({
     where: { challenge },
   });
 
   if (!authChallenge) {
-    throw new BadRequestError('Invalid challenge');
+    throw new BadRequestError("Invalid challenge");
   }
 
+  // Validate that the challenge belongs to the requesting address
   if (authChallenge.stellarAddress !== stellarAddress) {
-    throw new BadRequestError('Challenge address mismatch');
+    throw new BadRequestError("Challenge address mismatch");
+  }
+
+  // Validate that the challenge is for the correct network
+  if (authChallenge.network !== expectedNetwork) {
+    throw new BadRequestError("Challenge network mismatch");
   }
 
   if (authChallenge.usedAt) {
-    throw new ConflictError('Challenge already used');
+    throw new ConflictError("Challenge already used");
   }
 
   if (authChallenge.expiresAt < new Date()) {
-    throw new BadRequestError('Challenge expired');
+    throw new BadRequestError("Challenge expired");
   }
 
-  // In production, verify the signature here using Stellar SDK
-  // For now, we accept any non-empty signature as valid
-  if (!signature || signature.length === 0) {
-    throw new BadRequestError('Invalid signature');
+  // Verify the ed25519 signature
+  const isValidSignature = verifyEd25519Signature(
+    stellarAddress,
+    challenge,
+    signature,
+  );
+
+  if (!isValidSignature) {
+    throw new UnauthorizedError("Invalid signature");
   }
 
   // Mark challenge as used
@@ -164,19 +205,24 @@ export async function verifyChallenge(
     user = await prisma.user.create({
       data: { stellarAddress },
     });
-    logger.info({ stellarAddress, userId: user.id }, 'Created new user');
+    logger.info({ stellarAddress, userId: user.id }, "Created new user");
   }
 
   // Generate tokens
   const payload: AuthPayload = {
     userId: user.id,
     stellarAddress: user.stellarAddress,
+    role: user.role,
+    scopes: user.scopes,
   };
 
   const accessToken = generateAccessToken(payload);
   const refreshToken = await generateRefreshToken(user.id);
 
-  logger.info({ stellarAddress, userId: user.id }, 'User authenticated successfully');
+  logger.info(
+    { stellarAddress, userId: user.id },
+    "User authenticated successfully",
+  );
 
   return {
     accessToken,
@@ -195,15 +241,15 @@ export async function refreshToken(refreshToken: string): Promise<TokenPair> {
   });
 
   if (!tokenRecord) {
-    throw new UnauthorizedError('Invalid refresh token');
+    throw new UnauthorizedError("Invalid refresh token");
   }
 
   if (tokenRecord.revokedAt) {
-    throw new UnauthorizedError('Refresh token revoked');
+    throw new UnauthorizedError("Refresh token revoked");
   }
 
   if (tokenRecord.expiresAt < new Date()) {
-    throw new UnauthorizedError('Refresh token expired');
+    throw new UnauthorizedError("Refresh token expired");
   }
 
   // Revoke old token
@@ -212,16 +258,18 @@ export async function refreshToken(refreshToken: string): Promise<TokenPair> {
     data: { revokedAt: new Date() },
   });
 
-  // Generate new tokens
+  // Generate new tokens with updated user info
   const payload: AuthPayload = {
     userId: tokenRecord.userId,
     stellarAddress: tokenRecord.user.stellarAddress,
+    role: tokenRecord.user.role,
+    scopes: tokenRecord.user.scopes,
   };
 
   const accessToken = generateAccessToken(payload);
   const newRefreshToken = await generateRefreshToken(tokenRecord.userId);
 
-  logger.info({ userId: tokenRecord.userId }, 'Token refreshed successfully');
+  logger.info({ userId: tokenRecord.userId }, "Token refreshed successfully");
 
   return {
     accessToken,
@@ -238,7 +286,7 @@ export async function revokeRefreshToken(refreshToken: string): Promise<void> {
   });
 
   if (!tokenRecord) {
-    throw new UnauthorizedError('Invalid refresh token');
+    throw new UnauthorizedError("Invalid refresh token");
   }
 
   if (tokenRecord.revokedAt) {
@@ -251,7 +299,7 @@ export async function revokeRefreshToken(refreshToken: string): Promise<void> {
     data: { revokedAt: new Date() },
   });
 
-  logger.info({ userId: tokenRecord.userId }, 'Refresh token revoked');
+  logger.info({ userId: tokenRecord.userId }, "Refresh token revoked");
 }
 
 /**
@@ -261,6 +309,6 @@ export function verifyAccessToken(token: string): AuthPayload {
   try {
     return jwt.verify(token, env.JWT_SECRET) as AuthPayload;
   } catch {
-    throw new UnauthorizedError('Invalid or expired access token');
+    throw new UnauthorizedError("Invalid or expired access token");
   }
 }

--- a/backend/src/modules/auth/auth.types.ts
+++ b/backend/src/modules/auth/auth.types.ts
@@ -5,6 +5,8 @@
 export interface AuthPayload {
   userId: string;
   stellarAddress: string;
+  role: string;
+  scopes: string[];
 }
 
 export interface TokenPair {
@@ -15,12 +17,14 @@ export interface TokenPair {
 export interface ChallengeResponse {
   challenge: string;
   expiresAt: string;
+  network: string;
 }
 
 export interface VerifyRequest {
   stellarAddress: string;
   signature: string;
   challenge: string;
+  network?: string;
 }
 
 export interface RefreshRequest {
@@ -31,5 +35,7 @@ export interface MeResponse {
   id: string;
   stellarAddress: string;
   username: string | null;
+  role: string;
+  scopes: string[];
   createdAt: string;
 }

--- a/backend/src/modules/auth/signature.ts
+++ b/backend/src/modules/auth/signature.ts
@@ -1,0 +1,80 @@
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import { BadRequestError } from "../../common/errors/AppError.js";
+import { z } from "zod";
+
+/**
+ * Schema for signature verification inputs.
+ */
+export const signatureVerificationSchema = z.object({
+  publicKey: z.string().min(1, "Public key is required"),
+  message: z.string().min(1, "Message is required"),
+  signature: z.string().min(1, "Signature is required"),
+});
+
+export type SignatureVerificationInput = z.infer<
+  typeof signatureVerificationSchema
+>;
+
+/**
+ * Verifies an ed25519 signature against a message and Stellar public key.
+ *
+ * @param publicKey - Stellar public key (G... address)
+ * @param message - The message that was signed (typically a challenge string)
+ * @param signature - The signature in hex format
+ * @returns true if the signature is valid
+ * @throws BadRequestError if inputs are invalid or signature verification fails
+ */
+export function verifyEd25519Signature(
+  publicKey: string,
+  message: string,
+  signature: string,
+): boolean {
+  // Validate inputs with Zod
+  const validation = signatureVerificationSchema.safeParse({
+    publicKey,
+    message,
+    signature,
+  });
+
+  if (!validation.success) {
+    throw new BadRequestError(
+      "Invalid signature verification inputs",
+      validation.error.issues,
+    );
+  }
+
+  // Validate Stellar address format
+  if (!StrKey.isValidEd25519PublicKey(publicKey)) {
+    throw new BadRequestError("Invalid Stellar public key format");
+  }
+
+  try {
+    // Decode the Stellar address to get raw public key bytes
+    const rawPublicKey = StrKey.decodeEd25519PublicKey(publicKey);
+
+    // Convert signature from hex to Buffer
+    const signatureBuffer = Buffer.from(signature, "hex");
+
+    if (signatureBuffer.length !== 64) {
+      throw new BadRequestError("Invalid signature length (expected 64 bytes)");
+    }
+
+    // Convert message to Buffer
+    const messageBuffer = Buffer.from(message, "utf-8");
+
+    // Create a keypair from the public key for verification
+    const keypair = Keypair.fromPublicKey(
+      Buffer.from(rawPublicKey).toString("base64"),
+    );
+
+    // Verify the signature
+    return keypair.verify(messageBuffer, signatureBuffer);
+  } catch (error) {
+    if (error instanceof BadRequestError) {
+      throw error;
+    }
+    throw new BadRequestError(
+      `Signature verification failed: ${(error as Error).message}`,
+    );
+  }
+}

--- a/backend/src/modules/profiles/profiles.controller.ts
+++ b/backend/src/modules/profiles/profiles.controller.ts
@@ -1,0 +1,128 @@
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { BadRequestError } from "../../common/errors/AppError.js";
+import {
+  getProfileById,
+  getProfileByUsername,
+  getProfileByAddress,
+  updateProfile,
+  listProfiles,
+} from "./profiles.service.js";
+import {
+  updateProfileSchema,
+  profileIdSchema,
+  usernameSchema,
+} from "./profiles.schema.js";
+import type { AuthPayload } from "../auth/auth.types.js";
+
+/**
+ * GET /profiles
+ * Lists all profiles with pagination.
+ */
+export async function listProfilesController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 20;
+
+    if (page < 1 || limit < 1 || limit > 100) {
+      throw new BadRequestError("Invalid pagination parameters");
+    }
+
+    const result = await listProfiles(page, limit);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * GET /profiles/:id
+ * Gets a profile by user ID.
+ */
+export async function getProfileController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const { id } = profileIdSchema.parse(req.params);
+    const profile = await getProfileById(id);
+    res.json(profile);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError("Invalid profile ID", error.issues));
+    } else {
+      next(error);
+    }
+  }
+}
+
+/**
+ * GET /profiles/username/:username
+ * Gets a profile by username.
+ */
+export async function getProfileByUsernameController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const { username } = usernameSchema.parse(req.params);
+    const profile = await getProfileByUsername(username);
+    res.json(profile);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError("Invalid username", error.issues));
+    } else {
+      next(error);
+    }
+  }
+}
+
+/**
+ * GET /profiles/address/:address
+ * Gets a profile by Stellar address.
+ */
+export async function getProfileByAddressController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const address = req.params.address;
+    if (!address) {
+      throw new BadRequestError("Stellar address is required");
+    }
+    const profile = await getProfileByAddress(address);
+    res.json(profile);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * PATCH /profiles/me
+ * Updates the authenticated user's profile.
+ */
+export async function updateProfileController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const auth = req.auth as AuthPayload;
+    const data = updateProfileSchema.parse(req.body);
+    const profile = await updateProfile(auth.userId, data);
+    res.json(profile);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError("Invalid profile data", error.issues));
+    } else {
+      next(error);
+    }
+  }
+}

--- a/backend/src/modules/profiles/profiles.routes.ts
+++ b/backend/src/modules/profiles/profiles.routes.ts
@@ -1,0 +1,28 @@
+import { Router } from "express";
+import { requireAuth } from "../auth/auth.middleware.js";
+import {
+  listProfilesController,
+  getProfileController,
+  getProfileByUsernameController,
+  getProfileByAddressController,
+  updateProfileController,
+} from "./profiles.controller.js";
+
+/**
+ * Profiles module router.
+ * Mounted at /api/v1/profiles in app.ts
+ */
+export const profilesRouter = Router();
+
+/**
+ * Public routes
+ */
+profilesRouter.get("/", listProfilesController);
+profilesRouter.get("/:id", getProfileController);
+profilesRouter.get("/username/:username", getProfileByUsernameController);
+profilesRouter.get("/address/:address", getProfileByAddressController);
+
+/**
+ * Protected routes - require authentication
+ */
+profilesRouter.patch("/me", requireAuth, updateProfileController);

--- a/backend/src/modules/profiles/profiles.schema.ts
+++ b/backend/src/modules/profiles/profiles.schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+/**
+ * Zod validation schemas for profiles endpoints.
+ */
+
+export const updateProfileSchema = z.object({
+  username: z
+    .string()
+    .min(3)
+    .max(30)
+    .regex(/^[a-zA-Z0-9_-]+$/)
+    .optional(),
+  displayName: z.string().min(1).max(100).optional(),
+  bio: z.string().max(500).optional(),
+  imageUrl: z.string().url().optional(),
+  avatarCid: z.string().optional(),
+  xHandle: z
+    .string()
+    .min(1)
+    .max(15)
+    .regex(/^[a-zA-Z0-9_]+$/)
+    .optional(),
+});
+
+export const profileIdSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const usernameSchema = z.object({
+  username: z.string().min(1),
+});
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+export type ProfileIdInput = z.infer<typeof profileIdSchema>;
+export type UsernameInput = z.infer<typeof usernameSchema>;

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -1,0 +1,204 @@
+import { prisma } from "../../db/prisma.js";
+import { logger } from "../../common/utils/logger.js";
+import {
+  BadRequestError,
+  NotFoundError,
+  ConflictError,
+} from "../../common/errors/AppError.js";
+import type {
+  ProfileResponse,
+  UpdateProfileRequest,
+} from "./profiles.types.js";
+
+/**
+ * Gets a profile by user ID.
+ */
+export async function getProfileById(userId: string): Promise<ProfileResponse> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      stellarAddress: true,
+      username: true,
+      displayName: true,
+      bio: true,
+      imageUrl: true,
+      avatarCid: true,
+      xHandle: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!user) {
+    throw new NotFoundError("Profile not found");
+  }
+
+  return {
+    ...user,
+    createdAt: user.createdAt.toISOString(),
+    updatedAt: user.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Gets a profile by username.
+ */
+export async function getProfileByUsername(
+  username: string,
+): Promise<ProfileResponse> {
+  const user = await prisma.user.findUnique({
+    where: { username },
+    select: {
+      id: true,
+      stellarAddress: true,
+      username: true,
+      displayName: true,
+      bio: true,
+      imageUrl: true,
+      avatarCid: true,
+      xHandle: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!user) {
+    throw new NotFoundError("Profile not found");
+  }
+
+  return {
+    ...user,
+    createdAt: user.createdAt.toISOString(),
+    updatedAt: user.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Gets a profile by Stellar address.
+ */
+export async function getProfileByAddress(
+  stellarAddress: string,
+): Promise<ProfileResponse> {
+  const user = await prisma.user.findUnique({
+    where: { stellarAddress },
+    select: {
+      id: true,
+      stellarAddress: true,
+      username: true,
+      displayName: true,
+      bio: true,
+      imageUrl: true,
+      avatarCid: true,
+      xHandle: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!user) {
+    throw new NotFoundError("Profile not found");
+  }
+
+  return {
+    ...user,
+    createdAt: user.createdAt.toISOString(),
+    updatedAt: user.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Updates the authenticated user's profile.
+ */
+export async function updateProfile(
+  userId: string,
+  data: UpdateProfileRequest,
+): Promise<ProfileResponse> {
+  // Check if username is already taken
+  if (data.username) {
+    const existingUser = await prisma.user.findUnique({
+      where: { username: data.username },
+    });
+
+    if (existingUser && existingUser.id !== userId) {
+      throw new ConflictError("Username already taken");
+    }
+  }
+
+  try {
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data,
+      select: {
+        id: true,
+        stellarAddress: true,
+        username: true,
+        displayName: true,
+        bio: true,
+        imageUrl: true,
+        avatarCid: true,
+        xHandle: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    logger.info({ userId }, "Profile updated successfully");
+
+    return {
+      ...updatedUser,
+      createdAt: updatedUser.createdAt.toISOString(),
+      updatedAt: updatedUser.updatedAt.toISOString(),
+    };
+  } catch (error) {
+    logger.error({ userId, error }, "Failed to update profile");
+    throw new BadRequestError("Failed to update profile");
+  }
+}
+
+/**
+ * Lists all profiles with pagination.
+ */
+export async function listProfiles(
+  page = 1,
+  limit = 20,
+): Promise<{
+  profiles: ProfileResponse[];
+  total: number;
+  page: number;
+  limit: number;
+}> {
+  const skip = (page - 1) * limit;
+
+  const [users, total] = await Promise.all([
+    prisma.user.findMany({
+      skip,
+      take: limit,
+      select: {
+        id: true,
+        stellarAddress: true,
+        username: true,
+        displayName: true,
+        bio: true,
+        imageUrl: true,
+        avatarCid: true,
+        xHandle: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.user.count(),
+  ]);
+
+  return {
+    profiles: users.map((user) => ({
+      ...user,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+    })),
+    total,
+    page,
+    limit,
+  };
+}

--- a/backend/src/modules/profiles/profiles.types.ts
+++ b/backend/src/modules/profiles/profiles.types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared types for the profiles module.
+ */
+
+export interface Profile {
+  id: string;
+  stellarAddress: string;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  imageUrl: string | null;
+  avatarCid: string | null;
+  xHandle: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ProfileResponse {
+  id: string;
+  stellarAddress: string;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  imageUrl: string | null;
+  avatarCid: string | null;
+  xHandle: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateProfileRequest {
+  username?: string;
+  displayName?: string;
+  bio?: string;
+  imageUrl?: string;
+  avatarCid?: string;
+  xHandle?: string;
+}


### PR DESCRIPTION



## Summary

This PR implements four critical auth and profiles features for the Stellar Tipz backend:

1. Ed25519 signature verification for wallet authentication
2. Role and scope-based authorization middleware
3. Complete profiles module with CRUD operations
4. Challenge binding to address and network for replay attack prevention

All implementations follow module conventions, use Zod validation, proper error handling with AppError classes, and pass typecheck and lint.

## Changes

### Issue: Ed25519 Signature Verification

- Created `backend/src/modules/auth/signature.ts` with `verifyEd25519Signature` function
- Validates Stellar public keys using `@stellar/stellar-sdk`
- Verifies ed25519 signatures against signed messages
- Full Zod validation for inputs (publicKey, message, signature)
- Proper error handling using BadRequestError
- Validates signature length (64 bytes)

### Issue: Role/Scope Authorization Middleware

- Implemented `requireRole(role: string)` middleware in `auth.middleware.ts`
- Implemented `requireScope(scope: string)` middleware
- Added `requireAnyScope(...scopes: string[])` for flexible scope checking
- Returns 403 Forbidden when authorization fails
- Zod validation for role and scope parameters
- Proper error handling with UnauthorizedError and ForbiddenError

### Issue: Profiles Module Skeleton

- Created complete profiles module structure:
  - `profiles.routes.ts` - Router with public and protected endpoints
  - `profiles.controller.ts` - Request/response handlers
  - `profiles.service.ts` - Business logic with Prisma queries
  - `profiles.schema.ts` - Zod validation schemas
  - `profiles.types.ts` - TypeScript interfaces
- Mounted profiles router in `app.ts` at `/api/v1/profiles`
- Endpoints: GET /, GET /:id, GET /username/:username, GET /address/:address, PATCH /me
- Protected routes use `requireAuth` middleware
- Full input validation with Zod
- Pagination support for list endpoint

### Issue: Challenge Binding to Address + Network

- Modified `createChallenge` in `auth.service.ts` to bind challenge to both address and network
- Modified `verifyChallenge` to validate address and network match
- Prevents cross-address and cross-network replay attacks
- Challenge validation includes:
  - Address match check
  - Network match check (TESTNET, FUTURENET, MAINNET)
  - Expiration check
  - Single-use enforcement

### Additional Fixes

- Fixed ZodError property references: changed `.errors` to `.issues` throughout auth and profiles controllers
- Fixed Keypair.fromPublicKey type error in signature verification
- All error handling uses AppError subclasses (BadRequestError, UnauthorizedError, ForbiddenError, NotFoundError, ConflictError)

## Testing

- `npm run typecheck` passes
- `npm run lint` passes
- All inputs validated with Zod schemas
- Error handling follows AppError patterns

## Module Conventions Followed

- Separate concerns: routes, controllers, services, schemas, types
- Zod validation in schemas
- Business logic in services (no Express dependencies)
- AppError subclasses for all errors
- Doc comments on public functions
- Proper TypeScript types


Closes #850
Closes #840
Closes #852
Closes #843
