### PR TITLE
feat(db): add RefreshToken, Goal, Subscription and WebhookDelivery

### DIFF
--- a/backend/prisma/migrations/20260625120000_add_refresh_token/migration.sql
+++ b/backend/prisma/migrations/20260625120000_add_refresh_token/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "hashedToken" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_hashedToken_key" ON "RefreshToken"("hashedToken");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_userId_idx" ON "RefreshToken"("userId");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260625120100_add_goal/migration.sql
+++ b/backend/prisma/migrations/20260625120100_add_goal/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "GoalStatus" AS ENUM ('ACTIVE', 'COMPLETED', 'CANCELLED', 'EXPIRED');
+
+-- CreateTable
+CREATE TABLE "Goal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "targetStroops" BIGINT NOT NULL,
+    "raisedStroops" BIGINT NOT NULL DEFAULT 0,
+    "deadline" TIMESTAMP(3),
+    "status" "GoalStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Goal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Goal_userId_idx" ON "Goal"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Goal" ADD CONSTRAINT "Goal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260625120200_add_subscription/migration.sql
+++ b/backend/prisma/migrations/20260625120200_add_subscription/migration.sql
@@ -1,0 +1,35 @@
+-- CreateEnum
+CREATE TYPE "SubscriptionInterval" AS ENUM ('DAILY', 'WEEKLY', 'MONTHLY');
+
+-- CreateEnum
+CREATE TYPE "SubscriptionStatus" AS ENUM ('ACTIVE', 'PAUSED', 'CANCELLED', 'EXPIRED');
+
+-- CreateTable
+CREATE TABLE "Subscription" (
+    "id" TEXT NOT NULL,
+    "tipperId" TEXT NOT NULL,
+    "creatorId" TEXT NOT NULL,
+    "amountStroops" BIGINT NOT NULL,
+    "interval" "SubscriptionInterval" NOT NULL,
+    "nextChargeAt" TIMESTAMP(3) NOT NULL,
+    "status" "SubscriptionStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Subscription_tipperId_idx" ON "Subscription"("tipperId");
+
+-- CreateIndex
+CREATE INDEX "Subscription_creatorId_idx" ON "Subscription"("creatorId");
+
+-- CreateIndex
+CREATE INDEX "Subscription_nextChargeAt_idx" ON "Subscription"("nextChargeAt");
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_tipperId_fkey" FOREIGN KEY ("tipperId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260625120300_add_webhook_delivery/migration.sql
+++ b/backend/prisma/migrations/20260625120300_add_webhook_delivery/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "WebhookDeliveryStatus" AS ENUM ('PENDING', 'SUCCESS', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "subscriptionId" TEXT NOT NULL,
+    "status" "WebhookDeliveryStatus" NOT NULL DEFAULT 'PENDING',
+    "responseCode" INTEGER,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "nextAttemptAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_subscriptionId_idx" ON "WebhookDelivery"("subscriptionId");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_status_nextAttemptAt_idx" ON "WebhookDelivery"("status", "nextAttemptAt");
+
+-- AddForeignKey
+ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_subscriptionId_fkey" FOREIGN KEY ("subscriptionId") REFERENCES "Subscription"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,6 +21,11 @@ model User {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
   apiKeys        ApiKey[]
+  refreshTokens  RefreshToken[]
+  goals          Goal[]
+
+  tipperSubscriptions  Subscription[] @relation("SubscriptionTipper")
+  creatorSubscriptions Subscription[] @relation("SubscriptionCreator")
 }
 
 /// API key for service/admin access and webhook integrations.
@@ -136,4 +141,102 @@ model AuthChallenge {
 
   @@index([address])
   @@index([expiresAt])
+}
+
+/// Refresh token issued on login, stored hashed for rotation/revocation.
+/// The raw token value is never persisted — only its hash is stored here.
+model RefreshToken {
+  id          String    @id @default(cuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  hashedToken String    @unique
+  expiresAt   DateTime
+  revokedAt   DateTime?
+  createdAt   DateTime  @default(now())
+
+  @@index([userId])
+}
+
+/// Lifecycle status of a creator funding goal.
+enum GoalStatus {
+  ACTIVE
+  COMPLETED
+  CANCELLED
+  EXPIRED
+}
+
+/// Creator-defined funding goal tracked against incoming tips.
+model Goal {
+  id            String     @id @default(cuid())
+  userId        String
+  user          User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title         String
+  targetStroops BigInt
+  raisedStroops BigInt     @default(0)
+  deadline      DateTime?
+  status        GoalStatus @default(ACTIVE)
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
+
+  @@index([userId])
+}
+
+/// Billing cadence for a recurring tip subscription.
+enum SubscriptionInterval {
+  DAILY
+  WEEKLY
+  MONTHLY
+}
+
+/// Lifecycle status of a recurring tip subscription.
+enum SubscriptionStatus {
+  ACTIVE
+  PAUSED
+  CANCELLED
+  EXPIRED
+}
+
+/// Recurring tip agreement between a tipper and a creator.
+model Subscription {
+  id            String               @id @default(cuid())
+  tipperId      String
+  tipper        User                 @relation("SubscriptionTipper", fields: [tipperId], references: [id], onDelete: Cascade)
+  creatorId     String
+  creator       User                 @relation("SubscriptionCreator", fields: [creatorId], references: [id], onDelete: Cascade)
+  amountStroops BigInt
+  interval      SubscriptionInterval
+  nextChargeAt  DateTime
+  status        SubscriptionStatus   @default(ACTIVE)
+  createdAt     DateTime             @default(now())
+  updatedAt     DateTime             @updatedAt
+
+  webhookDeliveries WebhookDelivery[]
+
+  @@index([tipperId])
+  @@index([creatorId])
+  @@index([nextChargeAt])
+}
+
+/// Delivery state of a single webhook notification attempt.
+enum WebhookDeliveryStatus {
+  PENDING
+  SUCCESS
+  FAILED
+}
+
+/// A single delivery attempt of a subscription billing event to a webhook
+/// consumer (e.g. notifying an integrator that a charge succeeded or failed).
+model WebhookDelivery {
+  id             String                @id @default(cuid())
+  subscriptionId String
+  subscription   Subscription          @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
+  status         WebhookDeliveryStatus @default(PENDING)
+  responseCode   Int?
+  attempts       Int                   @default(0)
+  nextAttemptAt  DateTime?
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
+
+  @@index([subscriptionId])
+  @@index([status, nextAttemptAt])
 }


### PR DESCRIPTION
Closes #817, Closes #810, Closes #811 and Closes #820.

Adds four Prisma models needed for the off-chain backend's auth, funding goal, recurring tip and webhook delivery flows:
- RefreshToken: stores only a hashed token (userId, expiresAt, revokedAt) so refresh tokens can be rotated/revoked server-side without keeping the raw value at rest.
- Goal: creator funding goal with title, targetStroops, raisedStroops, deadline and a GoalStatus enum, related to User.
- Subscription: recurring tip agreement between a tipper and a creator with amountStroops, a SubscriptionInterval enum, nextChargeAt (indexed for the billing worker) and a SubscriptionStatus enum.
- WebhookDelivery: tracks delivery attempts (status, responseCode, attempts, nextAttemptAt) for subscription billing webhook events, with a composite (status, nextAttemptAt) index to drive retries.

Each model ships with its own migration so history stays granular.