### PR TITLE
feat: Add AnalyticsDaily, AuditLog, soft-delete & timestamps to DB models

### DIFF
--- a/backend/prisma/migrations/20260626130000_add_analytics_daily/migration.sql
+++ b/backend/prisma/migrations/20260626130000_add_analytics_daily/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "AnalyticsDaily" (
+    "id" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "totalTips" INTEGER NOT NULL DEFAULT 0,
+    "totalVolume" BIGINT NOT NULL DEFAULT 0,
+    "newUsers" INTEGER NOT NULL DEFAULT 0,
+    "activeUsers" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "AnalyticsDaily_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AnalyticsDaily_date_key" ON "AnalyticsDaily"("date");
+

--- a/backend/prisma/migrations/20260626130100_add_audit_log/migration.sql
+++ b/backend/prisma/migrations/20260626130100_add_audit_log/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "actor" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "target" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AuditLog_actor_idx" ON "AuditLog"("actor");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_action_idx" ON "AuditLog"("action");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_createdAt_idx" ON "AuditLog"("createdAt");
+

--- a/backend/prisma/migrations/20260626130200_add_soft_delete/migration.sql
+++ b/backend/prisma/migrations/20260626130200_add_soft_delete/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "ApiKey" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Goal" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Subscription" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+

--- a/backend/prisma/migrations/20260626130300_add_timestamps/migration.sql
+++ b/backend/prisma/migrations/20260626130300_add_timestamps/migration.sql
@@ -1,0 +1,52 @@
+-- Add createdAt/updatedAt to every model that was missing them.
+--
+-- For updatedAt (managed by Prisma via @updatedAt, no DB default in the schema)
+-- the column is first added with DEFAULT CURRENT_TIMESTAMP so existing rows are
+-- backfilled, then the default is dropped so the database matches the schema
+-- exactly and no drift is reported. createdAt keeps its default because the
+-- schema declares @default(now()).
+
+-- AlterTable
+ALTER TABLE "Tip" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "Tip" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "IndexerCursor" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "EventLog" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "EventLog" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Refund" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "Refund" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "Notification" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "XAccount" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "XAccount" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "LeaderboardSnapshot" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "LeaderboardSnapshot" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "AuthChallenge" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "AuthChallenge" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "RefreshToken" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "RefreshToken" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "AnalyticsDaily" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "AnalyticsDaily" ALTER COLUMN  "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "AuditLog" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "AuditLog" ALTER COLUMN  "updatedAt" DROP DEFAULT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -270,3 +270,20 @@ model WebhookDelivery {
   @@index([subscriptionId])
   @@index([status, nextAttemptAt])
 }
+
+/// Pre-aggregated daily platform analytics, one row per calendar day (UTC).
+/// Populated by a scheduled job so dashboards can read trends without scanning
+/// the raw Tip/User tables.
+model AnalyticsDaily {
+  id          String   @id @default(cuid())
+  /// Calendar day (UTC) this aggregate covers; one row per day.
+  date        DateTime @unique @db.Date
+  /// Number of tips recorded on this day.
+  totalTips   Int      @default(0)
+  /// Sum of tip amounts (in stroops) on this day.
+  totalVolume BigInt   @default(0)
+  /// Users that registered on this day.
+  newUsers    Int      @default(0)
+  /// Distinct users that sent or received a tip on this day.
+  activeUsers Int      @default(0)
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,6 +20,8 @@ model User {
   username       String?  @unique
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
+  /// Soft-delete marker: non-null means the record is logically deleted.
+  deletedAt      DateTime?
   apiKeys        ApiKey[]
   refreshTokens  RefreshToken[]
   goals          Goal[]
@@ -42,6 +44,8 @@ model ApiKey {
   createdBy   User     @relation(fields: [createdById], references: [id], onDelete: Cascade)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  /// Soft-delete marker: non-null means the record is logically deleted.
+  deletedAt   DateTime?
 
   @@index([createdById])
 }
@@ -109,6 +113,8 @@ model Notification {
   payload   Json
   readAt    DateTime?
   createdAt DateTime  @default(now())
+  /// Soft-delete marker: non-null means the record is logically deleted.
+  deletedAt DateTime?
 
   @@index([userId, readAt])
   @@index([createdAt])
@@ -206,6 +212,8 @@ model Goal {
   status        GoalStatus @default(ACTIVE)
   createdAt     DateTime   @default(now())
   updatedAt     DateTime   @updatedAt
+  /// Soft-delete marker: non-null means the record is logically deleted.
+  deletedAt     DateTime?
 
   @@index([userId])
   @@index([status])
@@ -239,6 +247,8 @@ model Subscription {
   status        SubscriptionStatus   @default(ACTIVE)
   createdAt     DateTime             @default(now())
   updatedAt     DateTime             @updatedAt
+  /// Soft-delete marker: non-null means the record is logically deleted.
+  deletedAt     DateTime?
 
   webhookDeliveries WebhookDelivery[]
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Tip {
   amountStroops BigInt
   message       String?
   createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
   refund        Refund?
 
   @@index([toAddress, createdAt])
@@ -71,6 +72,7 @@ model Tip {
 model IndexerCursor {
   topic      String   @id
   lastLedger Int
+  createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 }
 
@@ -86,6 +88,7 @@ model EventLog {
   /// Decoded event payload as JSON.
   data      Json
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([topic])
   @@index([ledger])
@@ -102,6 +105,7 @@ model Refund {
   status    String   @default("pending")
   txHash    String?
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 /// In-app notification for a user.
@@ -113,6 +117,7 @@ model Notification {
   payload   Json
   readAt    DateTime?
   createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   /// Soft-delete marker: non-null means the record is logically deleted.
   deletedAt DateTime?
 
@@ -127,6 +132,8 @@ model XAccount {
   followers  Int      @default(0)
   engagement Float?
   fetchedAt  DateTime @default(now())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 }
 
 /// Leaderboard period tracked by snapshots.
@@ -145,6 +152,7 @@ model LeaderboardSnapshot {
   user      User     @relation(fields: [userId], references: [id])
   totalTips BigInt
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([period, rank])
 }
@@ -173,6 +181,7 @@ model AuthChallenge {
   /// UTC timestamp after which the challenge is no longer valid.
   expiresAt DateTime
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([address])
   @@index([expiresAt])
@@ -188,6 +197,7 @@ model RefreshToken {
   expiresAt   DateTime
   revokedAt   DateTime?
   createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   @@index([userId])
 }
@@ -296,6 +306,8 @@ model AnalyticsDaily {
   newUsers    Int      @default(0)
   /// Distinct users that sent or received a tip on this day.
   activeUsers Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 /// Append-only audit trail of privileged / admin actions for accountability.
@@ -312,6 +324,7 @@ model AuditLog {
   /// Arbitrary structured context for the action (before/after values, reason…).
   metadata  Json?
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([actor])
   @@index([action])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -287,3 +287,23 @@ model AnalyticsDaily {
   /// Distinct users that sent or received a tip on this day.
   activeUsers Int      @default(0)
 }
+
+/// Append-only audit trail of privileged / admin actions for accountability.
+/// Rows are written by the application whenever an actor performs a sensitive
+/// operation; they are never updated or deleted.
+model AuditLog {
+  id        String   @id @default(cuid())
+  /// Identifier of who performed the action (user id, api key id or "system").
+  actor     String
+  /// Machine-readable action name, e.g. "user.ban" or "tip.refund".
+  action    String
+  /// Identifier of the entity the action was performed on, when applicable.
+  target    String?
+  /// Arbitrary structured context for the action (before/after values, reason…).
+  metadata  Json?
+  createdAt DateTime @default(now())
+
+  @@index([actor])
+  @@index([action])
+  @@index([createdAt])
+}


### PR DESCRIPTION
## Summary

Adds the database models and conventions for four data-model issues, all in `backend/prisma/schema.prisma` with matching Prisma migrations. Targets `test-implement-drips`. The branch is rebased on the latest `test-implement-drips` and is **purely additive** (60 insertions, 0 deletions to the schema), so it merges without conflicts.

Closes #823
Closes #824
Closes #825
Closes #826

## Changes

| Issue | Change |
|-------|--------|
| #823 | `AnalyticsDaily` model — pre-aggregated daily metrics (`date` unique, `totalTips`, `totalVolume`, `newUsers`, `activeUsers`). |
| #824 | `AuditLog` model — append-only admin/privileged action trail (`actor`, `action`, `target`, `metadata`, `createdAt`), indexed by actor/action/createdAt. |
| #825 | Soft-delete convention — nullable `deletedAt` on user-facing resource models. |
| #826 | `createdAt @default(now())` + `updatedAt @updatedAt` on every model. |

## Migrations

Each migration was generated from the immediately preceding schema state, so they compose exactly to the final schema, and are timestamped after the base branch's latest migration (`20260626120000_add_indexes`):

- `20260626130000_add_analytics_daily`
- `20260626130100_add_audit_log`
- `20260626130200_add_soft_delete`
- `20260626130300_add_timestamps`

## Notes for the reviewer

- **Soft-delete scope (#825):** `deletedAt` was added to the user-facing resource models — `User`, `ApiKey`, `Notification`, `Goal`, `Subscription`. Immutable / on-chain / append-only models (`Tip`, `Refund`, `EventLog`, `AuditLog`, `AnalyticsDaily`) and infra tables (`AuthChallenge`, `RefreshToken`, `IndexerCursor`, `LeaderboardSnapshot`, `XAccount`, `WebhookDelivery`) are intentionally excluded. The schema has no `Profile`/`Resource` models referenced in the issue, so the convention was applied to the equivalent models that actually exist.
- **Timestamps scope (#826):** timestamps were added to every model lacking them, including the `EventLog` model recently merged into the base branch. New `NOT NULL updatedAt` columns are added with `DEFAULT CURRENT_TIMESTAMP` to backfill existing rows, then the default is dropped so the database matches the schema's bare `@updatedAt` with **no drift**. `createdAt` keeps its default (`@default(now())`).

## Verification

- `prisma validate` ✅
- `prisma generate` ✅
- Composite `prisma migrate diff` (base → final schema) matches the union of the four migrations.
- A live `migrate dev` apply was not run (no Docker/Postgres in the working environment); reviewers can confirm with `npm install && docker compose up -d && npx prisma migrate dev`.
