### PR TITLE
feat(backend): structured request logging with request ids

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import pinoHttp from 'pino-http';
 import swaggerUi from 'swagger-ui-express';
 import { env } from './config/env.js';
 import { errorHandler, notFoundHandler } from './common/middleware/errorHandler.js';
+import { requestId } from './common/middleware/requestId.js';
 import { logger } from './common/utils/logger.js';
 import { openApiDocument } from './docs/openapi.js';
 import { authRouter } from './modules/auth/auth.routes.js';
@@ -34,6 +35,8 @@ export function createApp(): Express {
   );
   app.use(cors({ origin: env.CORS_ORIGIN.split(','), credentials: true }));
   app.use(express.json({ limit: '1mb' }));
+  // Assign/propagate a correlation id before logging so pino-http reuses it.
+  app.use(requestId);
   app.use(pinoHttp({ logger }));
 
   const docsPath = `${env.API_BASE_PATH}/docs`;

--- a/backend/src/common/middleware/errorHandler.ts
+++ b/backend/src/common/middleware/errorHandler.ts
@@ -3,30 +3,45 @@ import { ZodError } from 'zod';
 import { AppError } from '../errors/AppError.js';
 import { logger } from '../utils/logger.js';
 
+/** Stringifies the correlation id set by the requestId middleware, if present. */
+function requestIdOf(req: Request): string | undefined {
+  return req.id === undefined ? undefined : String(req.id);
+}
+
 /** 404 fallthrough for unmatched routes. */
-export function notFoundHandler(_req: Request, res: Response): void {
-  res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Route not found' } });
+export function notFoundHandler(req: Request, res: Response): void {
+  res.status(404).json({
+    error: { code: 'NOT_FOUND', message: 'Route not found', requestId: requestIdOf(req) },
+  });
 }
 
 /** Global error handler. Must be registered LAST, after all routes. */
 export function errorHandler(
   err: unknown,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction,
 ): void {
+  const requestId = requestIdOf(req);
   if (err instanceof ZodError) {
     res.status(400).json({
-      error: { code: 'VALIDATION_ERROR', message: 'Invalid request', details: err.flatten() },
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid request',
+        details: err.flatten(),
+        requestId,
+      },
     });
     return;
   }
   if (err instanceof AppError) {
     res.status(err.statusCode).json({
-      error: { code: err.code, message: err.message, details: err.details },
+      error: { code: err.code, message: err.message, details: err.details, requestId },
     });
     return;
   }
-  logger.error({ err }, 'Unhandled error');
-  res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Something went wrong' } });
+  logger.error({ err, requestId }, 'Unhandled error');
+  res
+    .status(500)
+    .json({ error: { code: 'INTERNAL_ERROR', message: 'Something went wrong', requestId } });
 }

--- a/backend/src/common/middleware/requestId.ts
+++ b/backend/src/common/middleware/requestId.ts
@@ -1,0 +1,24 @@
+import type { NextFunction, Request, Response } from 'express';
+import { randomUUID } from 'node:crypto';
+
+/** Header used to carry the correlation id in and out of the service. */
+export const REQUEST_ID_HEADER = 'x-request-id';
+
+/**
+ * Attaches a unique id to every request for log correlation.
+ *
+ * Honours an inbound `x-request-id` header when one is supplied (so ids can be
+ * propagated across services), otherwise generates a UUID v4. The id is exposed
+ * on `req.id` — which pino-http picks up so application logs carry the same id —
+ * and echoed back on the response `x-request-id` header. Register this BEFORE
+ * `pino-http` so the logger reuses the id instead of generating its own.
+ */
+export function requestId(req: Request, res: Response, next: NextFunction): void {
+  const inbound = req.headers[REQUEST_ID_HEADER];
+  const provided = (Array.isArray(inbound) ? inbound[0] : inbound)?.trim();
+  const id = provided || randomUUID();
+
+  req.id = id;
+  res.setHeader(REQUEST_ID_HEADER, id);
+  next();
+}

--- a/backend/tests/requestId.test.ts
+++ b/backend/tests/requestId.test.ts
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../src/app.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('request id middleware', () => {
+  it('attaches a generated x-request-id to every response', async () => {
+    const app = createApp();
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-request-id']).toMatch(UUID_RE);
+  });
+
+  it('propagates an inbound x-request-id header', async () => {
+    const app = createApp();
+    const incoming = 'trace-abc-123';
+    const res = await request(app).get('/health').set('x-request-id', incoming);
+
+    expect(res.headers['x-request-id']).toBe(incoming);
+  });
+
+  it('includes the request id in error responses', async () => {
+    const app = createApp();
+    const incoming = 'trace-error-456';
+    const res = await request(app).get('/does-not-exist').set('x-request-id', incoming);
+
+    expect(res.status).toBe(404);
+    expect(res.headers['x-request-id']).toBe(incoming);
+    expect(res.body.error.requestId).toBe(incoming);
+  });
+});


### PR DESCRIPTION
Add a requestId middleware that honours an inbound x-request-id header or generates a UUID v4, exposes it on req.id (so pino-http logs the same id), and echoes it back on the x-request-id response header. Include the id in error responses via the global error handler.

Closes #797

## Description

<!-- Provide a clear and concise description of what this PR does and why it is needed. -->

Closes #<!-- Specify the issue number this PR resolves, e.g. Closes #123 -->

## Type of Change

Please mark the options that are relevant:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧪 Tests (adding new tests or updating existing tests)
- [ ] 📝 Documentation (changes to documentation/configs only)
- [ ] 🚀 DevOps & CI/CD (changes to workflows, scripts, or templates)

## Changes Made

<!-- List the specific files modified and key changes implemented in this PR. -->

- 
- 
- 

## How to Test

<!-- Describe the steps needed to verify your changes. Include details of your testing environment if relevant. -->

1. 
2. 
3. 

## Checklist

### 💻 Smart Contract Changes (if applicable)
- [ ] Running `cargo fmt -- --check` passes successfully.
- [ ] Running `cargo clippy -- -D warnings` runs without any warnings.
- [ ] All tests pass successfully using `cargo test`.
- [ ] New unit or integration tests have been written to cover the changes.
- [ ] No hardcoded values are present (e.g. addresses, fees) that should be configurable.

### 🎨 Frontend Changes (if applicable)
- [ ] TypeScript compiles cleanly with no errors (`npm run typecheck` or `npx tsc --noEmit`).
- [ ] Running `npm run lint` shows no linting errors.
- [ ] The production build compiles successfully via `npm run build`.
- [ ] Changes verified on local browser environment with Freighter/xBull/Albedo wallet.
- [ ] Responsive design verified (tested on mobile, tablet, and desktop viewport sizes).
- [ ] Keyboard navigation and accessibility (a11y) considerations are addressed.

### ⚙️ General
- [ ] Code follows the project's coding standards and structure guidelines.
- [ ] Self-reviewed the changes to ensure clean code with no commented-out code blocks.
- [ ] No `console.log` or debug code remains in production files.
- [ ] The branch is up-to-date with the `main` branch.

## Screenshots / Demos (if applicable)

<!-- Add screenshots, GIFs, or video recordings of the visual UI changes to help reviewers. -->
