### PR TITLE
Auth: Nonce single-use enforcement, account creation on first login, requireAuth middleware, and challenge-response ADR

### DIFF
--- a/backend/docs/adr/001-stellar-wallet-auth-flow.md
+++ b/backend/docs/adr/001-stellar-wallet-auth-flow.md
@@ -1,0 +1,142 @@
+# ADR 001 — Stellar Wallet Challenge-Response Authentication Flow
+
+**Status:** Accepted  
+**Date:** 2026-06-26  
+**Issues:** #832, #838, #842, #849
+
+---
+
+## Context
+
+Stellar Tipz is a tip-streaming platform whose users are identified by their Stellar public key (a `G…` address). Users own their private keys in a browser wallet (e.g. Freighter). There are no passwords to manage and no OAuth provider relationship to maintain.
+
+We need a stateless, JWT-based session layer that:
+
+- Proves the caller controls a Stellar key pair (public key + matching private key).
+- Issues short-lived access tokens and rotatable refresh tokens.
+- Prevents replay of signed messages.
+- Creates a `User` row automatically on first successful login.
+
+---
+
+## Decision
+
+We adopt a **challenge-response (nonce-sign-verify)** flow over HTTPS:
+
+1. **Request challenge** — the client sends its public key; the server stores a random nonce linked to that key with a short TTL (5 minutes by default) and returns a human-readable `messageToSign`.
+2. **Sign** — the client signs the raw nonce bytes with its Stellar private key using Ed25519 (`Keypair.sign`).
+3. **Verify** — the server looks up the challenge, verifies the Ed25519 signature against the stored nonce, **atomically consumes** the challenge (single-use enforcement), upserts the `User` row, and issues a JWT access token + opaque refresh token.
+4. **Access protected routes** — the client sends `Authorization: Bearer <accessToken>`; the `requireAuth` middleware validates the JWT and attaches `req.user`.
+5. **Refresh** — before the access token expires the client exchanges its refresh token for a new token pair (rotation with revocation).
+
+### Why nonce-sign-verify rather than SEP-10 or SIWE?
+
+| Option | Notes |
+|--------|-------|
+| SEP-10 (Stellar Web Auth) | Designed for Stellar network anchors and horizon. Heavyweight for a pure backend. |
+| SIWE (Sign-In With Ethereum) | Ethereum-specific message format; not idiomatic for Stellar. |
+| Custom nonce-sign-verify | Simple, auditable, no external spec dependencies; proven pattern in Solana/Stellar ecosystems. |
+
+### Token design
+
+| Token | Type | Lifetime | Storage |
+|-------|------|----------|---------|
+| Access token | Signed JWT (`RS256`-compatible, `HS256` for simplicity) | 15 min | Memory / `Authorization` header |
+| Refresh token | Opaque random bytes (96 hex chars), SHA-256 hashed in DB | 7 days | `HttpOnly` cookie or secure storage |
+
+### Nonce single-use enforcement (#842)
+
+After signature verification the server calls:
+
+```ts
+const deleted = await prisma.authChallenge.deleteMany({ where: { id: challenge.id } });
+if (deleted.count === 0) {
+  throw new UnauthorizedError('Challenge has already been used');
+}
+```
+
+`deleteMany` maps to a single `DELETE … WHERE id = ?` SQL statement, which is atomic at the database level. Only one concurrent request will receive `count = 1`; all others receive `count = 0` and are rejected. This eliminates the TOCTOU window that a read-then-delete approach would leave open.
+
+### User creation on first login (#849)
+
+```ts
+const user = await prisma.user.upsert({
+  where: { stellarAddress: address },
+  create: { stellarAddress: address },
+  update: {},
+});
+```
+
+`upsert` is a single `INSERT … ON CONFLICT DO NOTHING / UPDATE` statement, making first-login account creation atomic and safe under concurrent requests for the same key.
+
+---
+
+## Sequence Diagram
+
+```
+Client                       Backend (Express)               PostgreSQL
+  |                                |                               |
+  |-- POST /auth/challenge ------->|                               |
+  |   { address: "G..." }          |-- INSERT AuthChallenge ------>|
+  |                                |<-- { id, nonce, expiresAt } --|
+  |<-- 201 { messageToSign } ------|                               |
+  |                                |                               |
+  | [client signs nonce bytes      |                               |
+  |  with Stellar private key]     |                               |
+  |                                |                               |
+  |-- POST /auth/verify ---------->|                               |
+  |   { address, nonce, sig }      |-- SELECT AuthChallenge ------>|
+  |                                |<-- { id, address, expiresAt} -|
+  |                                |                               |
+  |                                | [validate address + expiry]   |
+  |                                | [verify Ed25519 signature]    |
+  |                                |                               |
+  |                                |-- DELETE AuthChallenge ------->|  ← atomic consume
+  |                                |<-- count=1 -------------------|
+  |                                |                               |
+  |                                |-- UPSERT User ---------------->|  ← first-login create
+  |                                |<-- User row ------------------|
+  |                                |                               |
+  |                                | [sign JWT, hash refresh token]|
+  |                                |-- INSERT RefreshToken -------->|
+  |<-- 200 { accessToken,          |                               |
+  |          refreshToken, user } -|                               |
+  |                                |                               |
+  |-- GET /protected               |                               |
+  |   Authorization: Bearer <jwt>  |                               |
+  |                                | [requireAuth middleware]       |
+  |                                | [jwt.verify → req.user]       |
+  |<-- 200 { … } -----------------|                               |
+  |                                |                               |
+  |-- POST /auth/refresh --------->|                               |
+  |   { refreshToken }             |-- SELECT RefreshToken -------->|
+  |                                |<-- { id, revokedAt, user } ---|
+  |                                | [validate not revoked/expired] |
+  |                                |-- UPDATE revokedAt ----------->|
+  |                                |-- INSERT new RefreshToken ---->|
+  |<-- 200 { accessToken,          |                               |
+  |          refreshToken, user } -|                               |
+```
+
+---
+
+## Consequences
+
+### Positive
+
+- No password storage; no OAuth provider lock-in.
+- Nonces expire after 5 minutes and are single-use, limiting the replay window to zero after consumption.
+- Refresh token rotation (revoke-on-use) limits the blast radius of a stolen refresh token.
+- `requireAuth` is a plain Express middleware — easy to compose on any router.
+
+### Negative / Trade-offs
+
+- Clients must implement Ed25519 signing (Freighter wallet handles this natively for Stellar).
+- Access tokens are not revocable before expiry; the 15-minute window is the accepted trade-off for statelessness.
+- `HS256` JWT secret must be rotated carefully (requires all access tokens to be re-issued).
+
+### Out of scope
+
+- Multi-device refresh token management (future work).
+- WebAuthn / passkey support (future work).
+- Role-based access control beyond the `req.user` attachment (future work).

--- a/backend/src/common/middleware/requireAuth.test.ts
+++ b/backend/src/common/middleware/requireAuth.test.ts
@@ -1,0 +1,101 @@
+import request from 'supertest';
+import express from 'express';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { requireAuth } from './requireAuth.js';
+import { errorHandler } from './errorHandler.js';
+
+vi.mock('../../config/index.js', () => ({
+  config: {
+    auth: {
+      jwtSecret: 'test-secret',
+      jwtExpiresIn: '15m',
+      refreshTokenExpiresIn: '7d',
+      challengeTtlSeconds: 300,
+    },
+  },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    verify: vi.fn(),
+  },
+}));
+
+const jwt = await import('jsonwebtoken');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.get('/protected', requireAuth, (req, res) => {
+    res.json({ user: req.user });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe('requireAuth middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 when Authorization header uses a non-Bearer scheme', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Basic dXNlcjpwYXNz');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 when the JWT is invalid', async () => {
+    (jwt.default.verify as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('invalid signature');
+    });
+
+    const app = buildApp();
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer bad-token');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+    expect(res.body.error.message).toBe('Invalid or expired access token');
+  });
+
+  it('returns 401 when the JWT is expired', async () => {
+    (jwt.default.verify as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const err = new Error('jwt expired');
+      (err as NodeJS.ErrnoException).name = 'TokenExpiredError';
+      throw err;
+    });
+
+    const app = buildApp();
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer expired-token');
+    expect(res.status).toBe(401);
+    expect(res.body.error.message).toBe('Invalid or expired access token');
+  });
+
+  it('attaches req.user and calls next on a valid token', async () => {
+    (jwt.default.verify as ReturnType<typeof vi.fn>).mockReturnValue({
+      sub: 'user-1',
+      stellarAddress: 'GABC123',
+    });
+
+    const app = buildApp();
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(200);
+    expect(res.body.user.id).toBe('user-1');
+    expect(res.body.user.stellarAddress).toBe('GABC123');
+    expect(res.body.user.username).toBeNull();
+  });
+});

--- a/backend/src/common/middleware/requireAuth.ts
+++ b/backend/src/common/middleware/requireAuth.ts
@@ -1,0 +1,39 @@
+import type { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { config } from '../../config/index.js';
+import { UnauthorizedError } from '../errors/AppError.js';
+import type { AuthUser } from '../../modules/auth/auth.types.js';
+
+interface JwtPayload {
+  sub: string;
+  stellarAddress: string;
+}
+
+/**
+ * Validates the Bearer access JWT from the Authorization header and attaches
+ * the decoded user to req.user. Passes a 401 UnauthorizedError to next() on
+ * any failure (missing header, bad format, invalid/expired token).
+ */
+export function requireAuth(req: Request, _res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    next(new UnauthorizedError('Missing or invalid authorization header'));
+    return;
+  }
+
+  const token = authHeader.slice(7);
+
+  try {
+    const payload = jwt.verify(token, config.auth.jwtSecret) as JwtPayload;
+    const user: AuthUser = {
+      id: payload.sub,
+      stellarAddress: payload.stellarAddress,
+      username: null,
+    };
+    req.user = user;
+    next();
+  } catch {
+    next(new UnauthorizedError('Invalid or expired access token'));
+  }
+}

--- a/backend/src/common/types/express.d.ts
+++ b/backend/src/common/types/express.d.ts
@@ -1,0 +1,9 @@
+import type { AuthUser } from '../../modules/auth/auth.types.js';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: AuthUser;
+    }
+  }
+}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -76,12 +76,17 @@ export async function verifyChallenge(
     throw new UnauthorizedError('Invalid signature');
   }
 
-  await prisma.authChallenge.delete({ where: { id: challenge.id } });
-
-  let user = await prisma.user.findUnique({ where: { stellarAddress: address } });
-  if (!user) {
-    user = await prisma.user.create({ data: { stellarAddress: address } });
+  // Atomic single-use enforcement: deleteMany returns count=0 if already consumed
+  const deleted = await prisma.authChallenge.deleteMany({ where: { id: challenge.id } });
+  if (deleted.count === 0) {
+    throw new UnauthorizedError('Challenge has already been used');
   }
+
+  const user = await prisma.user.upsert({
+    where: { stellarAddress: address },
+    create: { stellarAddress: address },
+    update: {},
+  });
 
   const authUser: AuthUser = {
     id: user.id,

--- a/backend/src/modules/auth/auth.test.ts
+++ b/backend/src/modules/auth/auth.test.ts
@@ -6,11 +6,10 @@ vi.mock('../../db/prisma.js', () => {
   const mockPrisma = {
     authChallenge: {
       findUnique: vi.fn(),
-      delete: vi.fn(),
+      deleteMany: vi.fn(),
     },
     user: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
+      upsert: vi.fn(),
     },
     refreshToken: {
       findUnique: vi.fn(),
@@ -44,7 +43,22 @@ vi.mock('jsonwebtoken', () => ({
 
 const { prisma } = await import('../../db/prisma.js');
 const { Keypair } = await import('@stellar/stellar-sdk');
-const jwt = await import('jsonwebtoken');
+
+const baseChallenge = {
+  id: 'ch-1',
+  address: 'GABC123',
+  nonce: 'nonce-1',
+  expiresAt: new Date(Date.now() + 100_000),
+  createdAt: new Date(),
+};
+
+const baseUser = {
+  id: 'user-1',
+  stellarAddress: 'GABC123',
+  username: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
 
 describe('POST /api/v1/auth/verify', () => {
   beforeEach(() => {
@@ -71,13 +85,24 @@ describe('POST /api/v1/auth/verify', () => {
     expect(res.body.error.message).toBe('Challenge not found');
   });
 
+  it('returns 400 when challenge address does not match', async () => {
+    prisma.authChallenge.findUnique.mockResolvedValue({
+      ...baseChallenge,
+      address: 'GDIFFERENT',
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/auth/verify')
+      .send({ address: 'GABC123', nonce: 'nonce-1', signature: 'abc' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toBe('Challenge does not match the provided address');
+  });
+
   it('returns 400 when challenge is expired', async () => {
     prisma.authChallenge.findUnique.mockResolvedValue({
-      id: 'ch-1',
-      address: 'GABC123',
-      nonce: 'nonce-1',
+      ...baseChallenge,
       expiresAt: new Date(Date.now() - 1000),
-      createdAt: new Date(),
     });
 
     const app = createApp();
@@ -89,14 +114,8 @@ describe('POST /api/v1/auth/verify', () => {
   });
 
   it('returns 401 when signature is invalid', async () => {
-    prisma.authChallenge.findUnique.mockResolvedValue({
-      id: 'ch-1',
-      address: 'GABC123',
-      nonce: 'nonce-1',
-      expiresAt: new Date(Date.now() + 100000),
-      createdAt: new Date(),
-    });
-    Keypair.fromPublicKey().verify.mockReturnValue(false);
+    prisma.authChallenge.findUnique.mockResolvedValue(baseChallenge);
+    Keypair.fromPublicKey('').verify.mockReturnValue(false);
 
     const app = createApp();
     const res = await request(app)
@@ -106,24 +125,26 @@ describe('POST /api/v1/auth/verify', () => {
     expect(res.body.error.message).toBe('Invalid signature');
   });
 
-  it('returns tokens on successful verification', async () => {
-    prisma.authChallenge.findUnique.mockResolvedValue({
-      id: 'ch-1',
-      address: 'GABC123',
-      nonce: 'nonce-1',
-      expiresAt: new Date(Date.now() + 100000),
-      createdAt: new Date(),
-    });
-    Keypair.fromPublicKey().verify.mockReturnValue(true);
-    prisma.authChallenge.delete.mockResolvedValue({});
-    prisma.user.findUnique.mockResolvedValue(null);
-    prisma.user.create.mockResolvedValue({
-      id: 'user-1',
-      stellarAddress: 'GABC123',
-      username: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+  it('returns 401 when nonce has already been consumed', async () => {
+    prisma.authChallenge.findUnique.mockResolvedValue(baseChallenge);
+    Keypair.fromPublicKey('').verify.mockReturnValue(true);
+    // Simulate concurrent request already deleted the challenge
+    prisma.authChallenge.deleteMany.mockResolvedValue({ count: 0 });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/auth/verify')
+      .send({ address: 'GABC123', nonce: 'nonce-1', signature: 'validsig' });
+    expect(res.status).toBe(401);
+    expect(res.body.error.message).toBe('Challenge has already been used');
+  });
+
+  it('creates a new user and returns tokens on first login', async () => {
+    prisma.authChallenge.findUnique.mockResolvedValue(baseChallenge);
+    Keypair.fromPublicKey('').verify.mockReturnValue(true);
+    prisma.authChallenge.deleteMany.mockResolvedValue({ count: 1 });
+    prisma.user.upsert.mockResolvedValue(baseUser);
+    prisma.refreshToken.create.mockResolvedValue({});
 
     const app = createApp();
     const res = await request(app)
@@ -133,6 +154,32 @@ describe('POST /api/v1/auth/verify', () => {
     expect(res.body.data.accessToken).toBe('mock-access-token');
     expect(res.body.data.refreshToken).toBeDefined();
     expect(res.body.data.user.stellarAddress).toBe('GABC123');
+    // Confirm upsert was used (not findUnique + create)
+    expect(prisma.user.upsert).toHaveBeenCalledOnce();
+    expect(prisma.user.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { stellarAddress: 'GABC123' },
+        create: { stellarAddress: 'GABC123' },
+        update: {},
+      }),
+    );
+  });
+
+  it('returns existing user data on subsequent logins', async () => {
+    const existingUser = { ...baseUser, username: 'tipmaster', id: 'existing-1' };
+    prisma.authChallenge.findUnique.mockResolvedValue(baseChallenge);
+    Keypair.fromPublicKey('').verify.mockReturnValue(true);
+    prisma.authChallenge.deleteMany.mockResolvedValue({ count: 1 });
+    prisma.user.upsert.mockResolvedValue(existingUser);
+    prisma.refreshToken.create.mockResolvedValue({});
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/auth/verify')
+      .send({ address: 'GABC123', nonce: 'nonce-1', signature: 'validsig' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.user.id).toBe('existing-1');
+    expect(res.body.data.user.username).toBe('tipmaster');
   });
 });
 
@@ -166,10 +213,10 @@ describe('POST /api/v1/auth/refresh', () => {
       id: 'rt-1',
       userId: 'user-1',
       hashedToken: 'hash',
-      expiresAt: new Date(Date.now() + 100000),
+      expiresAt: new Date(Date.now() + 100_000),
       revokedAt: new Date(),
       createdAt: new Date(),
-      user: { id: 'user-1', stellarAddress: 'GABC123', username: null },
+      user: baseUser,
     });
 
     const app = createApp();
@@ -180,15 +227,34 @@ describe('POST /api/v1/auth/refresh', () => {
     expect(res.body.error.message).toBe('Refresh token has been revoked');
   });
 
-  it('returns tokens on successful refresh', async () => {
+  it('returns 401 when refresh token is expired', async () => {
     prisma.refreshToken.findUnique.mockResolvedValue({
       id: 'rt-1',
       userId: 'user-1',
       hashedToken: 'hash',
-      expiresAt: new Date(Date.now() + 100000),
+      expiresAt: new Date(Date.now() - 1000),
       revokedAt: null,
       createdAt: new Date(),
-      user: { id: 'user-1', stellarAddress: 'GABC123', username: null },
+      user: baseUser,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/auth/refresh')
+      .send({ refreshToken: 'expired-token' });
+    expect(res.status).toBe(401);
+    expect(res.body.error.message).toBe('Refresh token has expired');
+  });
+
+  it('returns new token pair on successful refresh', async () => {
+    prisma.refreshToken.findUnique.mockResolvedValue({
+      id: 'rt-1',
+      userId: 'user-1',
+      hashedToken: 'hash',
+      expiresAt: new Date(Date.now() + 100_000),
+      revokedAt: null,
+      createdAt: new Date(),
+      user: baseUser,
     });
     prisma.refreshToken.update.mockResolvedValue({});
     prisma.refreshToken.create.mockResolvedValue({});


### PR DESCRIPTION
# Auth: Nonce single-use enforcement, account creation on first login, requireAuth middleware, and challenge-response ADR

Closes #842
closes #849 
closes #838
closes #832

## Summary

### #842 — Nonce single-use enforcement
Replaced `prisma.authChallenge.delete()` with `prisma.authChallenge.deleteMany()` and a count check in `verifyChallenge`. A single SQL `DELETE … WHERE id = ?` is atomic, so only one concurrent request receives `count = 1`; all subsequent attempts receive `count = 0` and are rejected with a 401.

### #849 — Account creation on first login
Replaced the sequential `findUnique` + conditional `create` for the `User` row with a single `prisma.user.upsert()` call. The upsert is atomic, eliminating the TOCTOU window where two concurrent first-logins for the same address could both attempt `create` and collide on the unique constraint.

### #838 — `requireAuth` middleware
- Added `src/common/types/express.d.ts` to extend `Express.Request` with an optional typed `user: AuthUser` field.
- Added `src/common/middleware/requireAuth.ts`: validates the `Authorization: Bearer <token>` header, calls `jwt.verify`, attaches `req.user`, and forwards a 401 `UnauthorizedError` to `next()` on any failure (missing header, wrong scheme, expired or invalid token).
- Tests cover all failure paths and the success path.

### #832 — Wallet challenge-response auth flow ADR
Added `backend/docs/adr/001-stellar-wallet-auth-flow.md` documenting:
- Why nonce-sign-verify was chosen over SEP-10 and SIWE.
- Token design (JWT access / opaque refresh).
- ASCII sequence diagram for the full flow (challenge → sign → verify → access → refresh).
- Consequences and trade-offs.

## Files changed

| File | Change |
|------|--------|
| `backend/src/modules/auth/auth.service.ts` | Atomic deleteMany + user upsert |
| `backend/src/modules/auth/auth.test.ts` | Updated mocks; new tests for consumed nonce + existing user |
| `backend/src/common/types/express.d.ts` | New — Express Request type extension |
| `backend/src/common/middleware/requireAuth.ts` | New — requireAuth middleware |
| `backend/src/common/middleware/requireAuth.test.ts` | New — middleware tests |
| `backend/docs/adr/001-stellar-wallet-auth-flow.md` | New — ADR for auth flow |

## Test plan

- [ ] `npm run typecheck` — no new errors introduced
- [ ] `npm run lint` — no new lint errors
- [ ] `npm run test` — all tests pass, including new coverage for consumed nonce, upsert paths, and requireAuth middleware
- [ ] Manual: `POST /api/v1/auth/verify` with a valid Stellar signature creates a new user and returns tokens
- [ ] Manual: replaying the same nonce returns 401 "Challenge has already been used"
- [ ] Manual: a protected route with a valid Bearer JWT succeeds; missing/invalid JWT returns 401
