### PR TITLE
Profiles & Tips: by-address lookup, reactivate, image upload, prepare tx

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -25,6 +25,12 @@ export default [
         exports: 'readonly',
         module: 'readonly',
         require: 'readonly',
+        fetch: 'readonly',
+        FormData: 'readonly',
+        Blob: 'readonly',
+        Headers: 'readonly',
+        Response: 'readonly',
+        Request: 'readonly',
       },
     },
     plugins: {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1085,9 +1085,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,9 +1099,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1119,9 +1113,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1136,9 +1127,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1153,9 +1141,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1170,9 +1155,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1187,9 +1169,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1204,9 +1183,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1221,9 +1197,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1238,9 +1211,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,9 +1225,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,9 +1239,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1289,9 +1253,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3260,6 +3221,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/backend/prisma/migrations/20260627100000_add_profile_image_cid/migration.sql
+++ b/backend/prisma/migrations/20260627100000_add_profile_image_cid/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "profileImageCid" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   id             String   @id @default(cuid())
   stellarAddress String   @unique
   username       String?  @unique
+  profileImageCid String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
   /// Soft-delete marker: non-null means the record is logically deleted.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,8 @@ import { errorHandler, notFoundHandler } from './common/middleware/errorHandler.
 import { logger } from './common/utils/logger.js';
 import { openApiDocument } from './docs/openapi.js';
 import { authRouter } from './modules/auth/auth.routes.js';
+import { profilesRouter } from './modules/profiles/profiles.routes.js';
+import { tipsRouter } from './modules/tips/tips.routes.js';
 
 /**
  * Builds and configures the Express application (no listening here — see server.ts).
@@ -49,8 +51,8 @@ export function createApp(): Express {
 
   // ── Feature routers mount here ───────────────────────────────
   app.use(`${env.API_BASE_PATH}/auth`, authRouter);
-  // app.use(`${env.API_BASE_PATH}/profiles`, profilesRouter);
-  // app.use(`${env.API_BASE_PATH}/tips`, tipsRouter);
+  app.use(`${env.API_BASE_PATH}/profiles`, profilesRouter);
+  app.use(`${env.API_BASE_PATH}/tips`, tipsRouter);
   // ... (one issue per module)
   // ─────────────────────────────────────────────────────────────
 

--- a/backend/src/common/middleware/requireAuth.ts
+++ b/backend/src/common/middleware/requireAuth.ts
@@ -1,0 +1,28 @@
+import type { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { config } from '../../config/index.js';
+import { UnauthorizedError } from '../errors/AppError.js';
+import type { AuthUser } from '../../modules/auth/auth.types.js';
+
+declare module 'express' {
+  interface Request {
+    user?: AuthUser;
+  }
+}
+
+export function requireAuth(req: Request, _res: Response, next: NextFunction): void {
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) {
+    next(new UnauthorizedError('Missing or invalid authorization header'));
+    return;
+  }
+
+  const token = header.slice(7);
+  try {
+    const payload = jwt.verify(token, config.auth.jwtSecret) as { sub: string; stellarAddress: string };
+    req.user = { id: payload.sub, stellarAddress: payload.stellarAddress, username: null };
+    next();
+  } catch {
+    next(new UnauthorizedError('Invalid or expired token'));
+  }
+}

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -40,6 +40,7 @@ export type OpenApiDocument = {
   };
   paths: OpenApiPaths;
   tags?: OpenApiTag[];
+  components?: Record<string, unknown>;
 };
 
 /** Base OpenAPI document — extended by feature modules via `mergeOpenApiPaths`. */
@@ -54,7 +55,18 @@ export const openApiDocument: OpenApiDocument = {
   tags: [
     { name: 'Health', description: 'Service liveness' },
     { name: 'Auth', description: 'Wallet authentication' },
+    { name: 'Profiles', description: 'Creator profile management' },
+    { name: 'Tips', description: 'On-chain tipping operations' },
   ],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+    },
+  },
   paths: {
     '/health': {
       get: {

--- a/backend/src/modules/auth/auth.test.ts
+++ b/backend/src/modules/auth/auth.test.ts
@@ -2,38 +2,55 @@ import request from 'supertest';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createApp } from '../../app.js';
 
-vi.mock('../../db/prisma.js', () => {
-  const mockPrisma = {
+const {
+  mockChallengeFindUnique,
+  mockChallengeDelete,
+  mockUserFindUnique,
+  mockUserCreate,
+  mockRefreshFindUnique,
+  mockRefreshCreate,
+  mockRefreshUpdate,
+  mockRefreshDeleteMany,
+  mockVerify,
+} = vi.hoisted(() => ({
+  mockChallengeFindUnique: vi.fn(),
+  mockChallengeDelete: vi.fn(),
+  mockUserFindUnique: vi.fn(),
+  mockUserCreate: vi.fn(),
+  mockRefreshFindUnique: vi.fn(),
+  mockRefreshCreate: vi.fn(),
+  mockRefreshUpdate: vi.fn(),
+  mockRefreshDeleteMany: vi.fn(),
+  mockVerify: vi.fn(),
+}));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
     authChallenge: {
-      findUnique: vi.fn(),
-      delete: vi.fn(),
+      findUnique: mockChallengeFindUnique,
+      delete: mockChallengeDelete,
     },
     user: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
+      findUnique: mockUserFindUnique,
+      create: mockUserCreate,
     },
     refreshToken: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      deleteMany: vi.fn(),
+      findUnique: mockRefreshFindUnique,
+      create: mockRefreshCreate,
+      update: mockRefreshUpdate,
+      deleteMany: mockRefreshDeleteMany,
     },
     $disconnect: vi.fn(),
-  };
-  return { prisma: mockPrisma };
-});
+  },
+}));
 
-vi.mock('@stellar/stellar-sdk', () => {
-  const mockVerify = vi.fn();
-  const mockFromPublicKey = vi.fn(() => ({
-    verify: mockVerify,
-  }));
-  return {
-    Keypair: {
-      fromPublicKey: mockFromPublicKey,
-    },
-  };
-});
+vi.mock('@stellar/stellar-sdk', () => ({
+  Keypair: {
+    fromPublicKey: vi.fn(() => ({
+      verify: mockVerify,
+    })),
+  },
+}));
 
 vi.mock('jsonwebtoken', () => ({
   default: {
@@ -41,10 +58,6 @@ vi.mock('jsonwebtoken', () => ({
   },
   sign: vi.fn(() => 'mock-access-token'),
 }));
-
-const { prisma } = await import('../../db/prisma.js');
-const { Keypair } = await import('@stellar/stellar-sdk');
-const jwt = await import('jsonwebtoken');
 
 describe('POST /api/v1/auth/verify', () => {
   beforeEach(() => {
@@ -61,7 +74,7 @@ describe('POST /api/v1/auth/verify', () => {
   });
 
   it('returns 400 when challenge is not found', async () => {
-    prisma.authChallenge.findUnique.mockResolvedValue(null);
+    mockChallengeFindUnique.mockResolvedValue(null);
 
     const app = createApp();
     const res = await request(app)
@@ -72,7 +85,7 @@ describe('POST /api/v1/auth/verify', () => {
   });
 
   it('returns 400 when challenge is expired', async () => {
-    prisma.authChallenge.findUnique.mockResolvedValue({
+    mockChallengeFindUnique.mockResolvedValue({
       id: 'ch-1',
       address: 'GABC123',
       nonce: 'nonce-1',
@@ -89,14 +102,14 @@ describe('POST /api/v1/auth/verify', () => {
   });
 
   it('returns 401 when signature is invalid', async () => {
-    prisma.authChallenge.findUnique.mockResolvedValue({
+    mockChallengeFindUnique.mockResolvedValue({
       id: 'ch-1',
       address: 'GABC123',
       nonce: 'nonce-1',
       expiresAt: new Date(Date.now() + 100000),
       createdAt: new Date(),
     });
-    Keypair.fromPublicKey().verify.mockReturnValue(false);
+    mockVerify.mockReturnValue(false);
 
     const app = createApp();
     const res = await request(app)
@@ -107,17 +120,17 @@ describe('POST /api/v1/auth/verify', () => {
   });
 
   it('returns tokens on successful verification', async () => {
-    prisma.authChallenge.findUnique.mockResolvedValue({
+    mockChallengeFindUnique.mockResolvedValue({
       id: 'ch-1',
       address: 'GABC123',
       nonce: 'nonce-1',
       expiresAt: new Date(Date.now() + 100000),
       createdAt: new Date(),
     });
-    Keypair.fromPublicKey().verify.mockReturnValue(true);
-    prisma.authChallenge.delete.mockResolvedValue({});
-    prisma.user.findUnique.mockResolvedValue(null);
-    prisma.user.create.mockResolvedValue({
+    mockVerify.mockReturnValue(true);
+    mockChallengeDelete.mockResolvedValue({});
+    mockUserFindUnique.mockResolvedValue(null);
+    mockUserCreate.mockResolvedValue({
       id: 'user-1',
       stellarAddress: 'GABC123',
       username: null,
@@ -151,7 +164,7 @@ describe('POST /api/v1/auth/refresh', () => {
   });
 
   it('returns 401 when refresh token is not found', async () => {
-    prisma.refreshToken.findUnique.mockResolvedValue(null);
+    mockRefreshFindUnique.mockResolvedValue(null);
 
     const app = createApp();
     const res = await request(app)
@@ -162,7 +175,7 @@ describe('POST /api/v1/auth/refresh', () => {
   });
 
   it('returns 401 when refresh token is revoked', async () => {
-    prisma.refreshToken.findUnique.mockResolvedValue({
+    mockRefreshFindUnique.mockResolvedValue({
       id: 'rt-1',
       userId: 'user-1',
       hashedToken: 'hash',
@@ -181,7 +194,7 @@ describe('POST /api/v1/auth/refresh', () => {
   });
 
   it('returns tokens on successful refresh', async () => {
-    prisma.refreshToken.findUnique.mockResolvedValue({
+    mockRefreshFindUnique.mockResolvedValue({
       id: 'rt-1',
       userId: 'user-1',
       hashedToken: 'hash',
@@ -190,8 +203,8 @@ describe('POST /api/v1/auth/refresh', () => {
       createdAt: new Date(),
       user: { id: 'user-1', stellarAddress: 'GABC123', username: null },
     });
-    prisma.refreshToken.update.mockResolvedValue({});
-    prisma.refreshToken.create.mockResolvedValue({});
+    mockRefreshUpdate.mockResolvedValue({});
+    mockRefreshCreate.mockResolvedValue({});
 
     const app = createApp();
     const res = await request(app)

--- a/backend/src/modules/profiles/profiles.controller.ts
+++ b/backend/src/modules/profiles/profiles.controller.ts
@@ -1,0 +1,32 @@
+import type { Request, Response, NextFunction } from 'express';
+import { imageUploadSchema } from './profiles.schema.js';
+import * as profilesService from './profiles.service.js';
+
+export async function getByAddress(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { address } = req.params;
+    const profile = await profilesService.getProfileByAddress(address);
+    res.status(200).json({ data: profile });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function reactivate(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const profile = await profilesService.reactivateProfile(req.user!.id);
+    res.status(200).json({ data: profile });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function uploadImage(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { dataUrl } = imageUploadSchema.parse(req.body);
+    const result = await profilesService.uploadProfileImage(req.user!.id, dataUrl);
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/profiles/profiles.routes.ts
+++ b/backend/src/modules/profiles/profiles.routes.ts
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import * as profilesController from './profiles.controller.js';
+import { requireAuth } from '../../common/middleware/requireAuth.js';
+import { env } from '../../config/env.js';
+import { mergeOpenApiPaths } from '../../docs/openapi.js';
+
+export const profilesRouter = Router();
+
+profilesRouter.get('/by-address/:address', profilesController.getByAddress);
+profilesRouter.patch('/reactivate', requireAuth, profilesController.reactivate);
+profilesRouter.post('/image', requireAuth, profilesController.uploadImage);
+
+const base = `${env.API_BASE_PATH}/profiles`;
+mergeOpenApiPaths({
+  [`${base}/by-address/{address}`]: {
+    get: {
+      tags: ['Profiles'],
+      summary: 'Look up a profile by Stellar address',
+      parameters: [
+        {
+          name: 'address',
+          in: 'path',
+          required: true,
+          schema: { type: 'string', pattern: '^G[A-Z2-7]{55}$' },
+          description: 'Stellar public key',
+        },
+      ],
+      responses: {
+        '200': { description: 'Profile found' },
+        '404': { description: 'Profile not found' },
+      },
+    },
+  },
+  [`${base}/reactivate`]: {
+    patch: {
+      tags: ['Profiles'],
+      summary: 'Reactivate a soft-deleted profile',
+      security: [{ bearerAuth: [] }],
+      responses: {
+        '200': { description: 'Profile reactivated' },
+        '400': { description: 'Profile is not deactivated' },
+        '401': { description: 'Unauthorized' },
+      },
+    },
+  },
+  [`${base}/image`]: {
+    post: {
+      tags: ['Profiles'],
+      summary: 'Upload a profile image (pinned to IPFS)',
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                dataUrl: { type: 'string', description: 'Base64-encoded image data URL' },
+              },
+              required: ['dataUrl'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Image uploaded and CID stored' },
+        '400': { description: 'Invalid image data' },
+        '401': { description: 'Unauthorized' },
+      },
+    },
+  },
+});

--- a/backend/src/modules/profiles/profiles.schema.ts
+++ b/backend/src/modules/profiles/profiles.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const imageUploadSchema = z.object({
+  dataUrl: z
+    .string()
+    .regex(/^data:image\/(png|jpeg|gif|webp);base64,/, 'Invalid image data URL'),
+});
+
+export type ImageUploadInput = z.infer<typeof imageUploadSchema>;

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -1,0 +1,90 @@
+import crypto from 'node:crypto';
+import { prisma } from '../../db/prisma.js';
+import { NotFoundError, BadRequestError } from '../../common/errors/AppError.js';
+import { config } from '../../config/index.js';
+
+export interface ProfileResult {
+  id: string;
+  stellarAddress: string;
+  username: string | null;
+  profileImageCid: string | null;
+  createdAt: Date;
+}
+
+function toProfile(user: {
+  id: string;
+  stellarAddress: string;
+  username: string | null;
+  profileImageCid: string | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+}): ProfileResult | null {
+  if (user.deletedAt) return null;
+  return {
+    id: user.id,
+    stellarAddress: user.stellarAddress,
+    username: user.username,
+    profileImageCid: user.profileImageCid,
+    createdAt: user.createdAt,
+  };
+}
+
+export async function getProfileByAddress(address: string): Promise<ProfileResult> {
+  const user = await prisma.user.findUnique({ where: { stellarAddress: address } });
+  if (!user) throw new NotFoundError('Profile not found');
+  const profile = toProfile(user);
+  if (!profile) throw new NotFoundError('Profile has been deactivated');
+  return profile;
+}
+
+export async function reactivateProfile(userId: string): Promise<ProfileResult> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new NotFoundError('User not found');
+  if (!user.deletedAt) throw new BadRequestError('Profile is not deactivated');
+
+  const updated = await prisma.user.update({
+    where: { id: userId },
+    data: { deletedAt: null },
+  });
+
+  return toProfile(updated)!;
+}
+
+async function pinToIPFS(dataUrl: string): Promise<string> {
+  if (!config.ipfs.apiUrl) {
+    return `sim-${crypto.randomBytes(16).toString('hex')}`;
+  }
+
+  const base64Data = dataUrl.split(',')[1];
+  const buffer = Buffer.from(base64Data, 'base64');
+
+  const formData = new FormData();
+  const blob = new Blob([buffer], { type: 'application/octet-stream' });
+  formData.append('file', blob, 'profile.png');
+
+  const res = await fetch(`${config.ipfs.apiUrl}/api/v0/add`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!res.ok) throw new Error(`IPFS pin failed: ${res.statusText}`);
+  const result = (await res.json()) as { Hash: string };
+  return result.Hash;
+}
+
+export async function uploadProfileImage(
+  userId: string,
+  dataUrl: string,
+): Promise<{ profileImageCid: string }> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new NotFoundError('User not found');
+
+  const cid = await pinToIPFS(dataUrl);
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { profileImageCid: cid },
+  });
+
+  return { profileImageCid: cid };
+}

--- a/backend/src/modules/profiles/profiles.test.ts
+++ b/backend/src/modules/profiles/profiles.test.ts
@@ -1,0 +1,197 @@
+import request from 'supertest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createApp } from '../../app.js';
+
+const { mockFindUnique, mockUpdate } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    user: {
+      findUnique: mockFindUnique,
+      update: mockUpdate,
+    },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: vi.fn(() => ({ sub: 'user-1', stellarAddress: 'GABCDEF123456789012345678901234567890123456789012345678901234' })) },
+  verify: vi.fn(() => ({ sub: 'user-1', stellarAddress: 'GABCDEF123456789012345678901234567890123456789012345678901234' })),
+}));
+
+vi.mock('node:crypto', () => ({
+  default: { randomBytes: vi.fn(() => Buffer.from('abcdef1234567890abcdef1234567890')) },
+  randomBytes: vi.fn(() => Buffer.from('abcdef1234567890abcdef1234567890')),
+}));
+
+const validAddress = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
+const authHeader = 'Bearer mock-token';
+
+describe('GET /api/v1/profiles/by-address/:address', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when profile is not found', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app).get(`/api/v1/profiles/by-address/${validAddress}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 404 when profile is soft-deleted', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: validAddress,
+      username: 'olduser',
+      profileImageCid: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: new Date(),
+    });
+
+    const app = createApp();
+    const res = await request(app).get(`/api/v1/profiles/by-address/${validAddress}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.message).toBe('Profile has been deactivated');
+  });
+
+  it('returns the profile when found and active', async () => {
+    const now = new Date();
+    mockFindUnique.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: validAddress,
+      username: 'testuser',
+      profileImageCid: null,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    });
+
+    const app = createApp();
+    const res = await request(app).get(`/api/v1/profiles/by-address/${validAddress}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.stellarAddress).toBe(validAddress);
+    expect(res.body.data.username).toBe('testuser');
+  });
+});
+
+describe('PATCH /api/v1/profiles/reactivate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = createApp();
+    const res = await request(app).patch('/api/v1/profiles/reactivate').send({});
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when profile is not deactivated', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: validAddress,
+      username: 'testuser',
+      profileImageCid: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .patch('/api/v1/profiles/reactivate')
+      .set('Authorization', authHeader)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toBe('Profile is not deactivated');
+  });
+
+  it('reactivates a soft-deleted profile', async () => {
+    const now = new Date();
+    mockFindUnique.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: validAddress,
+      username: 'testuser',
+      profileImageCid: null,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: now,
+    });
+    mockUpdate.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: validAddress,
+      username: 'testuser',
+      profileImageCid: null,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .patch('/api/v1/profiles/reactivate')
+      .set('Authorization', authHeader)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.data.stellarAddress).toBe(validAddress);
+  });
+});
+
+describe('POST /api/v1/profiles/image', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/profiles/image')
+      .send({ dataUrl: 'data:image/png;base64,abc' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid dataUrl', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/profiles/image')
+      .set('Authorization', authHeader)
+      .send({ dataUrl: 'not-a-data-url' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('uploads image and stores CID', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: validAddress,
+      username: 'testuser',
+      profileImageCid: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    });
+    mockUpdate.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: validAddress,
+      username: 'testuser',
+      profileImageCid: 'sim-abcdef123456',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/profiles/image')
+      .set('Authorization', authHeader)
+      .send({ dataUrl: 'data:image/png;base64,iVBORw0KGgo=' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.profileImageCid).toBeDefined();
+  });
+});

--- a/backend/src/modules/tips/tips.controller.ts
+++ b/backend/src/modules/tips/tips.controller.ts
@@ -1,0 +1,13 @@
+import type { Request, Response, NextFunction } from 'express';
+import { prepareTipSchema } from './tips.schema.js';
+import * as tipsService from './tips.service.js';
+
+export async function prepare(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { from, to, amount, message } = prepareTipSchema.parse(req.body);
+    const prepared = await tipsService.prepareTip(from, to, amount, message);
+    res.status(200).json({ data: prepared });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/tips/tips.routes.ts
+++ b/backend/src/modules/tips/tips.routes.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import * as tipsController from './tips.controller.js';
+import { env } from '../../config/env.js';
+import { mergeOpenApiPaths } from '../../docs/openapi.js';
+
+export const tipsRouter = Router();
+
+tipsRouter.post('/prepare', tipsController.prepare);
+
+const base = `${env.API_BASE_PATH}/tips`;
+mergeOpenApiPaths({
+  [`${base}/prepare`]: {
+    post: {
+      tags: ['Tips'],
+      summary: 'Prepare an unsigned Soroban tip transaction',
+      description: 'Builds and simulates a Soroban contract call for tipping, returning an unsigned transaction XDR for the frontend wallet to sign.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                from: { type: 'string', description: 'Sender Stellar address' },
+                to: { type: 'string', description: 'Recipient Stellar address' },
+                amount: { type: 'string', description: 'Tip amount in stroops' },
+                message: { type: 'string', description: 'Optional tip message', maxLength: 280 },
+              },
+              required: ['from', 'to', 'amount'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Unsigned transaction prepared' },
+        '400': { description: 'Validation or simulation error' },
+      },
+    },
+  },
+});

--- a/backend/src/modules/tips/tips.schema.ts
+++ b/backend/src/modules/tips/tips.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const prepareTipSchema = z.object({
+  from: z.string().regex(/^G[A-Z2-7]{55}$/, 'Invalid sender Stellar address'),
+  to: z.string().regex(/^G[A-Z2-7]{55}$/, 'Invalid recipient Stellar address'),
+  amount: z.string().regex(/^\d+$/, 'Amount must be a string of digits (stroops)'),
+  message: z.string().max(280).optional(),
+});
+
+export type PrepareTipInput = z.infer<typeof prepareTipSchema>;

--- a/backend/src/modules/tips/tips.service.ts
+++ b/backend/src/modules/tips/tips.service.ts
@@ -1,0 +1,74 @@
+import { Contract, TransactionBuilder, SorobanRpc, nativeToScVal, Networks } from '@stellar/stellar-sdk';
+import { config } from '../../config/index.js';
+import { BadRequestError } from '../../common/errors/AppError.js';
+import { logger } from '../../common/utils/logger.js';
+
+export interface PreparedTip {
+  unsignedTxXdr: string;
+  from: string;
+  to: string;
+  amount: string;
+  contractId: string;
+  networkPassphrase: string;
+}
+
+export async function prepareTip(
+  from: string,
+  to: string,
+  amount: string,
+  message?: string,
+): Promise<PreparedTip> {
+  const contractId = config.stellar.contractId;
+  if (!contractId) {
+    throw new BadRequestError('Contract ID is not configured');
+  }
+
+  const server = new SorobanRpc.Server(config.stellar.rpcUrl, {
+    allowHttp: config.stellar.rpcUrl.startsWith('http://'),
+  });
+
+  const sourceAccount = await server.getAccount(from).catch(() => {
+    throw new BadRequestError('Source account not found on network');
+  });
+
+  const networkPassphrase = Networks[config.stellar.network as keyof typeof Networks] ?? config.stellar.networkPassphrase;
+
+  const scParams = [
+    nativeToScVal(from, { type: 'address' }),
+    nativeToScVal(to, { type: 'address' }),
+    nativeToScVal(amount, { type: 'i128' }),
+  ];
+  if (message) {
+    scParams.push(nativeToScVal(message, { type: 'string' }));
+  }
+
+  const contract = new Contract(contractId);
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: '100',
+    networkPassphrase,
+  })
+    .addOperation(contract.call('tip', ...scParams))
+    .setTimeout(30)
+    .build();
+
+  const simulateResponse = await server.simulateTransaction(tx).catch((err: Error) => {
+    logger.error({ err }, 'Transaction simulation failed');
+    throw new BadRequestError('Transaction simulation failed');
+  });
+
+  if (SorobanRpc.Api.isSimulationError(simulateResponse)) {
+    throw new BadRequestError(`Simulation error: ${simulateResponse.error}`);
+  }
+
+  const prepared = SorobanRpc.assembleTransaction(tx, simulateResponse);
+  const unsignedTxXdr = prepared.build().toEnvelope().toXDR('base64');
+
+  return {
+    unsignedTxXdr,
+    from,
+    to,
+    amount,
+    contractId,
+    networkPassphrase,
+  };
+}

--- a/backend/src/modules/tips/tips.test.ts
+++ b/backend/src/modules/tips/tips.test.ts
@@ -1,0 +1,106 @@
+import request from 'supertest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createApp } from '../../app.js';
+
+const { mockGetAccount, mockSimulateTransaction, mockContractCall } = vi.hoisted(() => ({
+  mockGetAccount: vi.fn(),
+  mockSimulateTransaction: vi.fn(),
+  mockContractCall: vi.fn(),
+}));
+
+vi.mock('@stellar/stellar-sdk', () => {
+  const mockPreparedTx = {
+    build: vi.fn(() => ({
+      toEnvelope: vi.fn(() => ({
+        toXDR: vi.fn(() => 'AAAAAgAAAAA...mock-unsigned-xdr...'),
+      })),
+    })),
+  };
+
+  return {
+    Keypair: {
+      fromPublicKey: vi.fn(),
+    },
+    TransactionBuilder: vi.fn(() => ({
+      addOperation: vi.fn(() => ({
+        setTimeout: vi.fn(() => ({
+          build: vi.fn(() => ({})),
+        })),
+      })),
+    })),
+    SorobanRpc: {
+      Server: vi.fn(() => ({
+        getAccount: mockGetAccount,
+        simulateTransaction: mockSimulateTransaction,
+      })),
+      assembleTransaction: vi.fn(() => mockPreparedTx),
+      Api: {
+        isSimulationError: vi.fn(() => false),
+      },
+    },
+    Contract: vi.fn(() => ({
+      call: mockContractCall,
+    })),
+    nativeToScVal: vi.fn(() => ({ type: 'scval' })),
+    xdr: {
+      ScVal: {
+        scvVoid: () => ({}),
+      },
+    },
+    Networks: {
+      TESTNET: 'Test SDF Network ; September 2015',
+    },
+  };
+});
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    $disconnect: vi.fn(),
+  },
+}));
+
+describe('POST /api/v1/tips/prepare', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 when inputs are missing', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/tips/prepare')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for invalid stellar addresses', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/tips/prepare')
+      .send({ from: 'not-valid', to: 'also-not-valid', amount: '100' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns prepared transaction on success', async () => {
+    mockGetAccount.mockResolvedValue({
+      accountId: () => 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
+      sequenceNumber: () => '123',
+      incrementSequenceNumber: () => {},
+    });
+    mockSimulateTransaction.mockResolvedValue({});
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/tips/prepare')
+      .send({
+        from: 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
+        to: 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
+        amount: '100',
+        message: 'Great content!',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.data.unsignedTxXdr).toBeDefined();
+    expect(res.body.data.contractId).toBeDefined();
+  });
+});

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -2,7 +2,9 @@ import request from 'supertest';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createApp } from '../src/app.js';
 
-const mockAuthChallengeCreate = vi.fn();
+const { mockAuthChallengeCreate } = vi.hoisted(() => ({
+  mockAuthChallengeCreate: vi.fn(),
+}));
 
 vi.mock('../src/db/prisma.js', () => ({
   prisma: {
@@ -12,7 +14,7 @@ vi.mock('../src/db/prisma.js', () => ({
   },
 }));
 
-const validAddress = 'GCDUEW3G6B6G3WY5X6HJ6Z7O4X7K7Q5V5Z7O4X7K7Q5V5Z7O4X7K7Q';
+const validAddress = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
 
 function mockChallengeCreate(): void {
   mockAuthChallengeCreate.mockResolvedValue({

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    setupFiles: ['./vitest.setup.ts'],
     coverage: { provider: 'v8', reporter: ['text', 'html'] },
   },
 });

--- a/backend/vitest.setup.ts
+++ b/backend/vitest.setup.ts
@@ -1,0 +1,7 @@
+process.env.DATABASE_URL = 'postgresql://u:p@localhost:5432/db';
+process.env.REDIS_URL = 'redis://localhost:6379';
+process.env.JWT_SECRET = 'test-secret-key-for-testing';
+process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org';
+process.env.NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+process.env.CONTRACT_ID = 'CA3D5K7XK7Q5V5Z7O4X7K7Q5V5Z7O4X7K7Q5V5Z7O4X7K7Q5V5Z7O4X7';


### PR DESCRIPTION
## Changes

### Profiles module (`src/modules/profiles/`)
- **GET /profiles/by-address/:address** — Look up a profile by Stellar address. Returns profile data or 404 if not found / soft-deleted.
- **PATCH /profiles/reactivate** — Reactivate a soft-deleted profile (sets `deletedAt` → null). Requires auth.
- **POST /profiles/image** — Upload a profile image as base64 data URL, pins to IPFS (or generates simulated CID), stores the CID on the User. Requires auth.

### Tips module (`src/modules/tips/`)
- **POST /tips/prepare** — Builds an unsigned Soroban contract tip transaction via RPC simulation + `assembleTransaction`. Returns the unsigned XDR for the frontend wallet to sign.

### Supporting
- `requireAuth` middleware (JWT verification, Express type augmentation)
- `profileImageCid` field added to User model + migration
- Both routers registered in `app.ts`
- OpenAPI docs for all endpoints with bearer auth security scheme
- Vitest tests for all endpoints (33 tests passing)
- Fixed pre-existing test mock hoisting issues in auth tests

Closes #854
Closes #859
Closes #864
Closes #875