### PR TITLE
test(backend): add Supertest helper and wire app service to docker-compose

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,8 @@
-# Local infrastructure for backend development: PostgreSQL + Redis.
-# Usage:  docker compose -f backend/docker-compose.yml up -d
+# Local infrastructure for backend development: PostgreSQL, Redis, and the backend app.
+# Usage:  docker compose -f backend/docker-compose.yml up
+#
+# One-command startup — brings up Postgres, Redis, and the backend together.
+# The app container waits for both services to be healthy before starting.
 services:
   postgres:
     image: postgres:16-alpine
@@ -25,6 +28,32 @@ services:
       - '6379:6379'
     volumes:
       - tipz_redisdata:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - '${PORT:-3000}:3000'
+    environment:
+      NODE_ENV: development
+      PORT: 3000
+      DATABASE_URL: postgresql://tipz:tipz@postgres:5432/tipz
+      REDIS_URL: redis://redis:6379
+    env_file:
+      - path: .env
+        required: false
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
 volumes:
   tipz_pgdata:

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -1,11 +1,10 @@
-import request from 'supertest';
 import { describe, expect, it } from 'vitest';
-import { createApp } from '../src/app.js';
+import { buildTestApp } from './helpers/app.js';
 
 describe('GET /health', () => {
   it('returns ok status', async () => {
-    const app = createApp();
-    const res = await request(app).get('/health');
+    const agent = buildTestApp();
+    const res = await agent.get('/health');
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('ok');
   });

--- a/backend/tests/helpers/app.ts
+++ b/backend/tests/helpers/app.ts
@@ -1,0 +1,15 @@
+import request, { type Agent } from 'supertest';
+import { createApp } from '../../src/app.js';
+
+/**
+ * Returns a Supertest agent wired to a fresh Express app instance.
+ * Use this in every module test instead of instantiating createApp() directly
+ * so the setup stays DRY and the app config is always in sync with production.
+ *
+ * @example
+ * const agent = buildTestApp();
+ * const res = await agent.get('/health');
+ */
+export function buildTestApp(): Agent {
+  return request.agent(createApp());
+}


### PR DESCRIPTION
Closes #795
Closes #791
Closes #887
Closes #888

## What this adds

### `backend/tests/helpers/app.ts` — Supertest helper (#795)

Exports `buildTestApp()` which returns a `request.agent` wired to a fresh `createApp()` instance. All module tests can now import this single helper instead of each instantiating `createApp()` directly — keeps setup DRY and ensures every test always uses the current app config.

### `backend/tests/health.test.ts` — refactored to use helper (#795)

Replaced the inline `request(createApp())` call with `buildTestApp()`. Test behaviour is unchanged; it still asserts `GET /health` returns `200` with `{ status: "ok" }`.

### `backend/docker-compose.yml` — `app` service (#791)

Added an `app` service that:
- Builds from `./Dockerfile` (backend root context)
- Exposes port `3000` (overridable via `PORT` env var)
- Injects `DATABASE_URL` and `REDIS_URL` pointing at the sibling services
- Optionally loads a local `.env` file
- Declares `depends_on` with `condition: service_healthy` for both `postgres` and `redis` so the backend only starts once the data stores are ready

Also added a healthcheck to the `redis` service so the `depends_on` condition works correctly.

One-command startup: `docker compose -f backend/docker-compose.yml up`