### PR TITLE
feat: add username validation rules

### DIFF
--- a/backend/src/modules/profiles/profiles.schema.ts
+++ b/backend/src/modules/profiles/profiles.schema.ts
@@ -1,5 +1,30 @@
 import { z } from 'zod';
 
+export const reservedUsernames = [
+  'admin',
+  'root',
+  'system',
+  'api',
+  'tipz',
+  'stellar',
+  'support',
+  'moderator',
+  'null',
+  'undefined',
+  'test',
+  'help',
+] as const;
+
+export const usernameSchema = z
+  .string()
+  .min(3, 'Username must be at least 3 characters')
+  .max(32, 'Username must be at most 32 characters')
+  .regex(/^[a-z0-9_]+$/, 'Username can only contain lowercase letters, numbers, and underscores');
+
+export const usernameParamSchema = z.object({
+  username: usernameSchema,
+});
+
 export const imageUploadSchema = z.object({
   dataUrl: z
     .string()

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { prisma } from '../../db/prisma.js';
 import { NotFoundError, BadRequestError } from '../../common/errors/AppError.js';
+import { reservedUsernames, usernameSchema } from './profiles.schema.js';
 import { config } from '../../config/index.js';
 
 export interface ProfileResult {
@@ -27,6 +28,18 @@ function toProfile(user: {
     profileImageCid: user.profileImageCid,
     createdAt: user.createdAt,
   };
+}
+
+const reservedSet = new Set<string>(reservedUsernames);
+
+export function validateUsername(username: string): void {
+  const result = usernameSchema.safeParse(username);
+  if (!result.success) {
+    throw new BadRequestError(result.error.errors[0].message);
+  }
+  if (reservedSet.has(username)) {
+    throw new BadRequestError(`Username "${username}" is reserved`);
+  }
 }
 
 export async function getProfileByAddress(address: string): Promise<ProfileResult> {

--- a/backend/src/modules/profiles/profiles.test.ts
+++ b/backend/src/modules/profiles/profiles.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createApp } from '../../app.js';
+import { validateUsername } from './profiles.service.js';
 
 const { mockFindUnique, mockUpdate } = vi.hoisted(() => ({
   mockFindUnique: vi.fn(),
@@ -140,6 +141,52 @@ describe('PATCH /api/v1/profiles/reactivate', () => {
       .send({});
     expect(res.status).toBe(200);
     expect(res.body.data.stellarAddress).toBe(validAddress);
+  });
+});
+
+describe('validateUsername', () => {
+  it('accepts a valid lowercase username', () => {
+    expect(() => validateUsername('john_doe')).not.toThrow();
+  });
+
+  it('accepts a username with numbers', () => {
+    expect(() => validateUsername('user123')).not.toThrow();
+  });
+
+  it('rejects a username shorter than 3 characters', () => {
+    expect(() => validateUsername('ab')).toThrow('Username must be at least 3 characters');
+  });
+
+  it('rejects a username longer than 32 characters', () => {
+    expect(() => validateUsername('a'.repeat(33))).toThrow('Username must be at most 32 characters');
+  });
+
+  it('rejects a username with uppercase letters', () => {
+    expect(() => validateUsername('JohnDoe')).toThrow(
+      'Username can only contain lowercase letters, numbers, and underscores',
+    );
+  });
+
+  it('rejects a username with special characters', () => {
+    expect(() => validateUsername('john-doe')).toThrow(
+      'Username can only contain lowercase letters, numbers, and underscores',
+    );
+  });
+
+  it('rejects a reserved username', () => {
+    expect(() => validateUsername('admin')).toThrow('Username "admin" is reserved');
+  });
+
+  it('rejects another reserved username', () => {
+    expect(() => validateUsername('stellar')).toThrow('Username "stellar" is reserved');
+  });
+
+  it('rejects the test reserved username', () => {
+    expect(() => validateUsername('test')).toThrow('Username "test" is reserved');
+  });
+
+  it('rejects the help reserved username', () => {
+    expect(() => validateUsername('help')).toThrow('Username "help" is reserved');
   });
 });
 


### PR DESCRIPTION
Added username validation for the profiles module: 3-32 chars, lowercase alphanumeric + underscore, reserved-name blocklist. Includes exported `usernameSchema`, `validateUsername()` service helper, and 6 unit tests.

Closes #857