### PR TITLE
feat: add username availability check endpoint

### DIFF
--- a/backend/src/modules/profiles/profiles.controller.ts
+++ b/backend/src/modules/profiles/profiles.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { imageUploadSchema } from './profiles.schema.js';
+import { imageUploadSchema, checkUsernameQuerySchema } from './profiles.schema.js';
 import * as profilesService from './profiles.service.js';
 
 export async function getByAddress(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -16,6 +16,16 @@ export async function reactivate(req: Request, res: Response, next: NextFunction
   try {
     const profile = await profilesService.reactivateProfile(req.user!.id);
     res.status(200).json({ data: profile });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function checkUsername(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { username } = checkUsernameQuerySchema.parse(req.query);
+    const result = await profilesService.checkUsernameAvailability(username);
+    res.status(200).json({ data: result });
   } catch (err) {
     next(err);
   }

--- a/backend/src/modules/profiles/profiles.routes.ts
+++ b/backend/src/modules/profiles/profiles.routes.ts
@@ -6,6 +6,7 @@ import { mergeOpenApiPaths } from '../../docs/openapi.js';
 
 export const profilesRouter = Router();
 
+profilesRouter.get('/check-username', profilesController.checkUsername);
 profilesRouter.get('/by-address/:address', profilesController.getByAddress);
 profilesRouter.patch('/reactivate', requireAuth, profilesController.reactivate);
 profilesRouter.post('/image', requireAuth, profilesController.uploadImage);

--- a/backend/src/modules/profiles/profiles.schema.ts
+++ b/backend/src/modules/profiles/profiles.schema.ts
@@ -7,3 +7,11 @@ export const imageUploadSchema = z.object({
 });
 
 export type ImageUploadInput = z.infer<typeof imageUploadSchema>;
+
+export const checkUsernameQuerySchema = z.object({
+  username: z
+    .string()
+    .min(3, 'Username must be at least 3 characters')
+    .max(32, 'Username must be at most 32 characters')
+    .regex(/^[a-z0-9_]+$/, 'Username must be lowercase alphanumeric with underscores'),
+});

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -29,6 +29,16 @@ function toProfile(user: {
   };
 }
 
+export async function checkUsernameAvailability(username: string): Promise<{ available: boolean }> {
+  const user = await prisma.user.findFirst({
+    where: {
+      username: { equals: username, mode: 'insensitive' },
+      deletedAt: null,
+    },
+  });
+  return { available: !user };
+}
+
 export async function getProfileByAddress(address: string): Promise<ProfileResult> {
   const user = await prisma.user.findUnique({ where: { stellarAddress: address } });
   if (!user) throw new NotFoundError('Profile not found');

--- a/backend/src/modules/profiles/profiles.test.ts
+++ b/backend/src/modules/profiles/profiles.test.ts
@@ -2,8 +2,9 @@ import request from 'supertest';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createApp } from '../../app.js';
 
-const { mockFindUnique, mockUpdate } = vi.hoisted(() => ({
+const { mockFindUnique, mockFindFirst, mockUpdate } = vi.hoisted(() => ({
   mockFindUnique: vi.fn(),
+  mockFindFirst: vi.fn(),
   mockUpdate: vi.fn(),
 }));
 
@@ -11,6 +12,7 @@ vi.mock('../../db/prisma.js', () => ({
   prisma: {
     user: {
       findUnique: mockFindUnique,
+      findFirst: mockFindFirst,
       update: mockUpdate,
     },
     $disconnect: vi.fn(),
@@ -193,5 +195,53 @@ describe('POST /api/v1/profiles/image', () => {
       .send({ dataUrl: 'data:image/png;base64,iVBORw0KGgo=' });
     expect(res.status).toBe(200);
     expect(res.body.data.profileImageCid).toBeDefined();
+  });
+});
+
+describe('GET /api/v1/profiles/check-username', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns available=true when username is free', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/profiles/check-username?username=newuser');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ available: true });
+  });
+
+  it('returns available=false when username is taken', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
+      username: 'testuser',
+    });
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/profiles/check-username?username=testuser');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ available: false });
+  });
+
+  it('returns available=false when username taken with different case', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: 'user-1',
+      stellarAddress: 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
+      username: 'TestUser',
+    });
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/profiles/check-username?username=testuser');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ available: false });
+  });
+
+  it('returns validation error for invalid username', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/profiles/check-username?username=ab');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 });


### PR DESCRIPTION
Added `GET /profiles/check-username?username=` endpoint that returns `{ available: boolean }` via case-insensitive lookup. Includes Zod query validation, service method, and 4 integration tests.

Closes #856