### PR TITLE
feat: add Soroban RPC client wrapper and indexer core

### DIFF
--- a/backend/src/indexer/cursor.store.ts
+++ b/backend/src/indexer/cursor.store.ts
@@ -1,0 +1,16 @@
+import { prisma } from '../db/prisma.js';
+
+export class CursorStore {
+  async get(topic: string): Promise<number | null> {
+    const cursor = await prisma.indexerCursor.findUnique({ where: { topic } });
+    return cursor?.lastLedger ?? null;
+  }
+
+  async advance(topic: string, lastLedger: number): Promise<void> {
+    await prisma.indexerCursor.upsert({
+      where: { topic },
+      update: { lastLedger },
+      create: { topic, lastLedger },
+    });
+  }
+}

--- a/backend/src/indexer/event-log.store.ts
+++ b/backend/src/indexer/event-log.store.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+import type { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma.js';
+import { logger } from '../common/utils/logger.js';
+
+function deterministicId(event: { txHash: string; ledger: number; topic: string }): string {
+  return createHash('sha256')
+    .update(`${event.txHash}:${event.ledger}:${event.topic}`)
+    .digest('hex')
+    .slice(0, 30);
+}
+
+export class EventLogStore {
+  async persist(
+    events: Array<{
+      id: string;
+      txHash: string;
+      topic: string;
+      ledger: number;
+      contractId: string;
+      value: Record<string, unknown>;
+    }>,
+  ): Promise<number> {
+    const rows = events.map((e) => ({
+      id: deterministicId({ txHash: e.txHash, ledger: e.ledger, topic: e.topic }),
+      topic: e.topic,
+      ledger: e.ledger,
+      txHash: e.txHash,
+      data: { contractId: e.contractId, value: e.value, eventId: e.id } as Prisma.InputJsonValue,
+    }));
+
+    if (rows.length === 0) return 0;
+
+    const result = await prisma.eventLog.createMany({
+      data: rows,
+      skipDuplicates: true,
+    });
+
+    if (result.count < rows.length) {
+      logger.debug({ skipped: rows.length - result.count }, 'Duplicate events skipped');
+    }
+
+    return result.count;
+  }
+
+  async getEventsForLedger(ledger: number): Promise<Array<{ id: string; topic: string; txHash: string }>> {
+    return prisma.eventLog.findMany({
+      where: { ledger },
+      select: { id: true, topic: true, txHash: true },
+    });
+  }
+
+  async count(): Promise<number> {
+    return prisma.eventLog.count();
+  }
+}

--- a/backend/src/indexer/index.ts
+++ b/backend/src/indexer/index.ts
@@ -1,0 +1,5 @@
+export { SorobanClient } from './soroban.client.js';
+export { CursorStore } from './cursor.store.js';
+export { EventLogStore } from './event-log.store.js';
+export { IndexerService } from './indexer.service.js';
+export type { IndexedEvent, IndexerStatus } from './indexer.types.js';

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -1,0 +1,98 @@
+import { config } from '../config/index.js';
+import { logger } from '../common/utils/logger.js';
+import { SorobanClient } from './soroban.client.js';
+import { CursorStore } from './cursor.store.js';
+import { EventLogStore } from './event-log.store.js';
+import { registerClosable } from '../common/utils/lifecycle.js';
+import type { IndexerStatus } from './indexer.types.js';
+
+export class IndexerService {
+  private client: SorobanClient;
+  private cursors: CursorStore;
+  private events: EventLogStore;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private status: IndexerStatus = { state: 'stopped' };
+  private contractId: string | null;
+
+  constructor(options?: {
+    client?: SorobanClient;
+    cursors?: CursorStore;
+    events?: EventLogStore;
+    contractId?: string;
+  }) {
+    this.client = options?.client ?? new SorobanClient();
+    this.cursors = options?.cursors ?? new CursorStore();
+    this.events = options?.events ?? new EventLogStore();
+    this.contractId = options?.contractId ?? config.stellar.contractId ?? null;
+  }
+
+  getStatus(): IndexerStatus {
+    return this.status;
+  }
+
+  async start(): Promise<void> {
+    if (this.timer) return;
+
+    registerClosable({
+      name: 'Indexer',
+      close: async () => this.stop(),
+    });
+
+    const startLedger = config.indexer.startLedger ?? (await this.cursors.get('contract_events')) ?? undefined;
+
+    if (startLedger !== undefined) {
+      logger.info({ startLedger }, 'Indexer catching up from saved cursor');
+      await this.processLedgerRange(startLedger);
+    } else {
+      const latest = await this.client.getLatestLedger();
+      logger.info({ latestLedger: latest }, 'Indexer starting from latest ledger');
+      await this.cursors.advance('contract_events', latest);
+    }
+
+    this.timer = setInterval(() => {
+      this.poll().catch((err) => {
+        logger.error({ err }, 'Indexer poll cycle failed');
+        this.status = { state: 'error', message: String(err) };
+      });
+    }, config.indexer.pollIntervalMs);
+
+    logger.info({ pollIntervalMs: config.indexer.pollIntervalMs }, 'Indexer started');
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.status = { state: 'stopped' };
+    logger.info('Indexer stopped');
+  }
+
+  private async poll(): Promise<void> {
+    const lastProcessed = await this.cursors.get('contract_events');
+    const targetLedger = await this.client.getLatestLedger();
+
+    if (lastProcessed !== null && lastProcessed >= targetLedger) {
+      return;
+    }
+
+    const fromLedger = lastProcessed !== null ? lastProcessed + 1 : targetLedger;
+    this.status = { state: 'running', currentLedger: fromLedger, targetLedger };
+    await this.processLedgerRange(fromLedger, targetLedger);
+  }
+
+  private async processLedgerRange(fromLedger: number, toLedger?: number): Promise<void> {
+    const contractIds = this.contractId ? [this.contractId] : undefined;
+    const events = await this.client.getAllEvents(fromLedger, { contractIds });
+    if (events.length === 0) {
+      await this.cursors.advance('contract_events', toLedger ?? fromLedger);
+      return;
+    }
+
+    await this.events.persist(events);
+
+    const maxLedger = Math.max(...events.map((e) => e.ledger));
+    await this.cursors.advance('contract_events', maxLedger);
+    logger.debug({ count: events.length, maxLedger }, 'Indexer processed events');
+  }
+}

--- a/backend/src/indexer/indexer.test.ts
+++ b/backend/src/indexer/indexer.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { SorobanClient } from './soroban.client.js';
+import { CursorStore } from './cursor.store.js';
+import { EventLogStore } from './event-log.store.js';
+import { IndexerService } from './indexer.service.js';
+
+const { mockGetLatestLedger, mockGetEvents, mockIndexerCursorFindUnique, mockIndexerCursorUpsert, mockEventLogCreateMany, mockEventLogFindMany } = vi.hoisted(() => ({
+  mockGetLatestLedger: vi.fn(),
+  mockGetEvents: vi.fn(),
+  mockIndexerCursorFindUnique: vi.fn(),
+  mockIndexerCursorUpsert: vi.fn(),
+  mockEventLogCreateMany: vi.fn(),
+  mockEventLogFindMany: vi.fn(),
+}));
+
+vi.mock('@stellar/stellar-sdk', () => ({
+  SorobanRpc: {
+    Server: vi.fn(() => ({
+      getLatestLedger: mockGetLatestLedger,
+      getEvents: mockGetEvents,
+    })),
+  },
+}));
+
+vi.mock('../db/prisma.js', () => ({
+  prisma: {
+    indexerCursor: {
+      findUnique: mockIndexerCursorFindUnique,
+      upsert: mockIndexerCursorUpsert,
+    },
+    eventLog: {
+      createMany: mockEventLogCreateMany,
+      findMany: mockEventLogFindMany,
+      count: vi.fn(),
+    },
+  },
+}));
+
+const mockEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: '0000000000000001-0000000001',
+  type: 'contract',
+  ledger: 100,
+  ledgerClosedAt: '2024-01-15T00:00:00Z',
+  pagingToken: '100-1',
+  inSuccessfulContractCall: true,
+  txHash: 'abc123def456',
+  contractId: { toString: () => 'CDLZFC3SYJYDZT7K3V6X5J3BZRKLMRLQKLMJFL7LRB7YH5R5R5R5R5R5' },
+  topic: [{ sym: 'tip_sent' }],
+  value: { type: 'scvMap' },
+  ...overrides,
+});
+
+describe('SorobanClient', () => {
+  let client: SorobanClient | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    client?.destroy();
+    client = null;
+  });
+
+  it('returns latest ledger sequence', async () => {
+    mockGetLatestLedger.mockResolvedValue({ sequence: 500 });
+    client = new SorobanClient({ rpcUrl: 'http://localhost:8000' });
+    const result = await client.getLatestLedger();
+    expect(result).toBe(500);
+  });
+
+  it('fetches and processes events', async () => {
+    mockGetEvents.mockResolvedValue({
+      events: [
+        mockEvent(),
+        mockEvent({
+          id: '0000000000000001-0000000002',
+          topic: [{ sym: 'tip_withdrawn' }],
+          ledger: 101,
+          pagingToken: '101-1',
+        }),
+      ],
+      latestLedger: 101,
+    });
+
+    client = new SorobanClient({ rpcUrl: 'http://localhost:8000' });
+    const result = await client.fetchEvents(100);
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0].topic).toBe('tip_sent');
+    expect(result.events[1].topic).toBe('tip_withdrawn');
+    expect(result.events[0].ledger).toBe(100);
+    expect(result.events[0].txHash).toBe('abc123def456');
+    expect(result.cursor).toBeNull();
+  });
+
+  it('filters out failed contract calls', async () => {
+    mockGetEvents.mockResolvedValue({
+      events: [
+        mockEvent(),
+        mockEvent({ inSuccessfulContractCall: false }),
+      ],
+      latestLedger: 100,
+    });
+
+    client = new SorobanClient({ rpcUrl: 'http://localhost:8000' });
+    const result = await client.fetchEvents(100);
+    expect(result.events).toHaveLength(1);
+  });
+
+  it('paginates through multiple pages', async () => {
+    mockGetEvents
+      .mockResolvedValueOnce({
+        events: Array.from({ length: 100 }, (_, i) => mockEvent({ id: `evt-${i}`, pagingToken: `100-${i}` })),
+        latestLedger: 200,
+      })
+      .mockResolvedValueOnce({
+        events: [mockEvent({ id: 'evt-last', ledger: 150, pagingToken: '150-0' })],
+        latestLedger: 200,
+      });
+
+    client = new SorobanClient({ rpcUrl: 'http://localhost:8000', requestsPerSecond: 1000 });
+    const events = await client.getAllEvents(100);
+    expect(events).toHaveLength(101);
+    expect(mockGetEvents).toHaveBeenCalledTimes(2);
+    expect(mockGetEvents).toHaveBeenNthCalledWith(1, {
+      startLedger: 100,
+      filters: [],
+      cursor: undefined,
+      limit: 100,
+    });
+    expect(mockGetEvents).toHaveBeenNthCalledWith(2, {
+      startLedger: 100,
+      filters: [],
+      cursor: '100-99',
+      limit: 100,
+    });
+  });
+
+  it('uses contractIds filter when provided', async () => {
+    mockGetEvents.mockResolvedValue({
+      events: [],
+      latestLedger: 100,
+    });
+
+    client = new SorobanClient({ rpcUrl: 'http://localhost:8000' });
+    await client.fetchEvents(100, { contractIds: ['CA3D...'] });
+    expect(mockGetEvents).toHaveBeenCalledWith({
+      startLedger: 100,
+      filters: [expect.objectContaining({ contractIds: ['CA3D...'] })],
+      cursor: undefined,
+      limit: 100,
+    });
+  });
+});
+
+describe('CursorStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when no cursor exists', async () => {
+    mockIndexerCursorFindUnique.mockResolvedValue(null);
+    const store = new CursorStore();
+    const result = await store.get('contract_events');
+    expect(result).toBeNull();
+  });
+
+  it('returns lastLedger when cursor exists', async () => {
+    mockIndexerCursorFindUnique.mockResolvedValue({ topic: 'contract_events', lastLedger: 150 });
+    const store = new CursorStore();
+    const result = await store.get('contract_events');
+    expect(result).toBe(150);
+  });
+
+  it('upserts on advance', async () => {
+    mockIndexerCursorUpsert.mockResolvedValue({});
+    const store = new CursorStore();
+    await store.advance('contract_events', 200);
+    expect(mockIndexerCursorUpsert).toHaveBeenCalledWith({
+      where: { topic: 'contract_events' },
+      update: { lastLedger: 200 },
+      create: { topic: 'contract_events', lastLedger: 200 },
+    });
+  });
+});
+
+describe('EventLogStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists events with deterministic IDs', async () => {
+    mockEventLogCreateMany.mockResolvedValue({ count: 2 });
+
+    const store = new EventLogStore();
+    const count = await store.persist([
+      { id: 'evt-1', txHash: '0xaaa', topic: 'tip_sent', ledger: 100, contractId: '0xccc', value: { type: 'scvMap' } },
+      { id: 'evt-2', txHash: '0xbbb', topic: 'tip_received', ledger: 101, contractId: '0xccc', value: { type: 'scvMap' } },
+    ]);
+
+    expect(count).toBe(2);
+    expect(mockEventLogCreateMany).toHaveBeenCalledOnce();
+    const call = mockEventLogCreateMany.mock.calls[0][0];
+    expect(call.data).toHaveLength(2);
+    expect(call.skipDuplicates).toBe(true);
+    expect(call.data[0].topic).toBe('tip_sent');
+    expect(call.data[0].ledger).toBe(100);
+  });
+
+  it('same events produce same IDs (idempotent)', async () => {
+    const store = new EventLogStore();
+
+    await store.persist([
+      { id: 'evt-1', txHash: '0xaaa', topic: 'tip_sent', ledger: 100, contractId: '0xccc', value: { type: 'scvMap' } },
+    ]);
+
+    const call1 = mockEventLogCreateMany.mock.calls[0][0].data[0].id;
+
+    mockEventLogCreateMany.mockClear();
+
+    await store.persist([
+      { id: 'evt-1', txHash: '0xaaa', topic: 'tip_sent', ledger: 100, contractId: '0xccc', value: { type: 'scvMap' } },
+    ]);
+
+    const call2 = mockEventLogCreateMany.mock.calls[0][0].data[0].id;
+    expect(call1).toBe(call2);
+  });
+
+  it('returns zero for empty input', async () => {
+    const store = new EventLogStore();
+    const count = await store.persist([]);
+    expect(count).toBe(0);
+    expect(mockEventLogCreateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('IndexerService', () => {
+  let service: IndexerService | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (service) {
+      await service.stop();
+      service = null;
+    }
+  });
+
+  it('starts and processes from latest ledger when no cursor', async () => {
+    mockGetLatestLedger.mockResolvedValue({ sequence: 300 });
+    mockIndexerCursorFindUnique.mockResolvedValue(null);
+    mockIndexerCursorUpsert.mockResolvedValue({});
+
+    service = new IndexerService({
+      client: new SorobanClient({ rpcUrl: 'http://localhost:8000' }),
+    });
+
+    await service.start();
+    await service.stop();
+    expect(mockIndexerCursorUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ create: expect.objectContaining({ lastLedger: 300 }) }),
+    );
+  });
+
+  it('resumes from saved cursor', async () => {
+    mockGetLatestLedger.mockResolvedValue({ sequence: 300 });
+    mockIndexerCursorFindUnique.mockResolvedValue({ topic: 'contract_events', lastLedger: 100 });
+    mockGetEvents.mockResolvedValue({
+      events: [mockEvent({ ledger: 101 })],
+      latestLedger: 300,
+    });
+    mockEventLogCreateMany.mockResolvedValue({ count: 1 });
+    mockIndexerCursorUpsert.mockResolvedValue({});
+
+    service = new IndexerService({
+      client: new SorobanClient({ rpcUrl: 'http://localhost:8000' }),
+    });
+
+    await service.start();
+    await service.stop();
+    expect(mockGetEvents).toHaveBeenCalled();
+    expect(mockEventLogCreateMany).toHaveBeenCalled();
+  });
+
+  it('catch-up processes ledger range when cursor behind', async () => {
+    mockIndexerCursorFindUnique.mockResolvedValue({ topic: 'contract_events', lastLedger: 50 });
+    mockGetLatestLedger.mockResolvedValue({ sequence: 200 });
+    mockGetEvents
+      .mockResolvedValueOnce({
+        events: [mockEvent({ ledger: 60, id: 'evt-60' })],
+        latestLedger: 200,
+      });
+    mockEventLogCreateMany.mockResolvedValue({ count: 1 });
+    mockIndexerCursorUpsert.mockResolvedValue({});
+
+    service = new IndexerService({
+      client: new SorobanClient({ rpcUrl: 'http://localhost:8000' }),
+    });
+
+    await service.start();
+    await service.stop();
+    expect(mockGetEvents).toHaveBeenCalled();
+  });
+});

--- a/backend/src/indexer/indexer.types.ts
+++ b/backend/src/indexer/indexer.types.ts
@@ -1,0 +1,28 @@
+export interface IndexedEvent {
+  id: string;
+  topic: string;
+  ledger: number;
+  txHash: string;
+  contractId: string;
+  data: Record<string, unknown>;
+}
+
+export interface GetEventsFilter {
+  contractIds?: string[];
+  limit?: number;
+}
+
+export type IndexerStatus =
+  | { state: 'stopped' }
+  | { state: 'running'; currentLedger: number; targetLedger: number }
+  | { state: 'error'; message: string };
+
+export function parseEventTopic(event: { topic: unknown[] }): string {
+  if (event.topic.length === 0) return 'unknown';
+  const first = event.topic[0];
+  if (first && typeof first === 'object' && 'sym' in (first as Record<string, unknown>)) {
+    const sym = (first as Record<string, unknown>).sym;
+    if (typeof sym === 'string') return sym;
+  }
+  return String(first ?? 'unknown');
+}

--- a/backend/src/indexer/soroban.client.ts
+++ b/backend/src/indexer/soroban.client.ts
@@ -1,0 +1,108 @@
+import { SorobanRpc, Contract } from '@stellar/stellar-sdk';
+import { config } from '../config/index.js';
+import { ApiQueue } from './throttle.js';
+import { parseEventTopic } from './indexer.types.js';
+
+export interface SorobanClientOptions {
+  rpcUrl?: string;
+  requestsPerSecond?: number;
+}
+
+export interface ProcessedEvent {
+  id: string;
+  topic: string;
+  ledger: number;
+  txHash: string;
+  contractId: string;
+  value: Record<string, unknown>;
+  ledgerClosedAt: string;
+}
+
+export class SorobanClient {
+  private server: SorobanRpc.Server;
+  private queue: ApiQueue;
+
+  constructor(options?: SorobanClientOptions) {
+    const rpcUrl = options?.rpcUrl ?? config.stellar.rpcUrl;
+    this.server = new SorobanRpc.Server(rpcUrl, {
+      allowHttp: rpcUrl.startsWith('http://'),
+    });
+    this.queue = new ApiQueue(options?.requestsPerSecond ?? 10);
+  }
+
+  async getLatestLedger(): Promise<number> {
+    return this.queue.add(async () => {
+      const ledger = await this.server.getLatestLedger();
+      return ledger.sequence;
+    });
+  }
+
+  async fetchEvents(
+    startLedger: number,
+    options?: { contractIds?: string[]; limit?: number; cursor?: string },
+  ): Promise<{ events: ProcessedEvent[]; latestLedger: number; cursor: string | null }> {
+    return this.queue.add(async () => {
+      const filters: SorobanRpc.Api.EventFilter[] = [];
+      if (options?.contractIds?.length) {
+        filters.push({ contractIds: options.contractIds });
+      }
+
+      const response: SorobanRpc.Api.GetEventsResponse = await this.server.getEvents({
+        startLedger,
+        filters,
+        cursor: options?.cursor,
+        limit: options?.limit ?? 100,
+      });
+
+      const events = response.events
+        .filter((e) => e.inSuccessfulContractCall)
+        .map((e) => ({
+          id: e.id,
+          topic: parseEventTopic({ topic: e.topic }),
+          ledger: e.ledger,
+          txHash: e.txHash,
+          contractId: contractIdToString(e.contractId),
+          value: { pagingToken: e.pagingToken },
+          ledgerClosedAt: e.ledgerClosedAt,
+        }));
+
+      const limit = options?.limit ?? 100;
+      const nextCursor =
+        events.length === limit && events.length > 0
+          ? events[events.length - 1].value.pagingToken
+          : null;
+
+      return {
+        events,
+        latestLedger: response.latestLedger,
+        cursor: nextCursor,
+      };
+    });
+  }
+
+  destroy(): void {
+    this.queue.destroy();
+  }
+
+  async getAllEvents(
+    startLedger: number,
+    options?: { contractIds?: string[]; limit?: number },
+  ): Promise<ProcessedEvent[]> {
+    const allEvents: ProcessedEvent[] = [];
+    let cursor: string | null = null;
+
+    do {
+      const result = await this.fetchEvents(startLedger, { ...options, cursor: cursor ?? undefined });
+      allEvents.push(...result.events);
+      cursor = result.cursor;
+    } while (cursor);
+
+    return allEvents;
+  }
+}
+
+function contractIdToString(id: string | Contract | undefined): string {
+  if (!id) return '';
+  if (typeof id === 'string') return id;
+  return id.toString();
+}

--- a/backend/src/indexer/throttle.ts
+++ b/backend/src/indexer/throttle.ts
@@ -1,0 +1,45 @@
+export class ApiQueue {
+  private queue: Array<{
+    fn: () => Promise<unknown>;
+    resolve: (value: unknown) => void;
+    reject: (err: unknown) => void;
+  }> = [];
+  private intervalMs: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(requestsPerSecond: number) {
+    this.intervalMs = Math.max(100, Math.round(1000 / Math.max(1, requestsPerSecond)));
+  }
+
+  add<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({ fn: fn as () => Promise<unknown>, resolve: resolve as (v: unknown) => void, reject });
+      this.start();
+    });
+  }
+
+  private start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      const item = this.queue.shift();
+      if (item) {
+        item.fn().then(item.resolve).catch(item.reject);
+      }
+      if (this.queue.length === 0) {
+        this.stop();
+      }
+    }, this.intervalMs);
+  }
+
+  private stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  destroy(): void {
+    this.stop();
+    this.queue.length = 0;
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import { logger } from './common/utils/logger.js';
 import { prisma } from './db/prisma.js';
 import { redis } from './db/redis.js';
 import { registerClosable, closeAll } from './common/utils/lifecycle.js';
+import { IndexerService } from './indexer/indexer.service.js';
 
 /** Process entry point: starts the HTTP server (and, later, the WebSocket + indexer). */
 async function bootstrap(): Promise<void> {
@@ -22,6 +23,10 @@ async function bootstrap(): Promise<void> {
       await redis.quit();
     },
   });
+
+  // Start the on-chain event indexer.
+  const indexer = new IndexerService();
+  indexer.start().catch((err) => logger.error({ err }, 'Indexer failed to start'));
 
   // The realtime gateway (Socket.IO) attaches to this httpServer — see the realtime issues.
   // initRealtime(httpServer);


### PR DESCRIPTION
## Summary

Creates the `backend/src/indexer/` module: a typed Soroban RPC client wrapper with idempotent cursor tracking and event persistence, plus a polling indexer service.

## Changes

### `src/indexer/soroban.client.ts`
- Typed wrapper around `SorobanRpc.Server` with rate-limited `ApiQueue`
- `getLatestLedger()` — returns the latest ledger sequence
- `fetchEvents()` — fetches events with contract filtering and cursor-based pagination
- `getAllEvents()` — auto-paginates through all events from a starting ledger

### `src/indexer/cursor.store.ts`
- `CursorStore` — reads/advances `IndexerCursor` via Prisma upsert
- Idempotent: re-running the same ledger range updates the cursor without conflict

### `src/indexer/event-log.store.ts`
- `EventLogStore` — persists decoded events as `EventLog` rows with deterministic SHA-256 IDs
- Uses `createMany({ skipDuplicates: true })` — re-processing the same events skips existing rows

### `src/indexer/throttle.ts`
- `ApiQueue` — simple rate limiter for Soroban RPC calls (configurable requests/sec)

### `src/indexer/indexer.service.ts`
- `IndexerService` — polling loop that reads the last processed ledger, fetches new events, persists them idempotently, and advances the cursor
- Registers for graceful shutdown

### `src/indexer/indexer.test.ts`
- 14 tests covering all components

### `src/server.ts`
- Indexer starts automatically in `bootstrap()`

## Idempotency
- Cursors: `IndexerCursor.upsert` — same topic + ledger = no-op update
- Events: deterministic IDs from sha256 + `createMany(skipDuplicates)` — replaying the same ledger produces zero new rows

Closes #890
