### PR TITLE
feat(tips,indexer): tip status lifecycle, cursor pagination, DTO serializer, indexer cursor tests

### DIFF
--- a/backend/src/indexer/cursor.test.ts
+++ b/backend/src/indexer/cursor.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCursorLedger, setCursorLedger } from './cursor.js';
+
+const { mockFindUnique, mockUpsert } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockUpsert: vi.fn(),
+}));
+
+vi.mock('../db/prisma.js', () => ({
+  prisma: {
+    indexerCursor: {
+      findUnique: mockFindUnique,
+      upsert: mockUpsert,
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getCursorLedger', () => {
+  it('returns null when no cursor row exists', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    expect(await getCursorLedger('tip_sent')).toBeNull();
+  });
+
+  it('returns lastLedger from a stored row', async () => {
+    mockFindUnique.mockResolvedValue({ topic: 'tip_sent', lastLedger: 42 });
+    expect(await getCursorLedger('tip_sent')).toBe(42);
+  });
+
+  it('scopes lookup to the given topic', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    await getCursorLedger('subscription_charged');
+    expect(mockFindUnique).toHaveBeenCalledWith({ where: { topic: 'subscription_charged' } });
+  });
+});
+
+describe('setCursorLedger', () => {
+  it('upserts with the correct shape', async () => {
+    mockUpsert.mockResolvedValue({});
+    await setCursorLedger('tip_sent', 100);
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: { topic: 'tip_sent' },
+      create: { topic: 'tip_sent', lastLedger: 100 },
+      update: { lastLedger: 100 },
+    });
+  });
+
+  it('is idempotent — calling twice with the same ledger upserts twice without error', async () => {
+    mockUpsert.mockResolvedValue({});
+    await setCursorLedger('tip_sent', 50);
+    await setCursorLedger('tip_sent', 50);
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('advances the cursor to a higher ledger', async () => {
+    mockUpsert.mockResolvedValue({});
+    await setCursorLedger('tip_sent', 99);
+    await setCursorLedger('tip_sent', 100);
+    const secondCall = mockUpsert.mock.calls[1][0];
+    expect(secondCall.update.lastLedger).toBe(100);
+  });
+});

--- a/backend/src/indexer/projections.test.ts
+++ b/backend/src/indexer/projections.test.ts
@@ -42,12 +42,32 @@ const event = (topic: string, value: unknown, overrides: Partial<DecodedEvent> =
   ...overrides,
 });
 
-const ADDR_A = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
-const ADDR_B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const ADDR_A = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const ADDR_B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+const tipEvent: DecodedEvent = {
+  ledger: 100,
+  txHash: 'aabbcc001122',
+  pagingToken: '100-0',
+  topic: 'tip_sent',
+  value: {
+    from: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFGHIJKL',
+    to: 'GDEF1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFGHIJKL',
+    amount: '5000000',
+    message: 'Great content!',
+  },
+};
+
+const nonTipEvent: DecodedEvent = {
+  ledger: 101,
+  txHash: 'ddeeff334455',
+  pagingToken: '101-0',
+  topic: 'subscription_charged',
+  value: { subscriber: 'GABC', creator: 'GDEF' },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // ensureUserId / profile upsert resolve a deterministic id per address.
   mockUserUpsert.mockImplementation(async (args: { where: { stellarAddress: string } }) => ({
     id: 'u_' + args.where.stellarAddress,
   }));
@@ -216,5 +236,78 @@ describe('projectEvent — subscriptions (#900)', () => {
   it('skips a sub_created with an unparseable amount', async () => {
     await projectEvent(event('sub_created', [ADDR_A, ADDR_B, 'nope', 7]));
     expect(mockSubUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('projectEvent — tip idempotency (#892)', () => {
+  it('persists a new tip event and upserts the Tip row', async () => {
+    mockEventLogFindFirst.mockResolvedValue(null);
+    mockEventLogCreate.mockResolvedValue({});
+    mockTipUpsert.mockResolvedValue({});
+
+    await projectEvent(tipEvent);
+
+    expect(mockEventLogCreate).toHaveBeenCalledOnce();
+    expect(mockTipUpsert).toHaveBeenCalledOnce();
+    expect(mockTipUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { txHash: tipEvent.txHash },
+        update: {},
+      }),
+    );
+  });
+
+  it('skips duplicate event log on re-run over the same ledger', async () => {
+    mockEventLogFindFirst.mockResolvedValue({ id: 'existing' });
+    mockTipUpsert.mockResolvedValue({});
+
+    await projectEvent(tipEvent);
+
+    expect(mockEventLogCreate).not.toHaveBeenCalled();
+    expect(mockTipUpsert).toHaveBeenCalledOnce();
+  });
+
+  it('produces no duplicate Tip rows when replayed over the same events', async () => {
+    mockEventLogFindFirst.mockResolvedValueOnce(null);
+    mockEventLogCreate.mockResolvedValueOnce({});
+    mockTipUpsert.mockResolvedValueOnce({});
+    await projectEvent(tipEvent);
+
+    mockEventLogFindFirst.mockResolvedValueOnce({ id: 'existing' });
+    mockTipUpsert.mockResolvedValueOnce({});
+    await projectEvent(tipEvent);
+
+    expect(mockEventLogCreate).toHaveBeenCalledTimes(1);
+    expect(mockTipUpsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not upsert a Tip for non-tip topics', async () => {
+    mockEventLogFindFirst.mockResolvedValue(null);
+    mockEventLogCreate.mockResolvedValue({});
+
+    await projectEvent(nonTipEvent);
+
+    expect(mockEventLogCreate).toHaveBeenCalledOnce();
+    expect(mockTipUpsert).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning and skips Tip upsert when value is unparseable', async () => {
+    mockEventLogFindFirst.mockResolvedValue(null);
+    mockEventLogCreate.mockResolvedValue({});
+
+    const badEvent: DecodedEvent = { ...tipEvent, value: null };
+    await expect(projectEvent(badEvent)).resolves.not.toThrow();
+    expect(mockTipUpsert).not.toHaveBeenCalled();
+  });
+
+  it('handles tip topic alias "tip" the same as "tip_sent"', async () => {
+    mockEventLogFindFirst.mockResolvedValue(null);
+    mockEventLogCreate.mockResolvedValue({});
+    mockTipUpsert.mockResolvedValue({});
+
+    const aliasEvent: DecodedEvent = { ...tipEvent, topic: 'tip' };
+    await projectEvent(aliasEvent);
+
+    expect(mockTipUpsert).toHaveBeenCalledOnce();
   });
 });

--- a/backend/src/modules/tips/tips.controller.ts
+++ b/backend/src/modules/tips/tips.controller.ts
@@ -6,6 +6,7 @@ import {
   tipsListQuerySchema,
   getTipsQuerySchema,
   recordTipSchema,
+  confirmTipParamSchema,
 } from './tips.schema.js';
 import * as tipsService from './tips.service.js';
 
@@ -66,6 +67,17 @@ export async function record(req: Request, res: Response, next: NextFunction): P
   try {
     const input = recordTipSchema.parse(req.body);
     const tip = await tipsService.recordTip(input);
+    res.status(200).json({ data: tip });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** PATCH /tips/:txHash/confirm — transition tip to CONFIRMED, idempotent. */
+export async function confirm(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { txHash } = confirmTipParamSchema.parse(req.params);
+    const tip = await tipsService.confirmTip(txHash);
     res.status(200).json({ data: tip });
   } catch (err) {
     next(err);

--- a/backend/src/modules/tips/tips.dto.ts
+++ b/backend/src/modules/tips/tips.dto.ts
@@ -1,0 +1,11 @@
+export interface TipResponseDto {
+  id: string;
+  txHash: string;
+  ledger: number;
+  fromAddress: string;
+  toAddress: string;
+  amountStroops: string;
+  status: string;
+  message: string | null;
+  createdAt: string;
+}

--- a/backend/src/modules/tips/tips.routes.ts
+++ b/backend/src/modules/tips/tips.routes.ts
@@ -10,6 +10,7 @@ tipsRouter.get('/', tipsController.getTips);
 tipsRouter.post('/', tipsController.record);
 tipsRouter.post('/prepare', tipsController.prepare);
 tipsRouter.get('/:id', tipsController.getById);
+tipsRouter.patch('/:txHash/confirm', tipsController.confirm);
 
 /** Mounted under `${API_BASE_PATH}/profiles` — tips received by a profile. */
 export const profileTipsRouter = Router();
@@ -82,6 +83,26 @@ mergeOpenApiPaths({
       responses: {
         '200': { description: 'Tip found' },
         '400': { description: 'Validation error' },
+        '404': { description: 'Tip not found' },
+      },
+    },
+  },
+  [`${base}/{txHash}/confirm`]: {
+    patch: {
+      tags: ['Tips'],
+      summary: 'Confirm a pending tip',
+      description: 'Transitions a tip from PENDING to CONFIRMED. Idempotent — calling on an already-CONFIRMED tip is a no-op.',
+      parameters: [
+        {
+          name: 'txHash',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+          description: 'Transaction hash of the tip to confirm',
+        },
+      ],
+      responses: {
+        '200': { description: 'Tip confirmed (or already confirmed)' },
         '404': { description: 'Tip not found' },
       },
     },

--- a/backend/src/modules/tips/tips.schema.ts
+++ b/backend/src/modules/tips/tips.schema.ts
@@ -52,3 +52,10 @@ export const recordTipSchema = z.object({
 });
 
 export type RecordTipInput = z.infer<typeof recordTipSchema>;
+
+/** Path params for `PATCH /tips/:txHash/confirm`. */
+export const confirmTipParamSchema = z.object({
+  txHash: z.string().min(1, 'txHash is required'),
+});
+
+export type ConfirmTipParam = z.infer<typeof confirmTipParamSchema>;

--- a/backend/src/modules/tips/tips.serializer.test.ts
+++ b/backend/src/modules/tips/tips.serializer.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { serializeTip } from './tips.serializer.js';
+import type { Tip } from '@prisma/client';
+
+function makeTip(overrides: Partial<Tip> = {}): Tip {
+  return {
+    id: 'clh0000000001',
+    txHash: 'deadbeef0001',
+    ledger: 100,
+    fromAddress: 'GABC',
+    toAddress: 'GDEF',
+    amountStroops: BigInt(5_000_000),
+    status: 'PENDING',
+    message: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    networkFee: BigInt(0),
+    tokenCode: 'XLM',
+    isAnonymous: false,
+    senderId: null,
+    recipientId: null,
+    ...overrides,
+  } as Tip;
+}
+
+describe('serializeTip', () => {
+  it('converts BigInt amountStroops to a string', () => {
+    const dto = serializeTip(makeTip({ amountStroops: BigInt(1_234_567) }));
+    expect(dto.amountStroops).toBe('1234567');
+    expect(typeof dto.amountStroops).toBe('string');
+  });
+
+  it('converts createdAt Date to ISO 8601 string', () => {
+    const date = new Date('2026-06-15T12:30:00.000Z');
+    const dto = serializeTip(makeTip({ createdAt: date }));
+    expect(dto.createdAt).toBe('2026-06-15T12:30:00.000Z');
+  });
+
+  it('preserves the status field as a string', () => {
+    const dto = serializeTip(makeTip({ status: 'PENDING' }));
+    expect(dto.status).toBe('PENDING');
+  });
+
+  it('serializes CONFIRMED status correctly', () => {
+    const dto = serializeTip(makeTip({ status: 'CONFIRMED' }));
+    expect(dto.status).toBe('CONFIRMED');
+  });
+
+  it('passes through a null message', () => {
+    const dto = serializeTip(makeTip({ message: null }));
+    expect(dto.message).toBeNull();
+  });
+
+  it('passes through a non-null message', () => {
+    const dto = serializeTip(makeTip({ message: 'Great content!' }));
+    expect(dto.message).toBe('Great content!');
+  });
+
+  it('maps all fields correctly', () => {
+    const tip = makeTip({
+      id: 'clh_abc123',
+      txHash: 'txhash001',
+      ledger: 200,
+      fromAddress: 'GSENDER',
+      toAddress: 'GRECEIVER',
+      amountStroops: BigInt(999),
+      status: 'PENDING',
+      message: 'Hello',
+      createdAt: new Date('2026-03-01T00:00:00.000Z'),
+    });
+    const dto = serializeTip(tip);
+    expect(dto).toMatchObject({
+      id: 'clh_abc123',
+      txHash: 'txhash001',
+      ledger: 200,
+      fromAddress: 'GSENDER',
+      toAddress: 'GRECEIVER',
+      amountStroops: '999',
+      status: 'PENDING',
+      message: 'Hello',
+      createdAt: '2026-03-01T00:00:00.000Z',
+    });
+  });
+});

--- a/backend/src/modules/tips/tips.serializer.ts
+++ b/backend/src/modules/tips/tips.serializer.ts
@@ -1,0 +1,16 @@
+import type { Tip } from '@prisma/client';
+import type { TipResponseDto } from './tips.dto.js';
+
+export function serializeTip(tip: Tip): TipResponseDto {
+  return {
+    id: tip.id,
+    txHash: tip.txHash,
+    ledger: tip.ledger,
+    fromAddress: tip.fromAddress,
+    toAddress: tip.toAddress,
+    amountStroops: tip.amountStroops.toString(),
+    status: tip.status,
+    message: tip.message,
+    createdAt: tip.createdAt.toISOString(),
+  };
+}

--- a/backend/src/modules/tips/tips.service.ts
+++ b/backend/src/modules/tips/tips.service.ts
@@ -1,28 +1,21 @@
 import { Contract, TransactionBuilder, SorobanRpc, nativeToScVal, Networks } from '@stellar/stellar-sdk';
 import { Prisma } from '@prisma/client';
-import type { Tip } from '@prisma/client';
 import { config } from '../../config/index.js';
 import { prisma } from '../../db/prisma.js';
 import { BadRequestError, NotFoundError } from '../../common/errors/AppError.js';
 import { logger } from '../../common/utils/logger.js';
+import { TipStatus } from '../../types/enums.js';
 import type { RecordTipInput } from './tips.schema.js';
+import { serializeTip } from './tips.serializer.js';
+import type { TipResponseDto } from './tips.dto.js';
+
+export type { TipResponseDto };
 
 export interface GetTipsParams {
   cursor?: string;
   limit: number;
   address?: string;
   direction?: string;
-}
-
-export interface TipResult {
-  id: string;
-  txHash: string;
-  ledger: number;
-  fromAddress: string;
-  toAddress: string;
-  amountStroops: string;
-  message: string | null;
-  createdAt: Date;
 }
 
 export interface PreparedTip {
@@ -34,9 +27,14 @@ export interface PreparedTip {
   networkPassphrase: string;
 }
 
+export interface PaginatedTips {
+  data: TipResponseDto[];
+  nextCursor: string | null;
+}
+
 export async function getPaginatedTips(
   params: GetTipsParams,
-): Promise<{ data: TipResult[]; nextCursor: string | null }> {
+): Promise<PaginatedTips> {
   const where: Record<string, unknown> = {};
   if (params.address) {
     if (params.direction === 'sent') {
@@ -70,10 +68,7 @@ export async function getPaginatedTips(
   const nextCursor = hasMore && results.length > 0 ? results[results.length - 1].id : null;
 
   return {
-    data: results.map((t) => ({
-      ...t,
-      amountStroops: t.amountStroops.toString(),
-    })),
+    data: results.map(serializeTip),
     nextCursor,
   };
 }
@@ -139,29 +134,11 @@ export async function prepareTip(
   };
 }
 
-export interface PaginatedTips {
-  data: TipResult[];
-  nextCursor: string | null;
-}
-
-function toTipResult(tip: Tip): TipResult {
-  return {
-    id: tip.id,
-    txHash: tip.txHash,
-    ledger: tip.ledger,
-    fromAddress: tip.fromAddress,
-    toAddress: tip.toAddress,
-    amountStroops: tip.amountStroops.toString(),
-    message: tip.message,
-    createdAt: tip.createdAt,
-  };
-}
-
 /** GET /tips/:id — fetch a single tip by its id. */
-export async function getTipById(id: string): Promise<TipResult> {
+export async function getTipById(id: string): Promise<TipResponseDto> {
   const tip = await prisma.tip.findUnique({ where: { id } });
   if (!tip) throw new NotFoundError('Tip not found');
-  return toTipResult(tip);
+  return serializeTip(tip);
 }
 
 /** Shared cursor-paginated list query, newest first. */
@@ -181,7 +158,7 @@ async function listTips(
   const page = hasMore ? rows.slice(0, limit) : rows;
 
   return {
-    data: page.map(toTipResult),
+    data: page.map(serializeTip),
     nextCursor: hasMore ? page[page.length - 1].id : null,
   };
 }
@@ -212,9 +189,9 @@ export async function getTipsSentByAddress(
  * instead of inserting a duplicate. A Prisma P2002 unique-constraint violation
  * (from a concurrent insert) is handled the same way.
  */
-export async function recordTip(input: RecordTipInput): Promise<TipResult> {
+export async function recordTip(input: RecordTipInput): Promise<TipResponseDto> {
   const existing = await prisma.tip.findUnique({ where: { txHash: input.txHash } });
-  if (existing) return toTipResult(existing);
+  if (existing) return serializeTip(existing);
 
   try {
     const tip = await prisma.tip.create({
@@ -227,13 +204,27 @@ export async function recordTip(input: RecordTipInput): Promise<TipResult> {
         message: input.message,
       },
     });
-    return toTipResult(tip);
+    return serializeTip(tip);
   } catch (err) {
-    // Handle concurrent duplicate insert (race condition on the unique index).
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
       const tip = await prisma.tip.findUnique({ where: { txHash: input.txHash } });
-      if (tip) return toTipResult(tip);
+      if (tip) return serializeTip(tip);
     }
     throw err;
   }
+}
+
+/**
+ * PATCH /tips/:txHash/confirm — transition a tip from PENDING to CONFIRMED.
+ * Idempotent: calling on an already-CONFIRMED tip is a no-op.
+ */
+export async function confirmTip(txHash: string): Promise<TipResponseDto> {
+  const tip = await prisma.tip.findUnique({ where: { txHash } });
+  if (!tip) throw new NotFoundError('Tip not found');
+  if (tip.status === TipStatus.CONFIRMED) return serializeTip(tip);
+  const updated = await prisma.tip.update({
+    where: { txHash },
+    data: { status: TipStatus.CONFIRMED },
+  });
+  return serializeTip(updated);
 }

--- a/backend/src/modules/tips/tips.test.ts
+++ b/backend/src/modules/tips/tips.test.ts
@@ -2,13 +2,22 @@ import request from 'supertest';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createApp } from '../../app.js';
 
-const { mockGetAccount, mockSimulateTransaction, mockContractCall, mockFindMany, mockFindUnique, mockCreate } = vi.hoisted(() => ({
+const {
+  mockGetAccount,
+  mockSimulateTransaction,
+  mockContractCall,
+  mockFindMany,
+  mockFindUnique,
+  mockCreate,
+  mockUpdate,
+} = vi.hoisted(() => ({
   mockGetAccount: vi.fn(),
   mockSimulateTransaction: vi.fn(),
   mockContractCall: vi.fn(),
   mockFindMany: vi.fn(),
   mockFindUnique: vi.fn(),
   mockCreate: vi.fn(),
+  mockUpdate: vi.fn(),
 }));
 
 vi.mock('@stellar/stellar-sdk', () => {
@@ -62,10 +71,40 @@ vi.mock('../../db/prisma.js', () => ({
       findMany: mockFindMany,
       findUnique: mockFindUnique,
       create: mockCreate,
+      update: mockUpdate,
     },
     $disconnect: vi.fn(),
   },
 }));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const now = new Date('2026-06-29T00:00:00.000Z');
+const from = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
+const to   = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBFMF5CKFHGZXABSZLAZP2';
+
+function makeTipRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'clh1234567890',
+    txHash: 'abc123txhash',
+    ledger: 100,
+    fromAddress: from,
+    toAddress: to,
+    amountStroops: BigInt(1_000_000),
+    networkFee: BigInt(0),
+    tokenCode: 'XLM',
+    isAnonymous: false,
+    status: 'PENDING',
+    message: 'Great work!',
+    createdAt: now,
+    updatedAt: now,
+    senderId: null,
+    recipientId: null,
+    ...overrides,
+  };
+}
+
+// ── POST /api/v1/tips/prepare ─────────────────────────────────────────────
 
 describe('POST /api/v1/tips/prepare', () => {
   beforeEach(() => {
@@ -92,7 +131,7 @@ describe('POST /api/v1/tips/prepare', () => {
 
   it('returns prepared transaction on success', async () => {
     mockGetAccount.mockResolvedValue({
-      accountId: () => 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
+      accountId: () => from,
       sequenceNumber: () => '123',
       incrementSequenceNumber: () => {},
     });
@@ -101,30 +140,24 @@ describe('POST /api/v1/tips/prepare', () => {
     const app = createApp();
     const res = await request(app)
       .post('/api/v1/tips/prepare')
-      .send({
-        from: 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
-        to: 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN',
-        amount: '100',
-        message: 'Great content!',
-      });
+      .send({ from, to, amount: '100', message: 'Great content!' });
     expect(res.status).toBe(200);
     expect(res.body.data.unsignedTxXdr).toBeDefined();
     expect(res.body.data.contractId).toBeDefined();
   });
 });
 
-describe('GET /api/v1/tips', () => {
-  const address = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
+// ── GET /api/v1/tips ──────────────────────────────────────────────────────
 
+describe('GET /api/v1/tips', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('returns paginated tips', async () => {
-    const now = new Date();
     mockFindMany.mockResolvedValue([
-      { id: '1', txHash: 'hash-1', ledger: 100, fromAddress: address, toAddress: 'G' + 'X'.repeat(55), amountStroops: BigInt(100), message: 'Nice!', createdAt: now, updatedAt: now },
-      { id: '2', txHash: 'hash-2', ledger: 101, fromAddress: 'G' + 'Y'.repeat(55), toAddress: address, amountStroops: BigInt(200), message: null, createdAt: new Date(now.getTime() + 1000), updatedAt: new Date(now.getTime() + 1000) },
+      makeTipRow({ id: '1', txHash: 'hash-1', ledger: 100, amountStroops: BigInt(100), message: 'Nice!' }),
+      makeTipRow({ id: '2', txHash: 'hash-2', ledger: 101, fromAddress: to, toAddress: from, amountStroops: BigInt(200), message: null }),
     ]);
 
     const app = createApp();
@@ -132,23 +165,16 @@ describe('GET /api/v1/tips', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(2);
     expect(res.body.data[0].amountStroops).toBe('100');
-    expect(res.body.data[1].amountStroops).toBe('200');
+    expect(res.body.data[0].status).toBe('PENDING');
+    expect(res.body.data[0].createdAt).toBe(now.toISOString());
     expect(res.body.nextCursor).toBeNull();
   });
 
   it('includes nextCursor when there are more results', async () => {
     mockFindMany.mockResolvedValue(
-      Array.from({ length: 21 }, (_, i) => ({
-        id: `${i + 1}`,
-        txHash: `hash-${i + 1}`,
-        ledger: 100 + i,
-        fromAddress: address,
-        toAddress: 'G' + 'X'.repeat(55),
-        amountStroops: BigInt((i + 1) * 10),
-        message: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })),
+      Array.from({ length: 21 }, (_, i) =>
+        makeTipRow({ id: `${i + 1}`, txHash: `hash-${i + 1}`, ledger: 100 + i, amountStroops: BigInt((i + 1) * 10) }),
+      ),
     );
 
     const app = createApp();
@@ -169,27 +195,25 @@ describe('GET /api/v1/tips', () => {
   });
 
   it('filters by address', async () => {
-    const now = new Date();
     mockFindMany.mockResolvedValue([
-      { id: '3', txHash: 'hash-3', ledger: 102, fromAddress: address, toAddress: 'G' + 'Z'.repeat(55), amountStroops: BigInt(50), message: null, createdAt: now, updatedAt: now },
+      makeTipRow({ id: '3', txHash: 'hash-3', ledger: 102, amountStroops: BigInt(50), message: null }),
     ]);
 
     const app = createApp();
-    const res = await request(app).get(`/api/v1/tips?address=${address}`);
+    const res = await request(app).get(`/api/v1/tips?address=${from}`);
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
-    expect(res.body.data[0].amountStroops).toBe('50');
   });
 
   it('filters by direction=sent', async () => {
     mockFindMany.mockResolvedValue([]);
 
     const app = createApp();
-    const res = await request(app).get(`/api/v1/tips?address=${address}&direction=sent`);
+    const res = await request(app).get(`/api/v1/tips?address=${from}&direction=sent`);
     expect(res.status).toBe(200);
     expect(mockFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ fromAddress: { equals: address, mode: 'insensitive' } }),
+        where: expect.objectContaining({ fromAddress: { equals: from, mode: 'insensitive' } }),
       }),
     );
   });
@@ -207,9 +231,66 @@ describe('GET /api/v1/tips', () => {
   });
 });
 
+// ── Cursor-chain pagination (#881) ────────────────────────────────────────
+
+describe('GET /api/v1/tips — cursor-based pagination chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses nextCursor from page 1 to request page 2', async () => {
+    const page1Rows = Array.from({ length: 21 }, (_, i) =>
+      makeTipRow({ id: `cuid-${String(i + 1).padStart(5, '0')}`, txHash: `hash-${i}`, ledger: 100 + i, amountStroops: BigInt(i + 1) }),
+    );
+    mockFindMany.mockResolvedValueOnce(page1Rows);
+
+    const app = createApp();
+    const page1 = await request(app).get('/api/v1/tips?limit=20');
+    expect(page1.status).toBe(200);
+    const cursor = page1.body.nextCursor as string;
+    expect(cursor).toBe('cuid-00020');
+
+    mockFindMany.mockResolvedValueOnce([
+      makeTipRow({ id: 'cuid-00021', txHash: 'hash-20', ledger: 120, amountStroops: BigInt(21) }),
+    ]);
+
+    const page2 = await request(app).get(`/api/v1/tips?limit=20&cursor=${cursor}`);
+    expect(page2.status).toBe(200);
+    expect(page2.body.data).toHaveLength(1);
+    expect(page2.body.nextCursor).toBeNull();
+
+    expect(mockFindMany).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        cursor: { id: cursor },
+        skip: 1,
+      }),
+    );
+  });
+
+  it('returns 400 for a non-cuid cursor value', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/tips?cursor=not-a-cuid');
+    expect(res.status).toBe(400);
+  });
+
+  it('nextCursor is null on the last page', async () => {
+    mockFindMany.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) =>
+        makeTipRow({ id: `cuid-${i}`, txHash: `hash-${i}`, ledger: 100 + i }),
+      ),
+    );
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/tips?limit=10');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(5);
+    expect(res.body.nextCursor).toBeNull();
+  });
+});
+
+// ── POST /api/v1/tips — dedupe by txHash ─────────────────────────────────
+
 describe('POST /api/v1/tips — dedupe by txHash', () => {
-  const from = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
-  const to   = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBFMF5CKFHGZXABSZLAZP2';
   const validBody = {
     txHash: 'abc123txhash',
     ledger: 100,
@@ -218,17 +299,7 @@ describe('POST /api/v1/tips — dedupe by txHash', () => {
     amountStroops: '1000000',
     message: 'Great work!',
   };
-  const tipRow = {
-    id: 'clh1234567890',
-    txHash: 'abc123txhash',
-    ledger: 100,
-    fromAddress: from,
-    toAddress: to,
-    amountStroops: BigInt(1_000_000),
-    message: 'Great work!',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
+  const tipRow = makeTipRow();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -250,17 +321,67 @@ describe('POST /api/v1/tips — dedupe by txHash', () => {
     expect(res.status).toBe(200);
     expect(res.body.data.txHash).toBe('abc123txhash');
     expect(res.body.data.amountStroops).toBe('1000000');
+    expect(res.body.data.status).toBe('PENDING');
     expect(mockCreate).toHaveBeenCalledTimes(1);
   });
 
-  it('returns the existing tip and does NOT insert a duplicate when txHash already exists', async () => {
+  it('returns the existing tip without a duplicate insert when txHash already exists', async () => {
     mockFindUnique.mockResolvedValue(tipRow);
 
     const app = createApp();
     const res = await request(app).post('/api/v1/tips').send(validBody);
     expect(res.status).toBe(200);
     expect(res.body.data.txHash).toBe('abc123txhash');
-    // create must not be called — the duplicate was caught by the pre-check
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ── PATCH /api/v1/tips/:txHash/confirm — status lifecycle (#880) ──────────
+
+describe('PATCH /api/v1/tips/:txHash/confirm', () => {
+  const txHash = 'abc123txhash';
+  const pendingRow = makeTipRow({ status: 'PENDING' });
+  const confirmedRow = makeTipRow({ status: 'CONFIRMED' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when the tip does not exist', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app).patch(`/api/v1/tips/${txHash}/confirm`);
+    expect(res.status).toBe(404);
+  });
+
+  it('transitions PENDING → CONFIRMED and returns the updated tip', async () => {
+    mockFindUnique.mockResolvedValue(pendingRow);
+    mockUpdate.mockResolvedValue(confirmedRow);
+
+    const app = createApp();
+    const res = await request(app).patch(`/api/v1/tips/${txHash}/confirm`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('CONFIRMED');
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { txHash },
+      data: { status: 'CONFIRMED' },
+    });
+  });
+
+  it('is idempotent — a CONFIRMED tip is returned as-is without calling update', async () => {
+    mockFindUnique.mockResolvedValue(confirmedRow);
+
+    const app = createApp();
+    const res = await request(app).patch(`/api/v1/tips/${txHash}/confirm`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('CONFIRMED');
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when txHash path param is empty segment', async () => {
+    const app = createApp();
+    const res = await request(app).patch('/api/v1/tips//confirm');
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
Closes #880

---

Closes #881

---

Closes #886

---

Closes #892

---

## Summary

- **#892 — Indexer cursor persistence**: adds `cursor.test.ts` (unit tests for `getCursorLedger`/`setCursorLedger`) and `projections.test.ts` (idempotency fixtures proving re-running over the same ledger range produces no duplicate rows)
- **#886 — Tip response DTO + serializer**: new `tips.dto.ts` (`TipResponseDto` interface) and `tips.serializer.ts` (`serializeTip` pure function converting BigInt→string, Date→ISO 8601, adds `status` field); refactors `tips.service.ts` to use the serializer throughout; new `tips.serializer.test.ts` with 7 unit tests
- **#880 — Tip status lifecycle**: adds `confirmTip(txHash)` service function (PENDING→CONFIRMED, idempotent), `confirmTipParamSchema`, `confirm` controller, and `PATCH /tips/:txHash/confirm` route with OpenAPI spec entry
- **#881 — Tip pagination (cursor-based)**: expands test coverage with cursor-chain tests (verifies `nextCursor` from page 1 is forwarded to Prisma as `{ cursor: { id }, skip: 1 }` on page 2), non-cuid cursor rejection, and last-page null-cursor assertions

## Test plan

- [ ] `cursor.test.ts` — get null when no row, get stored ledger, upsert shape, idempotent writes, monotonic advance
- [ ] `projections.test.ts` — new event persisted + Tip upserted, duplicate event log skipped on replay, Tip upsert still fires (no-op), non-tip topics skip Tip upsert, unparseable value handled gracefully, `tip` alias treated same as `tip_sent`
- [ ] `tips.serializer.test.ts` — BigInt→string, Date→ISO, status/message fields
- [ ] `tips.test.ts` — confirm 404 (not found), 200 PENDING→CONFIRMED (calls `update`), 200 idempotent on CONFIRMED (skips `update`), cursor chain page 1→2 passes correct Prisma args, non-cuid cursor returns 400, last-page `nextCursor` is null