### PR TITLE
Feat/indexer projections 895 896 899 900

### DIFF
--- a/backend/src/indexer/projections.test.ts
+++ b/backend/src/indexer/projections.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { projectEvent } from './projections.js';
+import type { DecodedEvent } from './sorobanClient.js';
+
+const {
+  mockUserUpsert,
+  mockGoalUpsert,
+  mockGoalUpdateMany,
+  mockSubUpsert,
+  mockSubUpdateMany,
+  mockTipUpsert,
+  mockEventLogFindFirst,
+  mockEventLogCreate,
+} = vi.hoisted(() => ({
+  mockUserUpsert: vi.fn(),
+  mockGoalUpsert: vi.fn(),
+  mockGoalUpdateMany: vi.fn(),
+  mockSubUpsert: vi.fn(),
+  mockSubUpdateMany: vi.fn(),
+  mockTipUpsert: vi.fn(),
+  mockEventLogFindFirst: vi.fn(),
+  mockEventLogCreate: vi.fn(),
+}));
+
+vi.mock('../db/prisma.js', () => ({
+  prisma: {
+    user: { upsert: mockUserUpsert },
+    goal: { upsert: mockGoalUpsert, updateMany: mockGoalUpdateMany },
+    subscription: { upsert: mockSubUpsert, updateMany: mockSubUpdateMany },
+    tip: { upsert: mockTipUpsert },
+    eventLog: { findFirst: mockEventLogFindFirst, create: mockEventLogCreate },
+  },
+}));
+
+/** Build a decoded event; `value` is the positional payload tuple. */
+const event = (topic: string, value: unknown, overrides: Partial<DecodedEvent> = {}): DecodedEvent => ({
+  ledger: 100,
+  txHash: 'tx-' + topic,
+  pagingToken: '100-1',
+  topic,
+  value,
+  ...overrides,
+});
+
+const ADDR_A = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const ADDR_B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // ensureUserId / profile upsert resolve a deterministic id per address.
+  mockUserUpsert.mockImplementation(async (args: { where: { stellarAddress: string } }) => ({
+    id: 'u_' + args.where.stellarAddress,
+  }));
+  mockEventLogFindFirst.mockResolvedValue(null);
+  mockEventLogCreate.mockResolvedValue({});
+  mockGoalUpsert.mockResolvedValue({});
+  mockGoalUpdateMany.mockResolvedValue({ count: 1 });
+  mockSubUpsert.mockResolvedValue({});
+  mockSubUpdateMany.mockResolvedValue({ count: 1 });
+});
+
+describe('projectEvent — raw event log', () => {
+  it('persists every event before projecting', async () => {
+    await projectEvent(event('profile_register', [ADDR_A, 'alice']));
+    expect(mockEventLogCreate).toHaveBeenCalledOnce();
+  });
+
+  it('skips re-inserting an already-stored event (idempotent)', async () => {
+    mockEventLogFindFirst.mockResolvedValue({ id: 'existing' });
+    await projectEvent(event('profile_register', [ADDR_A, 'alice']));
+    expect(mockEventLogCreate).not.toHaveBeenCalled();
+  });
+
+  it('ignores topics with no projection handler', async () => {
+    await projectEvent(event('fee_updated', [10, 20]));
+    expect(mockUserUpsert).not.toHaveBeenCalled();
+    expect(mockGoalUpsert).not.toHaveBeenCalled();
+    expect(mockSubUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('projectEvent — profile (#895, #896)', () => {
+  it('upserts the user from a registration event', async () => {
+    await projectEvent(event('profile_register', [ADDR_A, 'alice']));
+    expect(mockUserUpsert).toHaveBeenCalledWith({
+      where: { stellarAddress: ADDR_A },
+      create: { stellarAddress: ADDR_A, username: 'alice' },
+      update: { username: 'alice' },
+    });
+  });
+
+  it('registration without a username leaves username untouched on replay', async () => {
+    await projectEvent(event('profile_register', [ADDR_A, '']));
+    expect(mockUserUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ create: { stellarAddress: ADDR_A, username: null }, update: {} }),
+    );
+  });
+
+  it('registration is idempotent — same address keys the same upsert', async () => {
+    await projectEvent(event('profile_register', [ADDR_A, 'alice']));
+    await projectEvent(event('profile_register', [ADDR_A, 'alice']));
+    const wheres = mockUserUpsert.mock.calls.map((c) => c[0].where);
+    expect(wheres).toEqual([{ stellarAddress: ADDR_A }, { stellarAddress: ADDR_A }]);
+  });
+
+  it('ensures the user exists on a profile update (payload is owner-only)', async () => {
+    await projectEvent(event('profile_updated', [ADDR_A]));
+    expect(mockUserUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { stellarAddress: ADDR_A }, update: {} }),
+    );
+  });
+
+  it('skips a registration with an unparseable owner', async () => {
+    await projectEvent(event('profile_register', [123, 'alice']));
+    expect(mockUserUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('projectEvent — goals (#899)', () => {
+  it('creates a goal keyed deterministically per creator', async () => {
+    await projectEvent(event('goal_set', [ADDR_A, '1000', 'Buy a mic', '1735000000']));
+    expect(mockGoalUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'goal_u_' + ADDR_A },
+        create: expect.objectContaining({
+          id: 'goal_u_' + ADDR_A,
+          userId: 'u_' + ADDR_A,
+          title: 'Buy a mic',
+          targetStroops: 1000n,
+          raisedStroops: 0n,
+          status: 'ACTIVE',
+        }),
+      }),
+    );
+    const call = mockGoalUpsert.mock.calls[0][0];
+    expect(call.create.deadline).toEqual(new Date(1735000000 * 1000));
+  });
+
+  it('treats a zero deadline as no deadline', async () => {
+    await projectEvent(event('goal_set', [ADDR_A, '1000', 'No deadline', '0']));
+    expect(mockGoalUpsert.mock.calls[0][0].create.deadline).toBeNull();
+  });
+
+  it('marks a goal completed with the absolute raised amount when reached', async () => {
+    await projectEvent(event('goal_reached', [ADDR_A, '1000', '1000']));
+    expect(mockGoalUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'goal_u_' + ADDR_A },
+        update: { targetStroops: 1000n, raisedStroops: 1000n, status: 'COMPLETED' },
+      }),
+    );
+  });
+
+  it('reached is idempotent — replay produces the same absolute update', async () => {
+    await projectEvent(event('goal_reached', [ADDR_A, '1000', '1000']));
+    await projectEvent(event('goal_reached', [ADDR_A, '1000', '1000']));
+    expect(mockGoalUpsert.mock.calls[0][0].update).toEqual(mockGoalUpsert.mock.calls[1][0].update);
+  });
+
+  it('cancels a goal via updateMany (no-op when absent)', async () => {
+    await projectEvent(event('goal_cancel', ADDR_A));
+    expect(mockGoalUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'goal_u_' + ADDR_A },
+      data: { status: 'CANCELLED' },
+    });
+  });
+
+  it('skips a goal_set with an unparseable target', async () => {
+    await projectEvent(event('goal_set', [ADDR_A, 'not-a-number', 'x', '0']));
+    expect(mockGoalUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('projectEvent — subscriptions (#900)', () => {
+  it('creates a subscription mapping interval_days to an interval', async () => {
+    await projectEvent(event('sub_created', [ADDR_A, ADDR_B, '500', 7]));
+    expect(mockSubUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: `sub_u_${ADDR_A}_u_${ADDR_B}` },
+        create: expect.objectContaining({
+          tipperId: 'u_' + ADDR_A,
+          creatorId: 'u_' + ADDR_B,
+          amountStroops: 500n,
+          interval: 'WEEKLY',
+          status: 'ACTIVE',
+        }),
+      }),
+    );
+  });
+
+  it('records a charge by keeping the subscription active', async () => {
+    await projectEvent(event('sub_exec', [ADDR_A, ADDR_B, '500']));
+    expect(mockSubUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: `sub_u_${ADDR_A}_u_${ADDR_B}` },
+        update: { amountStroops: 500n, status: 'ACTIVE' },
+      }),
+    );
+  });
+
+  it('charge is idempotent — replay keys the same subscription', async () => {
+    await projectEvent(event('sub_exec', [ADDR_A, ADDR_B, '500']));
+    await projectEvent(event('sub_exec', [ADDR_A, ADDR_B, '500']));
+    expect(mockSubUpsert.mock.calls[0][0].where).toEqual(mockSubUpsert.mock.calls[1][0].where);
+    expect(mockSubUpsert.mock.calls[0][0].update).toEqual(mockSubUpsert.mock.calls[1][0].update);
+  });
+
+  it('cancels a subscription via updateMany', async () => {
+    await projectEvent(event('sub_cancel', [ADDR_A, ADDR_B]));
+    expect(mockSubUpdateMany).toHaveBeenCalledWith({
+      where: { id: `sub_u_${ADDR_A}_u_${ADDR_B}` },
+      data: { status: 'CANCELLED' },
+    });
+  });
+
+  it('skips a sub_created with an unparseable amount', async () => {
+    await projectEvent(event('sub_created', [ADDR_A, ADDR_B, 'nope', 7]));
+    expect(mockSubUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/indexer/projections.ts
+++ b/backend/src/indexer/projections.ts
@@ -7,13 +7,36 @@ import type { DecodedEvent } from './sorobanClient.js';
 const TIP_TOPICS = new Set(['tip', 'tip_sent']);
 
 /**
+ * Per-topic projection handlers. Each handler is idempotent: re-running it over
+ * the same event never produces a duplicate row. Topics are the canonical
+ * `_`-joined names decoded from the contract's topic tuples (see `decodeTopic`).
+ */
+const PROJECTIONS: Record<string, (event: DecodedEvent) => Promise<void>> = {
+  profile_register: projectProfileRegistered,
+  profile_updated: projectProfileUpdated,
+  goal_set: projectGoalSet,
+  goal_reached: projectGoalReached,
+  goal_cancel: projectGoalCancelled,
+  sub_created: projectSubscriptionCreated,
+  sub_exec: projectSubscriptionCharged,
+  sub_cancel: projectSubscriptionCancelled,
+};
+
+/**
  * Project a decoded on-chain event into the off-chain store. Every projection is
  * idempotent: re-running over the same ledgers never produces duplicate rows.
  */
 export async function projectEvent(event: DecodedEvent): Promise<void> {
   await persistEventLog(event);
+
   if (TIP_TOPICS.has(event.topic)) {
     await projectTip(event);
+    return;
+  }
+
+  const handler = PROJECTIONS[event.topic];
+  if (handler) {
+    await handler(event);
   }
 }
 
@@ -105,4 +128,255 @@ function toBigInt(value: unknown): bigint | null {
     /* fall through */
   }
   return null;
+}
+
+// ── Profile projections (issues #895, #896) ───────────────────────────────────
+
+/**
+ * Project a `("profile", "register")` event — data `(owner, username)` — into the
+ * User table. Upsert on the unique `stellarAddress`, so replays are no-ops.
+ */
+async function projectProfileRegistered(event: DecodedEvent): Promise<void> {
+  const [owner, username] = tupleArgs(event.value);
+  if (typeof owner !== 'string') {
+    return warnUnparseable(event, 'profile_register');
+  }
+  const name = typeof username === 'string' && username.length > 0 ? username : null;
+
+  await prisma.user.upsert({
+    where: { stellarAddress: owner },
+    create: { stellarAddress: owner, username: name },
+    update: name === null ? {} : { username: name },
+  });
+}
+
+/**
+ * Project a `("profile", "updated")` event — data `(owner,)`. The event carries
+ * only the owner address (the mutated fields live in contract storage), so the
+ * projection just ensures the off-chain User row exists for that address.
+ */
+async function projectProfileUpdated(event: DecodedEvent): Promise<void> {
+  const owner = addressArg(event.value);
+  if (owner === null) {
+    return warnUnparseable(event, 'profile_updated');
+  }
+  await ensureUserId(owner);
+}
+
+// ── Goal projections (issue #899) ─────────────────────────────────────────────
+
+/**
+ * Project a `("goal", "set")` event — data `(creator, target, description,
+ * deadline)`. A creator has at most one on-chain goal, so the off-chain row is
+ * keyed deterministically per user (`goal_<userId>`); replays upsert the same row.
+ */
+async function projectGoalSet(event: DecodedEvent): Promise<void> {
+  const [creator, target, description, deadline] = tupleArgs(event.value);
+  const targetStroops = toBigInt(target);
+  if (typeof creator !== 'string' || targetStroops === null) {
+    return warnUnparseable(event, 'goal_set');
+  }
+
+  const userId = await ensureUserId(creator);
+  const title = typeof description === 'string' ? description : '';
+  const deadlineAt = toTimestamp(deadline);
+
+  await prisma.goal.upsert({
+    where: { id: goalId(userId) },
+    create: {
+      id: goalId(userId),
+      userId,
+      title,
+      targetStroops,
+      raisedStroops: 0n,
+      deadline: deadlineAt,
+      status: 'ACTIVE',
+    },
+    update: { title, targetStroops, deadline: deadlineAt, status: 'ACTIVE' },
+  });
+}
+
+/**
+ * Project a `("goal", "reached")` event — data `(creator, target, raised)`.
+ * `raised` is the absolute amount, so the update is idempotent on replay.
+ */
+async function projectGoalReached(event: DecodedEvent): Promise<void> {
+  const [creator, target, raised] = tupleArgs(event.value);
+  const targetStroops = toBigInt(target);
+  const raisedStroops = toBigInt(raised);
+  if (typeof creator !== 'string' || targetStroops === null || raisedStroops === null) {
+    return warnUnparseable(event, 'goal_reached');
+  }
+
+  const userId = await ensureUserId(creator);
+
+  await prisma.goal.upsert({
+    where: { id: goalId(userId) },
+    create: {
+      id: goalId(userId),
+      userId,
+      title: '',
+      targetStroops,
+      raisedStroops,
+      status: 'COMPLETED',
+    },
+    update: { targetStroops, raisedStroops, status: 'COMPLETED' },
+  });
+}
+
+/** Project a `("goal", "cancel")` event — data `(creator,)`. */
+async function projectGoalCancelled(event: DecodedEvent): Promise<void> {
+  const creator = addressArg(event.value);
+  if (creator === null) {
+    return warnUnparseable(event, 'goal_cancel');
+  }
+  const userId = await ensureUserId(creator);
+  // updateMany is a no-op (not an error) when the creator has no goal row yet.
+  await prisma.goal.updateMany({ where: { id: goalId(userId) }, data: { status: 'CANCELLED' } });
+}
+
+// ── Subscription projections (issue #900) ─────────────────────────────────────
+
+/**
+ * Project a `("sub", "created")` event — data `(subscriber, creator, amount,
+ * interval_days)`. One subscription per (tipper, creator) pair, keyed
+ * deterministically (`sub_<tipperId>_<creatorId>`) so replays upsert one row.
+ */
+async function projectSubscriptionCreated(event: DecodedEvent): Promise<void> {
+  const [subscriber, creator, amount, intervalDays] = tupleArgs(event.value);
+  const amountStroops = toBigInt(amount);
+  if (typeof subscriber !== 'string' || typeof creator !== 'string' || amountStroops === null) {
+    return warnUnparseable(event, 'sub_created');
+  }
+
+  const tipperId = await ensureUserId(subscriber);
+  const creatorId = await ensureUserId(creator);
+  const days = toIntervalDays(intervalDays);
+
+  await prisma.subscription.upsert({
+    where: { id: subscriptionId(tipperId, creatorId) },
+    create: {
+      id: subscriptionId(tipperId, creatorId),
+      tipperId,
+      creatorId,
+      amountStroops,
+      interval: intervalFromDays(days),
+      nextChargeAt: addDays(new Date(), days),
+      status: 'ACTIVE',
+    },
+    update: { amountStroops, interval: intervalFromDays(days), status: 'ACTIVE' },
+  });
+}
+
+/**
+ * Project a `("sub", "exec")` event — data `(subscriber, creator, amount)`. This
+ * confirms a successful recurring charge; the subscription is ensured ACTIVE and
+ * its charged amount recorded. Per-charge history is out of scope (no table).
+ */
+async function projectSubscriptionCharged(event: DecodedEvent): Promise<void> {
+  const [subscriber, creator, amount] = tupleArgs(event.value);
+  const amountStroops = toBigInt(amount);
+  if (typeof subscriber !== 'string' || typeof creator !== 'string' || amountStroops === null) {
+    return warnUnparseable(event, 'sub_exec');
+  }
+
+  const tipperId = await ensureUserId(subscriber);
+  const creatorId = await ensureUserId(creator);
+
+  await prisma.subscription.upsert({
+    where: { id: subscriptionId(tipperId, creatorId) },
+    create: {
+      id: subscriptionId(tipperId, creatorId),
+      tipperId,
+      creatorId,
+      amountStroops,
+      interval: 'MONTHLY',
+      nextChargeAt: addDays(new Date(), 30),
+      status: 'ACTIVE',
+    },
+    update: { amountStroops, status: 'ACTIVE' },
+  });
+}
+
+/** Project a `("sub", "cancel")` event — data `(subscriber, creator)`. */
+async function projectSubscriptionCancelled(event: DecodedEvent): Promise<void> {
+  const [subscriber, creator] = tupleArgs(event.value);
+  if (typeof subscriber !== 'string' || typeof creator !== 'string') {
+    return warnUnparseable(event, 'sub_cancel');
+  }
+  const tipperId = await ensureUserId(subscriber);
+  const creatorId = await ensureUserId(creator);
+  await prisma.subscription.updateMany({
+    where: { id: subscriptionId(tipperId, creatorId) },
+    data: { status: 'CANCELLED' },
+  });
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+/** Deterministic off-chain identifier for a creator's single goal. */
+function goalId(userId: string): string {
+  return `goal_${userId}`;
+}
+
+/** Deterministic off-chain identifier for a (tipper, creator) subscription. */
+function subscriptionId(tipperId: string, creatorId: string): string {
+  return `sub_${tipperId}_${creatorId}`;
+}
+
+/**
+ * Resolve a Stellar address to a User id, creating a minimal User row if none
+ * exists yet. Idempotent: the upsert keys on the unique `stellarAddress`.
+ */
+async function ensureUserId(address: string): Promise<string> {
+  const user = await prisma.user.upsert({
+    where: { stellarAddress: address },
+    create: { stellarAddress: address },
+    update: {},
+    select: { id: true },
+  });
+  return user.id;
+}
+
+/** Normalise an event value into its positional argument tuple. */
+function tupleArgs(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * Extract a single address argument, accepting either a bare value (single-field
+ * events publish the address directly) or a one-element tuple.
+ */
+function addressArg(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
+  return null;
+}
+
+/** Convert an on-chain unix-seconds timestamp to a Date, treating 0/invalid as none. */
+function toTimestamp(value: unknown): Date | null {
+  const seconds = toBigInt(value);
+  if (seconds === null || seconds === 0n) return null;
+  return new Date(Number(seconds) * 1000);
+}
+
+/** Coerce an on-chain `interval_days` value to a positive integer day count. */
+function toIntervalDays(value: unknown): number {
+  const days = toBigInt(value);
+  return days !== null && days > 0n ? Number(days) : 30;
+}
+
+/** Map a day interval onto the closest supported SubscriptionInterval. */
+function intervalFromDays(days: number): 'DAILY' | 'WEEKLY' | 'MONTHLY' {
+  if (days <= 1) return 'DAILY';
+  if (days <= 7) return 'WEEKLY';
+  return 'MONTHLY';
+}
+
+function addDays(from: Date, days: number): Date {
+  return new Date(from.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+function warnUnparseable(event: DecodedEvent, topic: string): void {
+  logger.warn({ txHash: event.txHash, topic }, 'Skipping event with unparseable payload');
 }

--- a/backend/src/indexer/projections.ts
+++ b/backend/src/indexer/projections.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import { prisma } from '../db/prisma.js';
 import { logger } from '../common/utils/logger.js';
 import type { DecodedEvent } from './sorobanClient.js';
@@ -58,7 +59,7 @@ async function persistEventLog(event: DecodedEvent): Promise<void> {
       topic: event.topic,
       ledger: event.ledger,
       txHash: event.txHash,
-      data: event.value as Record<string, unknown>,
+      data: (event.value ?? {}) as Prisma.InputJsonValue,
     },
   });
 }

--- a/backend/src/indexer/sorobanClient.ts
+++ b/backend/src/indexer/sorobanClient.ts
@@ -63,13 +63,24 @@ export async function getEventsFrom(startLedger: number, pagingToken?: string): 
   };
 }
 
-/** First topic of an event, decoded to its symbol/string name. */
+/**
+ * Decode an event's full topic tuple into a single canonical name.
+ *
+ * Contract events use a two-symbol topic tuple — e.g. `("profile", "register")`
+ * or `("goal", "set")`. Joining every symbol with `_` (→ `profile_register`,
+ * `goal_set`) preserves the sub-type so projections can distinguish, for
+ * example, a profile registration from a profile update. A single-symbol topic
+ * decodes to just that symbol.
+ */
 function decodeTopic(topic: xdr.ScVal[]): string {
-  const first = topic[0];
-  if (!first) return 'unknown';
+  if (topic.length === 0) return 'unknown';
   try {
-    const native = scValToNative(first);
-    return typeof native === 'string' ? native : String(native);
+    return topic
+      .map((part) => {
+        const native = scValToNative(part);
+        return typeof native === 'string' ? native : String(native);
+      })
+      .join('_');
   } catch {
     return 'unknown';
   }


### PR DESCRIPTION
## Description

Adds the off-chain indexer projections for **profile**, **goal**, and **subscription**
contract events. Each decoded event is projected into the relevant Prisma model
idempotently, so re-running the indexer over the same ledgers never produces
duplicate rows.

While implementing this I found that the event decoder kept only the **first**
symbol of each event's topic tuple. The contract publishes two-symbol topics
(e.g. `("profile", "register")`, `("goal", "set")`), so the first symbol alone
cannot distinguish a registration from an update, or a goal being set from a
goal being reached. The decoder now joins the full topic tuple into a canonical
`_`-separated name, which is the key the new projection handlers dispatch on.

> Target branch: **`test-implement-drips`** (not `main`).

Closes #895
Closes #896
Closes #899
Closes #900

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Tests (adding new tests or updating existing tests)

## Changes Made

- **`backend/src/indexer/sorobanClient.ts`** — `decodeTopic` now joins every
  symbol in an event's topic tuple with `_` (e.g. `profile_register`,
  `goal_set`, `sub_created`) so projections can dispatch on the event sub-type.
  Single-symbol topics are unchanged.
- **`backend/src/indexer/projections.ts`** — added idempotent handlers dispatched
  from `projectEvent` via a per-topic map:
  - `profile_register` / `profile_updated` → upsert `User` on the unique
    `stellarAddress` (#895, #896). `profile_updated` carries only the owner
    address on-chain, so it ensures the off-chain `User` row exists.
  - `goal_set` / `goal_reached` / `goal_cancel` → `Goal` lifecycle (#899). A
    creator has a single on-chain goal, so the row is keyed deterministically as
    `goal_<userId>`; `goal_reached` writes the absolute `raised` amount.
  - `sub_created` / `sub_exec` / `sub_cancel` → `Subscription` lifecycle (#900),
    keyed deterministically as `sub_<tipperId>_<creatorId>`; `interval_days` is
    mapped to the `SubscriptionInterval` enum.
  - Shared `ensureUserId` helper resolves a Stellar address to a `User` id via an
    idempotent upsert, so projections that need a foreign key never fail on a
    not-yet-seen address.
- **`backend/src/indexer/projections.test.ts`** — new Vitest suite (19 tests)
  with fixture event payloads covering every handler, idempotent replays
  (same deterministic key / same absolute update), unparseable-payload skips,
  the raw `EventLog` persistence path, and unknown topics being ignored.

## How to Test

```bash
git checkout feat/indexer-projections-895-896-899-900
cd backend && npm install
npx vitest run src/indexer
```

- The full indexer suite passes (**30 tests**, including the 19 new projection
  tests).
- Idempotency is asserted directly: replaying the same event keys the same row
  (deterministic id) and writes the same absolute values, so no duplicate rows
  are produced.

## Checklist

### ⚙️ General
- [x] Code follows the project's coding standards and structure guidelines
      (mirrors the existing `projectTip` / `persistEventLog` style).
- [x] Self-reviewed; no commented-out code blocks.
- [x] No `console.log` / debug code (uses the shared `logger`).
- [x] DB accessed only through the Prisma singleton (`src/db/prisma.ts`).
- [x] New logic has Vitest tests and they pass.
- [x] Public functions have short doc comments.
- [x] PR targets `test-implement-drips`.

## Notes for the reviewer

These changes are scoped to the indexer projection layer and the event decoder.
No Prisma schema migration was needed — the `User`, `Goal`, and `Subscription`
models already exist.

This branch is merged up to date with `test-implement-drips`. The merge
overlapped the new **refund** projection that landed upstream; both projection
paths now coexist in `projectEvent` (tip / refund handled inline, profile / goal
/ subscription via the per-topic `PROJECTIONS` map).

- ✅ `npm run lint` passes cleanly across the repo (the eslint config issue was
  fixed upstream).
- ✅ The new/changed files **typecheck cleanly** against the generated Prisma
  client (verified locally).
- ✅ `npx vitest run src/indexer` passes (30 tests).

**One pre-existing blocker remains (not introduced by and out of scope for this
PR):** `prisma/schema.prisma` still fails `prisma validate` because the `Tip`
model declares `@@index([toAddress, createdAt])` / `@@index([fromAddress,
createdAt])` referencing a `createdAt` field that does not exist on `Tip`. Until
that is fixed, `npx prisma generate` (and therefore a full-repo `npm run
typecheck`) cannot complete. This belongs to the Tip/indexer-model issue and
should land separately. I deliberately did **not** modify the `Tip` model.
