### PR TITLE
feat(profiles): add ProfileResponseDto and serializer

### DIFF
--- a/backend/src/modules/profiles/profiles.dto.ts
+++ b/backend/src/modules/profiles/profiles.dto.ts
@@ -1,0 +1,28 @@
+/**
+ * Profile response DTOs. These define the shape of data returned by the API,
+ * ensuring private fields are never leaked.
+ */
+
+/** Public profile response — safe for any consumer. */
+export interface ProfileResponseDto {
+  id: string;
+  stellarAddress: string;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  imageUrl: string | null;
+  avatarCid: string | null;
+  xHandle: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tipsCount: number;
+  totalReceived: string;
+}
+
+/** Paginated list of profiles. */
+export interface PaginatedProfilesDto {
+  profiles: ProfileResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/backend/src/modules/profiles/profiles.serializer.test.ts
+++ b/backend/src/modules/profiles/profiles.serializer.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { serializeProfile } from './profiles.serializer.js';
+
+describe('serializeProfile', () => {
+  const baseRow = {
+    id: 'user-123',
+    stellarAddress: 'GABCDEF123456789012345678901234567890123456789012345678901234',
+    username: 'testuser',
+    displayName: 'Test User',
+    bio: 'Hello, I am a developer!',
+    imageUrl: 'https://example.com/avatar.png',
+    avatarCid: 'QmHash123',
+    xHandle: 'testhandle',
+    createdAt: new Date('2026-01-15T10:30:00.000Z'),
+    updatedAt: new Date('2026-06-20T14:45:00.000Z'),
+  };
+
+  const stats = { tipsCount: 42, totalReceived: '50000000' };
+
+  it('converts Date objects to ISO strings', () => {
+    const dto = serializeProfile(baseRow, stats);
+    expect(dto.createdAt).toBe('2026-01-15T10:30:00.000Z');
+    expect(dto.updatedAt).toBe('2026-06-20T14:45:00.000Z');
+  });
+
+  it('accepts ISO string dates without error', () => {
+    const row = {
+      ...baseRow,
+      createdAt: '2026-01-15T10:30:00.000Z',
+      updatedAt: '2026-06-20T14:45:00.000Z',
+    };
+    const dto = serializeProfile(row, stats);
+    expect(dto.createdAt).toBe('2026-01-15T10:30:00.000Z');
+    expect(dto.updatedAt).toBe('2026-06-20T14:45:00.000Z');
+  });
+
+  it('maps all public fields correctly', () => {
+    const dto = serializeProfile(baseRow, stats);
+    expect(dto).toEqual({
+      id: 'user-123',
+      stellarAddress: baseRow.stellarAddress,
+      username: 'testuser',
+      displayName: 'Test User',
+      bio: 'Hello, I am a developer!',
+      imageUrl: 'https://example.com/avatar.png',
+      avatarCid: 'QmHash123',
+      xHandle: 'testhandle',
+      createdAt: '2026-01-15T10:30:00.000Z',
+      updatedAt: '2026-06-20T14:45:00.000Z',
+      tipsCount: 42,
+      totalReceived: '50000000',
+    });
+  });
+
+  it('includes tipsCount and totalReceived from stats', () => {
+    const dto = serializeProfile(baseRow, stats);
+    expect(dto.tipsCount).toBe(42);
+    expect(dto.totalReceived).toBe('50000000');
+  });
+
+  it('handles null optional fields', () => {
+    const row = {
+      ...baseRow,
+      username: null,
+      displayName: null,
+      bio: null,
+      imageUrl: null,
+      avatarCid: null,
+      xHandle: null,
+    };
+    const dto = serializeProfile(row, stats);
+    expect(dto.username).toBeNull();
+    expect(dto.displayName).toBeNull();
+    expect(dto.bio).toBeNull();
+    expect(dto.imageUrl).toBeNull();
+    expect(dto.avatarCid).toBeNull();
+    expect(dto.xHandle).toBeNull();
+  });
+
+  it('never exposes internal fields', () => {
+    const row = {
+      ...baseRow,
+      passwordHash: 'secret123',
+      email: 'secret@example.com',
+      role: 'admin',
+      deletedAt: new Date(),
+      internalNote: 'do not expose',
+    } as never;
+    const dto = serializeProfile(row, stats);
+    expect(dto).not.toHaveProperty('passwordHash');
+    expect(dto).not.toHaveProperty('email');
+    expect(dto).not.toHaveProperty('role');
+    expect(dto).not.toHaveProperty('deletedAt');
+    expect(dto).not.toHaveProperty('internalNote');
+  });
+
+  it('maps zero tips stats correctly', () => {
+    const zeroStats = { tipsCount: 0, totalReceived: '0' };
+    const dto = serializeProfile(baseRow, zeroStats);
+    expect(dto.tipsCount).toBe(0);
+    expect(dto.totalReceived).toBe('0');
+  });
+});

--- a/backend/src/modules/profiles/profiles.serializer.ts
+++ b/backend/src/modules/profiles/profiles.serializer.ts
@@ -1,0 +1,44 @@
+import type { ProfileResponseDto } from './profiles.dto.js';
+
+interface ProfileRow {
+  id: string;
+  stellarAddress: string;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  imageUrl: string | null;
+  avatarCid: string | null;
+  xHandle: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+
+/**
+ * Serializes a database profile row into a safe API response DTO.
+ * Only exposes public fields — never leaks private/internal data.
+ */
+export function serializeProfile(
+  profile: ProfileRow,
+  stats: { tipsCount: number; totalReceived: string },
+): ProfileResponseDto {
+  return {
+    id: profile.id,
+    stellarAddress: profile.stellarAddress,
+    username: profile.username,
+    displayName: profile.displayName,
+    bio: profile.bio,
+    imageUrl: profile.imageUrl,
+    avatarCid: profile.avatarCid,
+    xHandle: profile.xHandle,
+    createdAt:
+      profile.createdAt instanceof Date
+        ? profile.createdAt.toISOString()
+        : profile.createdAt,
+    updatedAt:
+      profile.updatedAt instanceof Date
+        ? profile.updatedAt.toISOString()
+        : profile.updatedAt,
+    tipsCount: stats.tipsCount,
+    totalReceived: stats.totalReceived,
+  };
+}

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -6,9 +6,10 @@ import {
   ConflictError,
 } from "../../common/errors/AppError.js";
 import type {
-  ProfileResponse,
   UpdateProfileRequest,
 } from "./profiles.types.js";
+import type { ProfileResponseDto, PaginatedProfilesDto } from "./profiles.dto.js";
+import { serializeProfile } from "./profiles.serializer.js";
 
 /**
  * Helper to fetch aggregate tip stats for a user.
@@ -42,7 +43,7 @@ async function getTipStats(userId: string): Promise<{ tipsCount: number; totalRe
 /**
  * Gets a profile by user ID.
  */
-export async function getProfileById(userId: string): Promise<ProfileResponse> {
+export async function getProfileById(userId: string): Promise<ProfileResponseDto> {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: {
@@ -65,20 +66,7 @@ export async function getProfileById(userId: string): Promise<ProfileResponse> {
   }
 
   const stats = await getTipStats(user.id);
-
-  return {
-    id: user.id,
-    stellarAddress: user.stellarAddress,
-    username: user.username,
-    displayName: user.displayName,
-    bio: user.bio,
-    imageUrl: user.imageUrl,
-    avatarCid: user.avatarCid,
-    xHandle: user.xHandle,
-    createdAt: user.createdAt.toISOString(),
-    updatedAt: user.updatedAt.toISOString(),
-    ...stats,
-  };
+  return serializeProfile(user, stats);
 }
 
 /**
@@ -86,7 +74,7 @@ export async function getProfileById(userId: string): Promise<ProfileResponse> {
  */
 export async function getProfileByUsername(
   username: string,
-): Promise<ProfileResponse> {
+): Promise<ProfileResponseDto> {
   const user = await prisma.user.findUnique({
     where: { username },
     select: {
@@ -109,20 +97,7 @@ export async function getProfileByUsername(
   }
 
   const stats = await getTipStats(user.id);
-
-  return {
-    id: user.id,
-    stellarAddress: user.stellarAddress,
-    username: user.username,
-    displayName: user.displayName,
-    bio: user.bio,
-    imageUrl: user.imageUrl,
-    avatarCid: user.avatarCid,
-    xHandle: user.xHandle,
-    createdAt: user.createdAt.toISOString(),
-    updatedAt: user.updatedAt.toISOString(),
-    ...stats,
-  };
+  return serializeProfile(user, stats);
 }
 
 /**
@@ -130,7 +105,7 @@ export async function getProfileByUsername(
  */
 export async function getProfileByAddress(
   stellarAddress: string,
-): Promise<ProfileResponse> {
+): Promise<ProfileResponseDto> {
   const user = await prisma.user.findUnique({
     where: { stellarAddress },
     select: {
@@ -153,20 +128,7 @@ export async function getProfileByAddress(
   }
 
   const stats = await getTipStats(user.id);
-
-  return {
-    id: user.id,
-    stellarAddress: user.stellarAddress,
-    username: user.username,
-    displayName: user.displayName,
-    bio: user.bio,
-    imageUrl: user.imageUrl,
-    avatarCid: user.avatarCid,
-    xHandle: user.xHandle,
-    createdAt: user.createdAt.toISOString(),
-    updatedAt: user.updatedAt.toISOString(),
-    ...stats,
-  };
+  return serializeProfile(user, stats);
 }
 
 /**
@@ -175,7 +137,7 @@ export async function getProfileByAddress(
 export async function updateProfile(
   userId: string,
   data: UpdateProfileRequest,
-): Promise<ProfileResponse> {
+): Promise<ProfileResponseDto> {
   // Check if profile exists and is active
   const user = await prisma.user.findUnique({
     where: { id: userId },
@@ -215,22 +177,8 @@ export async function updateProfile(
     });
 
     logger.info({ userId }, "Profile updated successfully");
-
     const stats = await getTipStats(updatedUser.id);
-
-    return {
-      id: updatedUser.id,
-      stellarAddress: updatedUser.stellarAddress,
-      username: updatedUser.username,
-      displayName: updatedUser.displayName,
-      bio: updatedUser.bio,
-      imageUrl: updatedUser.imageUrl,
-      avatarCid: updatedUser.avatarCid,
-      xHandle: updatedUser.xHandle,
-      createdAt: updatedUser.createdAt.toISOString(),
-      updatedAt: updatedUser.updatedAt.toISOString(),
-      ...stats,
-    };
+    return serializeProfile(updatedUser, stats);
   } catch (error) {
     logger.error({ userId, error }, "Failed to update profile");
     throw new BadRequestError("Failed to update profile");
@@ -243,12 +191,7 @@ export async function updateProfile(
 export async function listProfiles(
   page = 1,
   limit = 20,
-): Promise<{
-  profiles: ProfileResponse[];
-  total: number;
-  page: number;
-  limit: number;
-}> {
+): Promise<PaginatedProfilesDto> {
   const skip = (page - 1) * limit;
 
   const [users, total] = await Promise.all([
@@ -278,19 +221,7 @@ export async function listProfiles(
   const profiles = await Promise.all(
     users.map(async (user) => {
       const stats = await getTipStats(user.id);
-      return {
-        id: user.id,
-        stellarAddress: user.stellarAddress,
-        username: user.username,
-        displayName: user.displayName,
-        bio: user.bio,
-        imageUrl: user.imageUrl,
-        avatarCid: user.avatarCid,
-        xHandle: user.xHandle,
-        createdAt: user.createdAt.toISOString(),
-        updatedAt: user.updatedAt.toISOString(),
-        ...stats,
-      };
+      return serializeProfile(user, stats);
     })
   );
 


### PR DESCRIPTION
## Summary
- Created `ProfileResponseDto` and `PaginatedProfilesDto` type definitions
- Created `serializeProfile` function that maps DB rows to safe API DTOs, ensuring private fields (passwordHash, email, role, deletedAt) are never leaked
- Updated all service functions (`getProfileById`, `getProfileByUsername`, `getProfileByAddress`, `updateProfile`, `listProfiles`) to use the serializer
- Added 7 serializer tests covering Date conversion, null fields, and internal field exclusion
## Changes
- `backend/src/modules/profiles/profiles.dto.ts`: New DTO definitions
- `backend/src/modules/profiles/profiles.serializer.ts`: New serializer that excludes private fields
- `backend/src/modules/profiles/profiles.serializer.test.ts`: 7 tests for serialization correctness
- `backend/src/modules/profiles/profiles.service.ts`: Refactored to use `serializeProfile` instead of manual object construction
## Acceptance Criteria
- [x] Serializer never leaks private fields
- [x] Tests + typecheck + lint pass
- [x] PR targets `test-implement-drips`

## Fixes 
closes #860 
closes #866 
closes #870 
closes #877 