### PR TITLE
feat(indexer): publish projected events to the realtime layer

### DIFF
--- a/backend/src/indexer/projections.test.ts
+++ b/backend/src/indexer/projections.test.ts
@@ -13,6 +13,7 @@ const {
   mockEventLogCreate,
   mockCreditScoreUpsert,
   mockCreditScoreHistoryUpsert,
+  mockPublishProjection,
 } = vi.hoisted(() => ({
   mockUserUpsert: vi.fn(),
   mockGoalUpsert: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockEventLogCreate: vi.fn(),
   mockCreditScoreUpsert: vi.fn(),
   mockCreditScoreHistoryUpsert: vi.fn(),
+  mockPublishProjection: vi.fn(),
 }));
 
 vi.mock('../db/prisma.js', () => ({
@@ -36,6 +38,10 @@ vi.mock('../db/prisma.js', () => ({
     creditScore: { upsert: mockCreditScoreUpsert },
     creditScoreHistory: { upsert: mockCreditScoreHistoryUpsert },
   },
+}));
+
+vi.mock('./realtime-publisher.js', () => ({
+  publishProjection: mockPublishProjection,
 }));
 
 /** Build a decoded event; `value` is the positional payload tuple. */
@@ -85,6 +91,7 @@ beforeEach(() => {
   mockSubUpdateMany.mockResolvedValue({ count: 1 });
   mockCreditScoreUpsert.mockResolvedValue({});
   mockCreditScoreHistoryUpsert.mockResolvedValue({});
+  mockPublishProjection.mockResolvedValue(undefined);
 });
 
 describe('projectEvent — raw event log', () => {
@@ -104,6 +111,41 @@ describe('projectEvent — raw event log', () => {
     expect(mockUserUpsert).not.toHaveBeenCalled();
     expect(mockGoalUpsert).not.toHaveBeenCalled();
     expect(mockSubUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('projectEvent — realtime publish', () => {
+  it('publishes to the realtime layer after a new event is projected', async () => {
+    const e = event('profile_register', [ADDR_A, 'alice']);
+    await projectEvent(e);
+    expect(mockPublishProjection).toHaveBeenCalledTimes(1);
+    expect(mockPublishProjection).toHaveBeenCalledWith(e);
+  });
+
+  it('does not publish when replaying an already-stored event (idempotent)', async () => {
+    mockEventLogFindFirst.mockResolvedValue({ id: 'existing' });
+    await projectEvent(event('profile_register', [ADDR_A, 'alice']));
+    expect(mockPublishProjection).not.toHaveBeenCalled();
+  });
+
+  it('publishes exactly once per unique event across repeated runs over the same ledgers', async () => {
+    const e = event('tip_sent', tipEvent.value, { txHash: tipEvent.txHash, ledger: tipEvent.ledger });
+
+    // First run: event log is empty, so the event is new.
+    mockEventLogFindFirst.mockResolvedValueOnce(null);
+    await projectEvent(e);
+
+    // Re-run over the same ledger range: event log now has the row.
+    mockEventLogFindFirst.mockResolvedValueOnce({ id: 'existing' });
+    await projectEvent(e);
+
+    expect(mockPublishProjection).toHaveBeenCalledTimes(1);
+  });
+
+  it('still projects and publishes the tip event even on the early-return tip branch', async () => {
+    await projectEvent(tipEvent);
+    expect(mockTipUpsert).toHaveBeenCalledOnce();
+    expect(mockPublishProjection).toHaveBeenCalledWith(tipEvent);
   });
 });
 
@@ -397,4 +439,3 @@ describe('projectEvent — credit score (#898)', () => {
     );
   });
 });
-

--- a/backend/src/indexer/projections.ts
+++ b/backend/src/indexer/projections.ts
@@ -2,6 +2,7 @@ import type { Prisma } from '@prisma/client';
 import { prisma } from '../db/prisma.js';
 import { logger } from '../common/utils/logger.js';
 import type { DecodedEvent } from './sorobanClient.js';
+import { publishProjection } from './realtime-publisher.js';
 
 /** Event topics that represent an on-chain tip. */
 const TIP_TOPICS = new Set(['tip', 'tip_sent']);
@@ -29,12 +30,19 @@ const PROJECTIONS: Record<string, (event: DecodedEvent) => Promise<void>> = {
 /**
  * Project a decoded on-chain event into the off-chain store. Every projection is
  * idempotent: re-running over the same ledgers never produces duplicate rows.
+ *
+ * Once the projection has been written, the event is published to the realtime
+ * layer (see `realtime-publisher.ts`) — but only the first time it's seen, so
+ * replaying the same ledgers never re-broadcasts.
  */
 export async function projectEvent(event: DecodedEvent): Promise<void> {
-  await persistEventLog(event);
+  const isNewEvent = await persistEventLog(event);
 
   if (TIP_TOPICS.has(event.topic)) {
     await projectTip(event);
+    if (isNewEvent) {
+      await publishProjection(event);
+    }
     return;
   }
 
@@ -45,15 +53,23 @@ export async function projectEvent(event: DecodedEvent): Promise<void> {
   if (REFUND_TOPICS.has(event.topic)) {
     await projectRefund(event);
   }
+
+  if (isNewEvent) {
+    await publishProjection(event);
+  }
 }
 
-/** Store the raw decoded event for audit/replay, skipping if already stored. */
-async function persistEventLog(event: DecodedEvent): Promise<void> {
+/**
+ * Store the raw decoded event for audit/replay, skipping if already stored.
+ * Returns `true` if this is the first time the event has been seen (i.e. a new
+ * row was inserted), `false` if it was already persisted (a replay).
+ */
+async function persistEventLog(event: DecodedEvent): Promise<boolean> {
   const existing = await prisma.eventLog.findFirst({
     where: { txHash: event.txHash, topic: event.topic, ledger: event.ledger },
     select: { id: true },
   });
-  if (existing) return;
+  if (existing) return false;
 
   await prisma.eventLog.create({
     data: {
@@ -63,6 +79,7 @@ async function persistEventLog(event: DecodedEvent): Promise<void> {
       data: (event.value ?? {}) as Prisma.InputJsonValue,
     },
   });
+  return true;
 }
 
 /** Upsert the Tip row. txHash is unique, so replays are no-ops. */

--- a/backend/src/indexer/realtime-publisher.test.ts
+++ b/backend/src/indexer/realtime-publisher.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockPublish, mockLoggerError } = vi.hoisted(() => ({
+  mockPublish: vi.fn(),
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('../db/redis.js', () => ({
+  redis: { publish: mockPublish },
+}));
+
+vi.mock('../common/utils/logger.js', () => ({
+  logger: { error: mockLoggerError, warn: vi.fn(), info: vi.fn() },
+}));
+
+import { publishProjection, REALTIME_PROJECTION_CHANNEL } from './realtime-publisher.js';
+import type { DecodedEvent } from './sorobanClient.js';
+
+const tipEvent: DecodedEvent = {
+  ledger: 100,
+  txHash: 'fixture-tip-tx-001',
+  pagingToken: '100-0',
+  topic: 'tip_sent',
+  value: { from: 'GAAA', to: 'GBBB', amount: '1000000', message: 'Thanks!' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('publishProjection', () => {
+  it('publishes a JSON-encoded message to the realtime channel', async () => {
+    mockPublish.mockResolvedValue(1);
+
+    await publishProjection(tipEvent);
+
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    const [channel, payload] = mockPublish.mock.calls[0] as [string, string];
+    expect(channel).toBe(REALTIME_PROJECTION_CHANNEL);
+
+    const parsed = JSON.parse(payload);
+    expect(parsed).toMatchObject({
+      topic: 'tip_sent',
+      ledger: 100,
+      txHash: 'fixture-tip-tx-001',
+      data: tipEvent.value,
+    });
+    expect(typeof parsed.publishedAt).toBe('number');
+  });
+
+  it('falls back to null data when the event value is nullish', async () => {
+    mockPublish.mockResolvedValue(1);
+
+    await publishProjection({ ...tipEvent, value: undefined });
+
+    const [, payload] = mockPublish.mock.calls[0] as [string, string];
+    expect(JSON.parse(payload).data).toBeNull();
+  });
+
+  it('swallows redis errors instead of throwing, and logs them', async () => {
+    mockPublish.mockRejectedValue(new Error('redis connection lost'));
+
+    await expect(publishProjection(tipEvent)).resolves.toBeUndefined();
+    expect(mockLoggerError).toHaveBeenCalledOnce();
+  });
+
+  it('publishes a fresh message (independent publishedAt) on every call, even for the same event', async () => {
+    mockPublish.mockResolvedValue(1);
+
+    await publishProjection(tipEvent);
+    await publishProjection(tipEvent);
+
+    expect(mockPublish).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/indexer/realtime-publisher.ts
+++ b/backend/src/indexer/realtime-publisher.ts
@@ -1,0 +1,51 @@
+import { redis } from '../db/redis.js';
+import { logger } from '../common/utils/logger.js';
+import type { DecodedEvent } from './sorobanClient.js';
+
+/**
+ * Redis pub/sub channel the realtime gateway (Socket.IO) subscribes to.
+ * The gateway re-broadcasts messages on this channel to connected clients;
+ * see the `initRealtime` hookup in `src/server.ts`.
+ */
+export const REALTIME_PROJECTION_CHANNEL = 'realtime:projections';
+
+/** Message broadcast to the realtime layer after an event has been projected. */
+export interface RealtimeProjectionMessage {
+  /** Canonical contract event topic, e.g. `tip_sent`, `goal_set`. */
+  topic: string;
+  /** Ledger sequence the event was emitted in. */
+  ledger: number;
+  /** Transaction hash the event was emitted in. */
+  txHash: string;
+  /** Decoded on-chain payload, as handed to the projection. */
+  data: unknown;
+  /** Unix-ms timestamp the message was published at. */
+  publishedAt: number;
+}
+
+/**
+ * Publish a projected event to the realtime pub/sub layer.
+ *
+ * Best-effort: a Redis failure is logged and swallowed rather than thrown, so
+ * an outage in the realtime layer never blocks indexing or cursor advance.
+ * Callers should only invoke this for events that were newly projected (not
+ * replays), so re-running over the same ledgers does not re-broadcast.
+ */
+export async function publishProjection(event: DecodedEvent): Promise<void> {
+  const message: RealtimeProjectionMessage = {
+    topic: event.topic,
+    ledger: event.ledger,
+    txHash: event.txHash,
+    data: event.value ?? null,
+    publishedAt: Date.now(),
+  };
+
+  try {
+    await redis.publish(REALTIME_PROJECTION_CHANNEL, JSON.stringify(message));
+  } catch (err) {
+    logger.error(
+      { err, txHash: event.txHash, topic: event.topic },
+      'Failed to publish projection to realtime layer',
+    );
+  }
+}


### PR DESCRIPTION
## Description

After an event is projected into the off-chain Postgres store, this PR publishes it to a Redis pub/sub channel (`realtime:projections`) so the Socket.IO realtime gateway can re-broadcast it to connected clients. This is the missing link between the indexer and the realtime layer referenced (but commented out) in `src/server.ts`.

### Idempotency Guarantee
Re-running `projectEvent` over the same ledger range:
1. `persistEventLog` finds the existing `EventLog` row (keyed on `txHash` + `topic` + `ledger`) and returns `false`.
2. The Prisma upsert projections remain no-ops on replay (unchanged, pre-existing behavior).
3. `publishProjection` is not called, since `isNewEvent` is `false`.

This keeps the realtime publish idempotent in lockstep with the existing DB idempotency guarantee: re-running over the same ledgers writes no duplicate rows and re-broadcasts nothing.

### Out of Scope
The Socket.IO gateway itself (subscribing to `REALTIME_PROJECTION_CHANNEL` and broadcasting to connected clients / rooms) is a separate "realtime gateway" issue — `src/server.ts` already has a commented-out `initRealtime(httpServer)` call marking that hookup point.

Closes #909

## Type of Change

Please mark the options that are relevant:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧪 Tests (adding new tests or updating existing tests)
- [ ] 📝 Documentation (changes to documentation/configs only)
- [ ] 🚀 DevOps & CI/CD (changes to workflows, scripts, or templates)

## Changes Made

- **`backend/src/indexer/realtime-publisher.ts` (new)** — exports `publishProjection(event)`, which JSON-encodes `{ topic, ledger, txHash, data, publishedAt }` and publishes it on `REALTIME_PROJECTION_CHANNEL` via the shared redis singleton. Publish failures are caught, logged via the shared logger, and swallowed — never thrown — so an outage in the realtime layer can't block indexing or cursor advance.
- **`backend/src/indexer/projections.ts`** — `persistEventLog()` now returns a boolean indicating whether the event was newly inserted (vs. already present from a prior run). `projectEvent()` calls `publishProjection()` only when the event is new, after the DB projection has been written.

## How to Test

1. Navigate to the backend directory and install dependencies:
   ```bash
   cd backend
   npm install

 npx vitest run src/indexer/projections.test.ts src/indexer/realtime-publisher.test.ts

npx tsc --noEmit src/indexer/projections.ts src/indexer/realtime-publisher.ts

## Checklist
###💻 Smart Contract Changes (if applicable)
[ ] Running cargo fmt -- --check passes successfully.

[ ] Running cargo clippy -- -D warnings runs without any warnings.

[ ] All tests pass successfully using cargo test.

[ ] New unit or integration tests have been written to cover the changes.

[ ] No hardcoded values are present (e.g. addresses, fees) that should be configurable.

##🎨 Frontend Changes (if applicable)
[x] TypeScript compiles cleanly with no errors (npm run typecheck or npx tsc --noEmit).

[ ] Running npm run lint shows no linting errors.

[ ] The production build compiles successfully via npm run build.

[ ] Changes verified on local browser environment with Freighter/xBull/Albedo wallet.

[ ] Responsive design verified (tested on mobile, tablet, and desktop viewport sizes).

[ ] Keyboard navigation and accessibility (a11y) considerations are addressed.

##⚙️ General
[x] Code follows the project's coding standards and structure guidelines.

[x] Self-reviewed the changes to ensure clean code with no commented-out code blocks.

[x] No console.log or debug code remains in production files.

[x] The branch is up-to-date with the main branch.

Screenshots / Demos (if applicable)
