### PR TITLE
feat: withdrawals module + credit score history (#936, #937, #915) — #927 already implemented

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -16,6 +16,7 @@ import { profilesRouter } from "./modules/profiles/profiles.routes.js";
 import { tipsRouter } from "./modules/tips/tips.routes.js";
 import { leaderboardRouter } from "./modules/leaderboard/leaderboard.routes.js";
 import { creditRouter } from "./modules/credit/credit.routes.js";
+import { withdrawalsRouter } from "./modules/withdrawals/withdrawals.routes.js";
 
 /**
  * Builds and configures the Express application (no listening here — see server.ts).
@@ -66,6 +67,7 @@ export function createApp(): Express {
   app.use(`${env.API_BASE_PATH}/tips`, tipsRouter);
   app.use(`${env.API_BASE_PATH}/leaderboard`, leaderboardRouter);
   app.use(`${env.API_BASE_PATH}/credit`, creditRouter);
+  app.use(`${env.API_BASE_PATH}/withdrawals`, withdrawalsRouter);
   // ─────────────────────────────────────────────────────────────
 
   app.use(notFoundHandler);

--- a/backend/src/modules/credit/credit.controller.ts
+++ b/backend/src/modules/credit/credit.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { userIdParamSchema, recalculateSchema } from './credit.schema.js';
+import { userIdParamSchema, recalculateSchema, creditHistoryQuerySchema } from './credit.schema.js';
 import * as creditService from './credit.service.js';
 
 export async function getCreditScore(
@@ -10,6 +10,21 @@ export async function getCreditScore(
   try {
     const { userId } = userIdParamSchema.parse(req.params);
     const result = await creditService.getCreditScore(userId);
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getCreditScoreHistory(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { userId } = userIdParamSchema.parse(req.params);
+    const { limit, offset } = creditHistoryQuerySchema.parse(req.query);
+    const result = await creditService.getCreditScoreHistory(userId, limit, offset);
     res.status(200).json({ data: result });
   } catch (err) {
     next(err);

--- a/backend/src/modules/credit/credit.routes.ts
+++ b/backend/src/modules/credit/credit.routes.ts
@@ -4,4 +4,5 @@ import * as creditController from './credit.controller.js';
 export const creditRouter = Router();
 
 creditRouter.get('/:userId', creditController.getCreditScore);
+creditRouter.get('/:userId/history', creditController.getCreditScoreHistory);
 creditRouter.post('/recalculate', creditController.recalculate);

--- a/backend/src/modules/credit/credit.schema.ts
+++ b/backend/src/modules/credit/credit.schema.ts
@@ -8,5 +8,11 @@ export const recalculateSchema = z.object({
   userId: z.string().min(1),
 });
 
+export const creditHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
 export type UserIdParam = z.infer<typeof userIdParamSchema>;
 export type RecalculateInput = z.infer<typeof recalculateSchema>;
+export type CreditHistoryQuery = z.infer<typeof creditHistoryQuerySchema>;

--- a/backend/src/modules/credit/credit.service.ts
+++ b/backend/src/modules/credit/credit.service.ts
@@ -1,6 +1,11 @@
 import { prisma } from '../../db/prisma.js';
 import { NotFoundError } from '../../common/errors/AppError.js';
-import type { CreditScoreResponse, CreditScoreComponents, ComputeCreditScoreInput } from './credit.types.js';
+import type {
+  CreditScoreResponse,
+  CreditScoreComponents,
+  ComputeCreditScoreInput,
+  CreditScoreHistoryPoint,
+} from './credit.types.js';
 
 const BASE_SCORE = 40;
 const MAX_SCORE = 100;
@@ -117,6 +122,30 @@ export async function getCreditScore(userId: string): Promise<CreditScoreRespons
     },
     computedAt: user.creditScore.computedAt.toISOString(),
   };
+}
+
+export async function getCreditScoreHistory(
+  userId: string,
+  limit: number,
+  offset: number,
+): Promise<CreditScoreHistoryPoint[]> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+
+  if (!user || user.deletedAt) {
+    throw new NotFoundError('User not found');
+  }
+
+  const history = await prisma.creditScoreHistory.findMany({
+    where: { userId },
+    orderBy: { computedAt: 'asc' },
+    skip: offset,
+    take: limit,
+  });
+
+  return history.map((h) => ({
+    value: h.value,
+    computedAt: h.computedAt.toISOString(),
+  }));
 }
 
 export async function recalculateCreditScore(userId: string): Promise<CreditScoreResponse> {

--- a/backend/src/modules/credit/credit.test.ts
+++ b/backend/src/modules/credit/credit.test.ts
@@ -147,11 +147,12 @@ describe('computeCreditScore (pure formula)', () => {
   });
 });
 
-const { mockFindUnique, mockAggregate, mockUpsert, mockCreate } = vi.hoisted(() => ({
+const { mockFindUnique, mockAggregate, mockUpsert, mockCreate, mockHistoryFindMany } = vi.hoisted(() => ({
   mockFindUnique: vi.fn(),
   mockAggregate: vi.fn(),
   mockUpsert: vi.fn(),
   mockCreate: vi.fn(),
+  mockHistoryFindMany: vi.fn(),
 }));
 
 vi.mock('../../db/prisma.js', () => ({
@@ -167,6 +168,7 @@ vi.mock('../../db/prisma.js', () => ({
     },
     creditScoreHistory: {
       create: mockCreate,
+      findMany: mockHistoryFindMany,
     },
     $disconnect: vi.fn(),
   },
@@ -218,5 +220,42 @@ describe('GET /api/v1/credit/:userId', () => {
     expect(res.status).toBe(200);
     expect(res.body.data.score).toBe(75);
     expect(res.body.data.tier).toBe('Gold');
+  });
+});
+
+describe('GET /api/v1/credit/:userId/history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when user not found', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/credit/nonexistent/history');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns the time series of a creator\'s score', async () => {
+    mockFindUnique.mockResolvedValue({ id: 'user-1', deletedAt: null });
+    mockHistoryFindMany.mockResolvedValue([
+      { value: 42, computedAt: new Date('2024-01-01T00:00:00.000Z') },
+      { value: 55, computedAt: new Date('2024-02-01T00:00:00.000Z') },
+    ]);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/credit/user-1/history');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([
+      { value: 42, computedAt: '2024-01-01T00:00:00.000Z' },
+      { value: 55, computedAt: '2024-02-01T00:00:00.000Z' },
+    ]);
+    expect(mockHistoryFindMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      orderBy: { computedAt: 'asc' },
+      skip: 0,
+      take: 20,
+    });
   });
 });

--- a/backend/src/modules/credit/credit.types.ts
+++ b/backend/src/modules/credit/credit.types.ts
@@ -21,3 +21,8 @@ export interface ComputeCreditScoreInput {
   accountAgeDays: number;
   streakBonus: number;
 }
+
+export interface CreditScoreHistoryPoint {
+  value: number;
+  computedAt: string;
+}

--- a/backend/src/modules/withdrawals/withdrawals.controller.ts
+++ b/backend/src/modules/withdrawals/withdrawals.controller.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from 'express';
+import { withdrawalHistoryQuerySchema } from './withdrawals.schema.js';
+import * as withdrawalsService from './withdrawals.service.js';
+
+/** GET /withdrawals/me — withdrawal history for the authenticated user. */
+export async function getMyWithdrawals(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { limit, offset } = withdrawalHistoryQuerySchema.parse(req.query);
+    const result = await withdrawalsService.getWithdrawalHistory(req.user!.id, limit, offset);
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/withdrawals/withdrawals.routes.ts
+++ b/backend/src/modules/withdrawals/withdrawals.routes.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import * as withdrawalsController from './withdrawals.controller.js';
+import { requireAuth } from '../../common/middleware/requireAuth.js';
+
+export const withdrawalsRouter = Router();
+
+withdrawalsRouter.get('/me', requireAuth, withdrawalsController.getMyWithdrawals);

--- a/backend/src/modules/withdrawals/withdrawals.schema.ts
+++ b/backend/src/modules/withdrawals/withdrawals.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const withdrawalHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type WithdrawalHistoryQuery = z.infer<typeof withdrawalHistoryQuerySchema>;

--- a/backend/src/modules/withdrawals/withdrawals.service.ts
+++ b/backend/src/modules/withdrawals/withdrawals.service.ts
@@ -1,0 +1,25 @@
+import { prisma } from '../../db/prisma.js';
+import type { WithdrawalResponse } from './withdrawals.types.js';
+
+export async function getWithdrawalHistory(
+  userId: string,
+  limit: number,
+  offset: number,
+): Promise<WithdrawalResponse[]> {
+  const withdrawals = await prisma.withdrawal.findMany({
+    where: { userId },
+    orderBy: { requestedAt: 'desc' },
+    skip: offset,
+    take: limit,
+  });
+
+  return withdrawals.map((w) => ({
+    id: w.id,
+    amount: w.amount.toString(),
+    fee: w.fee.toString(),
+    txHash: w.txHash,
+    status: w.status,
+    requestedAt: w.requestedAt.toISOString(),
+    confirmedAt: w.confirmedAt ? w.confirmedAt.toISOString() : null,
+  }));
+}

--- a/backend/src/modules/withdrawals/withdrawals.test.ts
+++ b/backend/src/modules/withdrawals/withdrawals.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createApp } from '../../app.js';
+
+const { mockFindMany } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+}));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    withdrawal: {
+      findMany: mockFindMany,
+    },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    verify: vi.fn(),
+  },
+}));
+
+const jwt = await import('jsonwebtoken');
+
+describe('GET /api/v1/withdrawals/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without an Authorization header', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/withdrawals/me');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the authenticated user\'s withdrawal history', async () => {
+    (jwt.default.verify as ReturnType<typeof vi.fn>).mockReturnValue({
+      sub: 'user-1',
+      stellarAddress: 'GABC123',
+    });
+    mockFindMany.mockResolvedValue([
+      {
+        id: 'wd-1',
+        userId: 'user-1',
+        amount: BigInt(1_000_000),
+        fee: BigInt(1_000),
+        txHash: 'tx-1',
+        status: 'CONFIRMED',
+        requestedAt: new Date('2024-01-01T00:00:00.000Z'),
+        confirmedAt: new Date('2024-01-01T00:05:00.000Z'),
+      },
+    ]);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/withdrawals/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({
+      id: 'wd-1',
+      amount: '1000000',
+      fee: '1000',
+      status: 'CONFIRMED',
+    });
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      orderBy: { requestedAt: 'desc' },
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it('returns an empty list when the user has no withdrawals', async () => {
+    (jwt.default.verify as ReturnType<typeof vi.fn>).mockReturnValue({
+      sub: 'user-2',
+      stellarAddress: 'GDEF456',
+    });
+    mockFindMany.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/withdrawals/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+});

--- a/backend/src/modules/withdrawals/withdrawals.types.ts
+++ b/backend/src/modules/withdrawals/withdrawals.types.ts
@@ -1,0 +1,9 @@
+export interface WithdrawalResponse {
+  id: string;
+  amount: string;
+  fee: string;
+  txHash: string | null;
+  status: 'PENDING' | 'CONFIRMED' | 'FAILED';
+  requestedAt: string;
+  confirmedAt: string | null;
+}


### PR DESCRIPTION
## Summary
- Closes #936 — new `withdrawals` module skeleton: routes/controller/service/schema/types, following the same conventions as `credit`/`leaderboard`.
- Closes #937 — `GET /withdrawals/me` (auth-gated via `requireAuth`) returns the authenticated user's withdrawal history, paginated (`limit`/`offset`), reading the existing `Withdrawal` Prisma model.
- Closes #915 — `GET /credit/:userId/history` returns the time-series of a creator's credit score. The formula itself (`computeCreditScore`) was already pure/unit-tested; this adds the read endpoint over the `CreditScoreHistory` table, which `recalculateCreditScore` was already writing to but nothing ever read back.
- Closes #927 (`GET /leaderboard`) — already fully implemented and tested on this branch (`leaderboardRouter` mounted at `/leaderboard`, `GET /` returns top creators). No code change needed; verified its existing test suite still passes.
Closes #936 
Closes #937 
Closes #915 
Closes #927 
## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (0 errors)
- [x] `npm run test` (credit, leaderboard, withdrawals) — 24/24 passed, including 3 new withdrawals tests and 2 new credit-history tests