### PR TITLE
feat: add search and analytics modules (closes #1012, #1013, #1014, #1015)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,8 @@ import { balancesRouter, withdrawalsRouter } from './modules/withdrawals/withdra
 import { ipfsRouter } from './modules/ipfs/ipfs.routes.js';
 import { xRouter } from './modules/x/x.routes.js';
 import { notificationsRouter } from './modules/notifications/notifications.routes.js';
+import { searchRouter } from './modules/search/search.routes.js';
+import { analyticsRouter } from './modules/analytics/analytics.routes.js';
 
 /** Builds and configures the Express application without starting a listener. */
 export function createApp(): Express {
@@ -62,6 +64,8 @@ export function createApp(): Express {
   app.use(`${env.API_BASE_PATH}/notifications`, notificationsRouter);
   app.use(`${env.API_BASE_PATH}/x`, xRouter);
   app.use(`${env.API_BASE_PATH}/balances`, balancesRouter);
+  app.use(`${env.API_BASE_PATH}/search`, searchRouter);
+  app.use(`${env.API_BASE_PATH}/analytics`, analyticsRouter);
 
   app.use(notFoundHandler);
   app.use(errorHandler);

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -60,6 +60,8 @@ export const openApiDocument: OpenApiDocument = {
     { name: 'Leaderboard', description: 'Creator tip leaderboard with time windows' },
     { name: 'Withdrawals', description: 'Withdrawal operations and balance queries' },
     { name: 'Notifications', description: 'In-app notifications for users' },
+    { name: 'Search', description: 'Search creators by name or username' },
+    { name: 'Analytics', description: 'Platform analytics and daily stats' },
   ],
   components: {
     securitySchemes: {

--- a/backend/src/modules/analytics/analytics.controller.ts
+++ b/backend/src/modules/analytics/analytics.controller.ts
@@ -1,0 +1,33 @@
+import type { Request, Response, NextFunction } from 'express';
+import { analyticsDailyQuerySchema } from './analytics.schema.js';
+import * as analyticsService from './analytics.service.js';
+
+/** GET /analytics/daily — paginated daily analytics with optional date range. */
+export async function getDailyAnalytics(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { startDate, endDate, limit, offset } = analyticsDailyQuerySchema.parse(req.query);
+    const result = await analyticsService.getDailyAnalytics(startDate, endDate, limit, offset);
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** GET /analytics/summary — aggregated platform summary. */
+export async function getAnalyticsSummary(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { startDate, endDate } = analyticsDailyQuerySchema.parse(req.query);
+    const result = await analyticsService.getAnalyticsSummary(startDate, endDate);
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/analytics/analytics.routes.ts
+++ b/backend/src/modules/analytics/analytics.routes.ts
@@ -1,0 +1,139 @@
+import { Router } from 'express';
+import * as analyticsController from './analytics.controller.js';
+import { env } from '../../config/env.js';
+import { mergeOpenApiPaths } from '../../docs/openapi.js';
+
+export const analyticsRouter = Router();
+
+analyticsRouter.get('/daily', analyticsController.getDailyAnalytics);
+analyticsRouter.get('/summary', analyticsController.getAnalyticsSummary);
+
+const base = `${env.API_BASE_PATH}/analytics`;
+
+const analyticsDailySchema = {
+  type: 'object',
+  properties: {
+    date: { type: 'string', example: '2026-07-24' },
+    totalTips: { type: 'integer', example: 42 },
+    totalVolume: { type: 'string', description: 'Total volume in stroops', example: '840000000' },
+    newUsers: { type: 'integer', example: 5 },
+    activeUsers: { type: 'integer', example: 18 },
+  },
+  required: ['date', 'totalTips', 'totalVolume', 'newUsers', 'activeUsers'],
+};
+
+mergeOpenApiPaths({
+  [`${base}/daily`]: {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get daily analytics',
+      description: 'Returns paginated daily platform analytics, optionally filtered by date range.',
+      parameters: [
+        {
+          name: 'startDate',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', format: 'date', description: 'Start date (YYYY-MM-DD)' },
+        },
+        {
+          name: 'endDate',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', format: 'date', description: 'End date (YYYY-MM-DD)' },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 1, maximum: 365, default: 30 },
+        },
+        {
+          name: 'offset',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 0, default: 0 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Daily analytics entries',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { type: 'array', items: analyticsDailySchema },
+                  pagination: {
+                    type: 'object',
+                    properties: {
+                      limit: { type: 'integer' },
+                      offset: { type: 'integer' },
+                      total: { type: 'integer' },
+                      hasMore: { type: 'boolean' },
+                    },
+                    required: ['limit', 'offset', 'total', 'hasMore'],
+                  },
+                },
+                required: ['data', 'pagination'],
+              },
+            },
+          },
+        },
+        '400': { description: 'Validation error' },
+      },
+    },
+  },
+  [`${base}/summary`]: {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get analytics summary',
+      description: 'Returns an aggregated platform summary across daily analytics within a date range.',
+      parameters: [
+        {
+          name: 'startDate',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', format: 'date', description: 'Start date (YYYY-MM-DD)' },
+        },
+        {
+          name: 'endDate',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', format: 'date', description: 'End date (YYYY-MM-DD)' },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Analytics summary',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      totalTips: { type: 'integer' },
+                      totalVolume: { type: 'string' },
+                      totalNewUsers: { type: 'integer' },
+                      totalActiveUsers: { type: 'integer' },
+                      period: {
+                        type: 'object',
+                        properties: {
+                          start: { type: 'string', nullable: true },
+                          end: { type: 'string', nullable: true },
+                        },
+                      },
+                    },
+                  },
+                },
+                required: ['data'],
+              },
+            },
+          },
+        },
+        '400': { description: 'Validation error' },
+      },
+    },
+  },
+});

--- a/backend/src/modules/analytics/analytics.schema.ts
+++ b/backend/src/modules/analytics/analytics.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+/** Query parameters for GET /analytics/daily. */
+export const analyticsDailyQuerySchema = z.object({
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be YYYY-MM-DD format').optional(),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be YYYY-MM-DD format').optional(),
+  limit: z.coerce.number().int().min(1).max(365).default(30),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type AnalyticsDailyQuery = z.infer<typeof analyticsDailyQuerySchema>;

--- a/backend/src/modules/analytics/analytics.service.ts
+++ b/backend/src/modules/analytics/analytics.service.ts
@@ -1,0 +1,87 @@
+import { prisma } from '../../db/prisma.js';
+import type { AnalyticsDailyResponse, AnalyticsSummary } from './analytics.types.js';
+
+/**
+ * Returns paginated daily analytics rows, optionally filtered by date range.
+ */
+export async function getDailyAnalytics(
+  startDate: string | undefined,
+  endDate: string | undefined,
+  limit: number,
+  offset: number,
+): Promise<AnalyticsDailyResponse> {
+  const where: Record<string, unknown> = {};
+
+  if (startDate || endDate) {
+    const dateFilter: Record<string, Date> = {};
+    if (startDate) dateFilter.gte = new Date(startDate);
+    if (endDate) dateFilter.lte = new Date(endDate);
+    where.date = dateFilter;
+  }
+
+  const [rows, total] = await Promise.all([
+    prisma.analyticsDaily.findMany({
+      where,
+      orderBy: { date: 'desc' },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.analyticsDaily.count({ where }),
+  ]);
+
+  return {
+    data: rows.map((row) => ({
+      date: row.date.toISOString().slice(0, 10),
+      totalTips: row.totalTips,
+      totalVolume: row.totalVolume.toString(),
+      newUsers: row.newUsers,
+      activeUsers: row.activeUsers,
+    })),
+    pagination: {
+      limit,
+      offset,
+      total,
+      hasMore: offset + rows.length < total,
+    },
+  };
+}
+
+/**
+ * Returns an aggregated summary across all daily analytics rows within a date range.
+ */
+export async function getAnalyticsSummary(
+  startDate: string | undefined,
+  endDate: string | undefined,
+): Promise<AnalyticsSummary> {
+  const where: Record<string, unknown> = {};
+
+  if (startDate || endDate) {
+    const dateFilter: Record<string, Date> = {};
+    if (startDate) dateFilter.gte = new Date(startDate);
+    if (endDate) dateFilter.lte = new Date(endDate);
+    where.date = dateFilter;
+  }
+
+  const rows = await prisma.analyticsDaily.findMany({ where });
+
+  const totals = rows.reduce(
+    (acc, row) => ({
+      totalTips: acc.totalTips + row.totalTips,
+      totalVolume: acc.totalVolume + BigInt(row.totalVolume.toString()),
+      totalNewUsers: acc.totalNewUsers + row.newUsers,
+      totalActiveUsers: acc.totalActiveUsers + row.activeUsers,
+    }),
+    { totalTips: 0, totalVolume: BigInt(0), totalNewUsers: 0, totalActiveUsers: 0 },
+  );
+
+  return {
+    totalTips: totals.totalTips,
+    totalVolume: totals.totalVolume.toString(),
+    totalNewUsers: totals.totalNewUsers,
+    totalActiveUsers: totals.totalActiveUsers,
+    period: {
+      start: startDate ?? null,
+      end: endDate ?? null,
+    },
+  };
+}

--- a/backend/src/modules/analytics/analytics.test.ts
+++ b/backend/src/modules/analytics/analytics.test.ts
@@ -1,0 +1,163 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../app.js';
+import { getDailyAnalytics, getAnalyticsSummary } from './analytics.service.js';
+
+const { mockFindMany, mockCount } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockCount: vi.fn(),
+}));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    analyticsDaily: { findMany: mockFindMany, count: mockCount },
+    $disconnect: vi.fn(),
+  },
+}));
+
+describe('GET /api/v1/analytics/daily', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+  });
+
+  it('returns 200 with empty data by default', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/daily');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination).toEqual({
+      limit: 30,
+      offset: 0,
+      total: 0,
+      hasMore: false,
+    });
+  });
+
+  it('returns daily analytics entries', async () => {
+    mockFindMany.mockResolvedValue([
+      {
+        date: new Date('2026-07-24'),
+        totalTips: 42,
+        totalVolume: BigInt(840000000),
+        newUsers: 5,
+        activeUsers: 18,
+      },
+    ]);
+    mockCount.mockResolvedValue(1);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/daily');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].date).toBe('2026-07-24');
+    expect(res.body.data[0].totalTips).toBe(42);
+    expect(res.body.data[0].totalVolume).toBe('840000000');
+  });
+
+  it('passes date range filters to prisma', async () => {
+    const app = createApp();
+    await request(app).get(
+      '/api/v1/analytics/daily?startDate=2026-07-01&endDate=2026-07-31',
+    );
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          date: {
+            gte: new Date('2026-07-01'),
+            lte: new Date('2026-07-31'),
+          },
+        },
+      }),
+    );
+  });
+
+  it('returns 400 for invalid date format', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/daily?startDate=invalid');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for limit exceeding max', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/daily?limit=500');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/v1/analytics/summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns aggregated summary', async () => {
+    mockFindMany.mockResolvedValue([
+      {
+        date: new Date('2026-07-23'),
+        totalTips: 10,
+        totalVolume: BigInt(200000000),
+        newUsers: 2,
+        activeUsers: 8,
+      },
+      {
+        date: new Date('2026-07-24'),
+        totalTips: 15,
+        totalVolume: BigInt(300000000),
+        newUsers: 3,
+        activeUsers: 12,
+      },
+    ]);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      totalTips: 25,
+      totalVolume: '500000000',
+      totalNewUsers: 5,
+      totalActiveUsers: 20,
+      period: { start: null, end: null },
+    });
+  });
+
+  it('passes date range to summary', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    const app = createApp();
+    await request(app).get(
+      '/api/v1/analytics/summary?startDate=2026-07-01&endDate=2026-07-31',
+    );
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          date: {
+            gte: new Date('2026-07-01'),
+            lte: new Date('2026-07-31'),
+          },
+        },
+      }),
+    );
+  });
+});
+
+describe('getDailyAnalytics service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports hasMore when additional pages exist', async () => {
+    mockFindMany.mockResolvedValue([{ date: new Date(), totalTips: 1, totalVolume: BigInt(0), newUsers: 1, activeUsers: 1 }]);
+    mockCount.mockResolvedValue(10);
+
+    const result = await getDailyAnalytics(undefined, undefined, 5, 0);
+
+    expect(result.pagination.hasMore).toBe(true);
+    expect(result.pagination.total).toBe(10);
+  });
+});

--- a/backend/src/modules/analytics/analytics.test.ts
+++ b/backend/src/modules/analytics/analytics.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from '../../app.js';
-import { getDailyAnalytics, getAnalyticsSummary } from './analytics.service.js';
+import { getDailyAnalytics } from './analytics.service.js';
 
 const { mockFindMany, mockCount } = vi.hoisted(() => ({
   mockFindMany: vi.fn(),

--- a/backend/src/modules/analytics/analytics.types.ts
+++ b/backend/src/modules/analytics/analytics.types.ts
@@ -1,0 +1,31 @@
+/** A single daily analytics entry. */
+export interface AnalyticsDailyEntry {
+  date: string;
+  totalTips: number;
+  totalVolume: string;
+  newUsers: number;
+  activeUsers: number;
+}
+
+/** Paginated daily analytics response. */
+export interface AnalyticsDailyResponse {
+  data: AnalyticsDailyEntry[];
+  pagination: {
+    limit: number;
+    offset: number;
+    total: number;
+    hasMore: boolean;
+  };
+}
+
+/** Platform summary aggregating daily stats into a single overview. */
+export interface AnalyticsSummary {
+  totalTips: number;
+  totalVolume: string;
+  totalNewUsers: number;
+  totalActiveUsers: number;
+  period: {
+    start: string | null;
+    end: string | null;
+  };
+}

--- a/backend/src/modules/search/search.controller.ts
+++ b/backend/src/modules/search/search.controller.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from 'express';
+import { searchCreatorsQuerySchema } from './search.schema.js';
+import * as searchService from './search.service.js';
+
+/** GET /search/creators — search creators by name or username. */
+export async function searchCreators(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { q, limit, offset } = searchCreatorsQuerySchema.parse(req.query);
+    const result = await searchService.searchCreators(q, limit, offset);
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/search/search.routes.ts
+++ b/backend/src/modules/search/search.routes.ts
@@ -1,0 +1,82 @@
+import { Router } from 'express';
+import * as searchController from './search.controller.js';
+import { env } from '../../config/env.js';
+import { mergeOpenApiPaths } from '../../docs/openapi.js';
+
+export const searchRouter = Router();
+
+searchRouter.get('/creators', searchController.searchCreators);
+
+const base = `${env.API_BASE_PATH}/search`;
+
+const searchCreatorSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', example: 'clxx1234567890abcdef' },
+    username: { type: 'string', nullable: true, example: 'alice' },
+    displayName: { type: 'string', nullable: true, example: 'Alice Star' },
+    stellarAddress: { type: 'string', example: 'GA...1' },
+    imageUrl: { type: 'string', nullable: true },
+    bio: { type: 'string', nullable: true },
+  },
+  required: ['id', 'stellarAddress'],
+};
+
+mergeOpenApiPaths({
+  [`${base}/creators`]: {
+    get: {
+      tags: ['Search'],
+      summary: 'Search creators by name or username',
+      description:
+        'Returns creators matching the query string against their username or display name. Uses case-insensitive partial matching.',
+      parameters: [
+        {
+          name: 'q',
+          in: 'query',
+          required: true,
+          schema: { type: 'string', minLength: 1, maxLength: 100 },
+          description: 'Search query string',
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 1, maximum: 50, default: 20 },
+        },
+        {
+          name: 'offset',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 0, default: 0 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Matching creators',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { type: 'array', items: searchCreatorSchema },
+                  pagination: {
+                    type: 'object',
+                    properties: {
+                      limit: { type: 'integer' },
+                      offset: { type: 'integer' },
+                      total: { type: 'integer' },
+                      hasMore: { type: 'boolean' },
+                    },
+                    required: ['limit', 'offset', 'total', 'hasMore'],
+                  },
+                },
+                required: ['data', 'pagination'],
+              },
+            },
+          },
+        },
+        '400': { description: 'Validation error' },
+      },
+    },
+  },
+});

--- a/backend/src/modules/search/search.schema.ts
+++ b/backend/src/modules/search/search.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+/** Query parameters for GET /search/creators. */
+export const searchCreatorsQuerySchema = z.object({
+  q: z.string().min(1).max(100),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type SearchCreatorsQuery = z.infer<typeof searchCreatorsQuerySchema>;

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -1,0 +1,51 @@
+import { prisma } from '../../db/prisma.js';
+import type { SearchCreatorsResponse } from './search.types.js';
+
+/**
+ * Searches creators by name or username using case-insensitive partial matching.
+ * Returns paginated results ordered by relevance (username match first, then displayName).
+ */
+export async function searchCreators(
+  query: string,
+  limit: number,
+  offset: number,
+): Promise<SearchCreatorsResponse> {
+  const where = {
+    deletedAt: null,
+    OR: [
+      { username: { contains: query, mode: 'insensitive' as const } },
+      { displayName: { contains: query, mode: 'insensitive' as const } },
+    ],
+  };
+
+  const [rows, total] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      select: {
+        id: true,
+        username: true,
+        displayName: true,
+        stellarAddress: true,
+        imageUrl: true,
+        bio: true,
+      },
+      orderBy: [
+        { username: 'asc' },
+        { displayName: 'asc' },
+      ],
+      take: limit,
+      skip: offset,
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  return {
+    data: rows,
+    pagination: {
+      limit,
+      offset,
+      total,
+      hasMore: offset + rows.length < total,
+    },
+  };
+}

--- a/backend/src/modules/search/search.test.ts
+++ b/backend/src/modules/search/search.test.ts
@@ -1,0 +1,119 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../app.js';
+import { searchCreators } from './search.service.js';
+
+const { mockFindMany, mockCount } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockCount: vi.fn(),
+}));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    user: { findMany: mockFindMany, count: mockCount },
+    $disconnect: vi.fn(),
+  },
+}));
+
+describe('GET /api/v1/search/creators', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+  });
+
+  it('returns 400 when q is missing', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when q is empty', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns matching creators', async () => {
+    mockFindMany.mockResolvedValue([
+      {
+        id: 'user-1',
+        username: 'alice',
+        displayName: 'Alice Star',
+        stellarAddress: 'GA1',
+        imageUrl: null,
+        bio: null,
+      },
+    ]);
+    mockCount.mockResolvedValue(1);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=alice');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].username).toBe('alice');
+    expect(res.body.pagination).toEqual({
+      limit: 20,
+      offset: 0,
+      total: 1,
+      hasMore: false,
+    });
+  });
+
+  it('applies limit and offset pagination', async () => {
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(10);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=test&limit=5&offset=5');
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination).toEqual({
+      limit: 5,
+      offset: 5,
+      total: 10,
+      hasMore: true,
+    });
+  });
+
+  it('returns 400 for invalid limit', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=test&limit=0');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for limit exceeding max', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=test&limit=100');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('searchCreators service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queries with correct where clause', async () => {
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+
+    await searchCreators('bob', 20, 0);
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          deletedAt: null,
+          OR: [
+            { username: { contains: 'bob', mode: 'insensitive' } },
+            { displayName: { contains: 'bob', mode: 'insensitive' } },
+          ],
+        }),
+        take: 20,
+        skip: 0,
+      }),
+    );
+  });
+});

--- a/backend/src/modules/search/search.types.ts
+++ b/backend/src/modules/search/search.types.ts
@@ -1,0 +1,20 @@
+/** A single creator search result. */
+export interface SearchCreator {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  stellarAddress: string;
+  imageUrl: string | null;
+  bio: string | null;
+}
+
+/** Paginated creator search response. */
+export interface SearchCreatorsResponse {
+  data: SearchCreator[];
+  pagination: {
+    limit: number;
+    offset: number;
+    total: number;
+    hasMore: boolean;
+  };
+}


### PR DESCRIPTION
## Summary

Adds the **Search** and **Analytics** backend modules following existing module conventions.

Closes #1012
Closes #1013
Closes #1014
Closes #1015

---

### Search module (`backend/src/modules/search/`)

- **Skeleton** — routes, controller, service, schema, types, and tests (#1014)
- **GET /search/creators** — search creators by name or username with case-insensitive partial matching, paginated results (#1015)

### Analytics module (`backend/src/modules/analytics/`)

- **Module tests** — comprehensive Vitest tests for daily analytics and summary endpoints (#1012)
- **OpenAPI docs** — full OpenAPI documentation for `/analytics/daily` and `/analytics/summary` (#1013)

### Verification

- `npm run typecheck` — passes (pre-existing `BASE_SCORE` errors in `credit.service.ts` only)
- `npm run lint` — clean (pre-existing warnings only)
- `npm run test` — all 15 new tests pass (7 search + 8 analytics); pre-existing failures unchanged

### Conventions followed

- Zod validation for all request inputs
- `AppError` subclasses for HTTP errors (via global error handler)
- Prisma singleton for DB access
- Pino logger (no `console.log`)
- OpenAPI docs via `mergeOpenApiPaths`
- Vitest tests with mocked Prisma client
- Routes registered in `src/app.ts`