### PR TITLE
feat(goals): implement goals module skeleton

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -20,6 +20,7 @@ import { notificationsRouter } from './modules/notifications/notifications.route
 import { searchRouter } from './modules/search/search.routes.js';
 import { webhooksRouter } from './modules/webhooks/webhooks.routes.js';
 import { analyticsRouter } from './modules/analytics/analytics.routes.js';
+import { goalsRouter } from './modules/goals/goals.routes.js';
 
 /** Builds and configures the Express application without starting a listener. */
 export function createApp(): Express {
@@ -68,6 +69,7 @@ export function createApp(): Express {
   app.use(`${env.API_BASE_PATH}/search`, searchRouter);
   app.use(`${env.API_BASE_PATH}/webhooks`, webhooksRouter);
   app.use(`${env.API_BASE_PATH}/analytics`, analyticsRouter);
+  app.use(`${env.API_BASE_PATH}/goals`, goalsRouter);
 
   app.use(notFoundHandler);
   app.use(errorHandler);

--- a/backend/src/modules/goals/goals.controller.ts
+++ b/backend/src/modules/goals/goals.controller.ts
@@ -1,0 +1,105 @@
+import type { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { BadRequestError } from '../../common/errors/AppError.js';
+import type { AuthPayload } from '../auth/auth.types.js';
+import * as goalsService from './goals.service.js';
+import {
+  createGoalSchema,
+  updateGoalSchema,
+  goalIdSchema,
+  goalListQuerySchema,
+} from './goals.schema.js';
+
+export async function createGoalController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const auth = req.auth as AuthPayload;
+    const data = createGoalSchema.parse(req.body);
+    const goal = await goalsService.createGoal(auth.userId, data);
+    res.status(201).json({ data: goal });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError('Invalid goal data', error.issues));
+    } else {
+      next(error);
+    }
+  }
+}
+
+export async function getGoalController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id } = goalIdSchema.parse(req.params);
+    const goal = await goalsService.getGoalById(id);
+    res.json({ data: goal });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError('Invalid goal ID', error.issues));
+    } else {
+      next(error);
+    }
+  }
+}
+
+export async function listGoalsController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { limit, offset, status } = goalListQuerySchema.parse(req.query);
+    const result = await goalsService.listGoals(limit, offset, status);
+    res.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError('Invalid query parameters', error.issues));
+    } else {
+      next(error);
+    }
+  }
+}
+
+export async function updateGoalController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const auth = req.auth as AuthPayload;
+    const { id } = goalIdSchema.parse(req.params);
+    const data = updateGoalSchema.parse(req.body);
+    const goal = await goalsService.updateGoal(id, auth.userId, data);
+    res.json({ data: goal });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError('Invalid goal data', error.issues));
+    } else {
+      next(error);
+    }
+  }
+}
+
+export async function cancelGoalController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const auth = req.auth as AuthPayload;
+    const { id } = goalIdSchema.parse(req.params);
+    const goal = await goalsService.cancelGoal(id, auth.userId);
+    res.json({ data: goal });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError('Invalid goal ID', error.issues));
+    } else {
+      next(error);
+    }
+  }
+}

--- a/backend/src/modules/goals/goals.routes.ts
+++ b/backend/src/modules/goals/goals.routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { requireAuth } from '../auth/auth.middleware.js';
+import {
+  createGoalController,
+  getGoalController,
+  listGoalsController,
+  updateGoalController,
+  cancelGoalController,
+} from './goals.controller.js';
+
+export const goalsRouter = Router();
+
+goalsRouter.get('/', listGoalsController);
+goalsRouter.get('/:id', getGoalController);
+goalsRouter.post('/', requireAuth, createGoalController);
+goalsRouter.patch('/:id', requireAuth, updateGoalController);
+goalsRouter.delete('/:id', requireAuth, cancelGoalController);

--- a/backend/src/modules/goals/goals.schema.ts
+++ b/backend/src/modules/goals/goals.schema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const createGoalSchema = z.object({
+  title: z.string().min(1).max(200),
+  targetStroops: z.string().regex(/^\d+$/, 'Must be a positive integer string'),
+  deadline: z.string().datetime({ offset: true }).optional(),
+});
+
+export const updateGoalSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  targetStroops: z.string().regex(/^\d+$/, 'Must be a positive integer string').optional(),
+  deadline: z.string().datetime({ offset: true }).nullable().optional(),
+  status: z.enum(['ACTIVE', 'CANCELLED']).optional(),
+});
+
+export const goalIdSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const goalListQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+  status: z.enum(['ACTIVE', 'COMPLETED', 'CANCELLED', 'EXPIRED']).optional(),
+});
+
+export type CreateGoalInput = z.infer<typeof createGoalSchema>;
+export type UpdateGoalInput = z.infer<typeof updateGoalSchema>;
+export type GoalIdInput = z.infer<typeof goalIdSchema>;
+export type GoalListQuery = z.infer<typeof goalListQuerySchema>;

--- a/backend/src/modules/goals/goals.service.ts
+++ b/backend/src/modules/goals/goals.service.ts
@@ -1,0 +1,134 @@
+import { prisma } from '../../db/prisma.js';
+import { NotFoundError, ForbiddenError } from '../../common/errors/AppError.js';
+import type { GoalResponse, GoalListResponse } from './goals.types.js';
+import type { CreateGoalInput, UpdateGoalInput } from './goals.schema.js';
+
+function serializeGoal(goal: {
+  id: string;
+  userId: string;
+  title: string;
+  targetStroops: bigint;
+  raisedStroops: bigint;
+  deadline: Date | null;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}): GoalResponse {
+  return {
+    id: goal.id,
+    userId: goal.userId,
+    title: goal.title,
+    targetStroops: goal.targetStroops.toString(),
+    raisedStroops: goal.raisedStroops.toString(),
+    deadline: goal.deadline?.toISOString() ?? null,
+    status: goal.status,
+    createdAt: goal.createdAt.toISOString(),
+    updatedAt: goal.updatedAt.toISOString(),
+  };
+}
+
+export async function createGoal(
+  userId: string,
+  data: CreateGoalInput,
+): Promise<GoalResponse> {
+  const goal = await prisma.goal.create({
+    data: {
+      userId,
+      title: data.title,
+      targetStroops: BigInt(data.targetStroops),
+      deadline: data.deadline ? new Date(data.deadline) : null,
+    },
+  });
+
+  return serializeGoal(goal);
+}
+
+export async function getGoalById(goalId: string): Promise<GoalResponse> {
+  const goal = await prisma.goal.findUnique({ where: { id: goalId } });
+
+  if (!goal || goal.deletedAt !== null) {
+    throw new NotFoundError('Goal not found');
+  }
+
+  return serializeGoal(goal);
+}
+
+export async function listGoals(
+  limit: number,
+  offset: number,
+  status?: string,
+): Promise<GoalListResponse> {
+  const where: Record<string, unknown> = { deletedAt: null };
+  if (status) where.status = status;
+
+  const [goals, total] = await Promise.all([
+    prisma.goal.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.goal.count({ where }),
+  ]);
+
+  return {
+    data: goals.map(serializeGoal),
+    pagination: {
+      limit,
+      offset,
+      total,
+      hasMore: offset + goals.length < total,
+    },
+  };
+}
+
+export async function updateGoal(
+  goalId: string,
+  userId: string,
+  data: UpdateGoalInput,
+): Promise<GoalResponse> {
+  const goal = await prisma.goal.findUnique({ where: { id: goalId } });
+
+  if (!goal || goal.deletedAt !== null) {
+    throw new NotFoundError('Goal not found');
+  }
+
+  if (goal.userId !== userId) {
+    throw new ForbiddenError('You can only update your own goals');
+  }
+
+  const updateData: Record<string, unknown> = {};
+  if (data.title !== undefined) updateData.title = data.title;
+  if (data.targetStroops !== undefined) updateData.targetStroops = BigInt(data.targetStroops);
+  if (data.deadline !== undefined) updateData.deadline = data.deadline ? new Date(data.deadline) : null;
+  if (data.status !== undefined) updateData.status = data.status;
+
+  const updated = await prisma.goal.update({
+    where: { id: goalId },
+    data: updateData,
+  });
+
+  return serializeGoal(updated);
+}
+
+export async function cancelGoal(
+  goalId: string,
+  userId: string,
+): Promise<GoalResponse> {
+  const goal = await prisma.goal.findUnique({ where: { id: goalId } });
+
+  if (!goal || goal.deletedAt !== null) {
+    throw new NotFoundError('Goal not found');
+  }
+
+  if (goal.userId !== userId) {
+    throw new ForbiddenError('You can only cancel your own goals');
+  }
+
+  const updated = await prisma.goal.update({
+    where: { id: goalId },
+    data: { status: 'CANCELLED' },
+  });
+
+  return serializeGoal(updated);
+}

--- a/backend/src/modules/goals/goals.test.ts
+++ b/backend/src/modules/goals/goals.test.ts
@@ -1,0 +1,334 @@
+import request from 'supertest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createApp } from '../../app.js';
+
+const { mockGoalFindUnique, mockGoalFindMany, mockGoalCreate, mockGoalUpdate, mockGoalCount } =
+  vi.hoisted(() => ({
+    mockGoalFindUnique: vi.fn(),
+    mockGoalFindMany: vi.fn(),
+    mockGoalCreate: vi.fn(),
+    mockGoalUpdate: vi.fn(),
+    mockGoalCount: vi.fn(),
+  }));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    goal: {
+      findUnique: mockGoalFindUnique,
+      findMany: mockGoalFindMany,
+      create: mockGoalCreate,
+      update: mockGoalUpdate,
+      count: mockGoalCount,
+    },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    verify: vi.fn(() => ({
+      userId: 'user-1',
+      stellarAddress: 'GABCDEF123456789012345678901234567890123456789012345678901234',
+      role: 'user',
+      scopes: [],
+    })),
+  },
+  verify: vi.fn(() => ({
+    userId: 'user-1',
+    stellarAddress: 'GABCDEF123456789012345678901234567890123456789012345678901234',
+    role: 'user',
+    scopes: [],
+  })),
+}));
+
+function resetMocks() {
+  vi.clearAllMocks();
+  mockGoalFindMany.mockResolvedValue([]);
+  mockGoalCount.mockResolvedValue(0);
+}
+
+describe('GET /api/v1/goals', () => {
+  beforeEach(resetMocks);
+
+  it('returns 200 with empty list by default', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/goals');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.pagination).toEqual({
+      limit: 20,
+      offset: 0,
+      total: 0,
+      hasMore: false,
+    });
+  });
+
+  it('returns goals with pagination', async () => {
+    const now = new Date();
+    mockGoalFindMany.mockResolvedValue([
+      {
+        id: 'goal-1',
+        userId: 'user-1',
+        title: 'Fund my project',
+        targetStroops: BigInt(1000000000),
+        raisedStroops: BigInt(500000000),
+        deadline: null,
+        status: 'ACTIVE',
+        deletedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    mockGoalCount.mockResolvedValue(1);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/goals');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].title).toBe('Fund my project');
+    expect(res.body.data[0].targetStroops).toBe('1000000000');
+    expect(res.body.data[0].raisedStroops).toBe('500000000');
+    expect(res.body.pagination.total).toBe(1);
+  });
+
+  it('filters by status', async () => {
+    const app = createApp();
+    await request(app).get('/api/v1/goals?status=ACTIVE');
+
+    expect(mockGoalFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: 'ACTIVE' }),
+      }),
+    );
+  });
+});
+
+describe('GET /api/v1/goals/:id', () => {
+  beforeEach(resetMocks);
+
+  it('returns 200 for an existing goal', async () => {
+    const now = new Date();
+    mockGoalFindUnique.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-1',
+      title: 'Test goal',
+      targetStroops: BigInt(1000000),
+      raisedStroops: BigInt(500000),
+      deadline: null,
+      status: 'ACTIVE',
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/goals/goal-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.title).toBe('Test goal');
+  });
+
+  it('returns 404 for a non-existent goal', async () => {
+    mockGoalFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/goals/nonexistent');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/v1/goals', () => {
+  beforeEach(resetMocks);
+
+  it('returns 201 when creating a goal', async () => {
+    const now = new Date();
+    mockGoalCreate.mockResolvedValue({
+      id: 'goal-new',
+      userId: 'user-1',
+      title: 'New goal',
+      targetStroops: BigInt(2000000),
+      raisedStroops: BigInt(0),
+      deadline: null,
+      status: 'ACTIVE',
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/goals')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ title: 'New goal', targetStroops: '2000000' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.title).toBe('New goal');
+    expect(res.body.data.targetStroops).toBe('2000000');
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/goals')
+      .send({ title: 'New goal', targetStroops: '2000000' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid data', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/goals')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ title: '', targetStroops: 'abc' });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('PATCH /api/v1/goals/:id', () => {
+  beforeEach(resetMocks);
+
+  it('returns 200 when updating own goal', async () => {
+    const now = new Date();
+    mockGoalFindUnique.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-1',
+      title: 'Old title',
+      targetStroops: BigInt(1000000),
+      raisedStroops: BigInt(0),
+      deadline: null,
+      status: 'ACTIVE',
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    mockGoalUpdate.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-1',
+      title: 'Updated title',
+      targetStroops: BigInt(2000000),
+      raisedStroops: BigInt(0),
+      deadline: null,
+      status: 'ACTIVE',
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .patch('/api/v1/goals/goal-1')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ title: 'Updated title', targetStroops: '2000000' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.title).toBe('Updated title');
+  });
+
+  it('returns 403 when updating another user goal', async () => {
+    mockGoalFindUnique.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-2',
+      title: 'Other user goal',
+      targetStroops: BigInt(1000000),
+      raisedStroops: BigInt(0),
+      deadline: null,
+      status: 'ACTIVE',
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .patch('/api/v1/goals/goal-1')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ title: 'Hacked' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .patch('/api/v1/goals/goal-1')
+      .send({ title: 'Updated' });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/v1/goals/:id', () => {
+  beforeEach(resetMocks);
+
+  it('returns 200 when cancelling own goal', async () => {
+    const now = new Date();
+    mockGoalFindUnique.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-1',
+      title: 'My goal',
+      targetStroops: BigInt(1000000),
+      raisedStroops: BigInt(0),
+      deadline: null,
+      status: 'ACTIVE',
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    mockGoalUpdate.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-1',
+      title: 'My goal',
+      targetStroops: BigInt(1000000),
+      raisedStroops: BigInt(0),
+      deadline: null,
+      status: 'CANCELLED',
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .delete('/api/v1/goals/goal-1')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('CANCELLED');
+  });
+
+  it('returns 403 when cancelling another user goal', async () => {
+    mockGoalFindUnique.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-2',
+      title: 'Other goal',
+      targetStroops: BigInt(1000000),
+      raisedStroops: BigInt(0),
+      deadline: null,
+      status: 'ACTIVE',
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .delete('/api/v1/goals/goal-1')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 without auth', async () => {
+    const app = createApp();
+    const res = await request(app).delete('/api/v1/goals/goal-1');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/modules/goals/goals.types.ts
+++ b/backend/src/modules/goals/goals.types.ts
@@ -1,0 +1,34 @@
+export interface GoalResponse {
+  id: string;
+  userId: string;
+  title: string;
+  targetStroops: string;
+  raisedStroops: string;
+  deadline: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateGoalRequest {
+  title: string;
+  targetStroops: string;
+  deadline?: string;
+}
+
+export interface UpdateGoalRequest {
+  title?: string;
+  targetStroops?: string;
+  deadline?: string | null;
+  status?: 'ACTIVE' | 'CANCELLED';
+}
+
+export interface GoalListResponse {
+  data: GoalResponse[];
+  pagination: {
+    limit: number;
+    offset: number;
+    total: number;
+    hasMore: boolean;
+  };
+}


### PR DESCRIPTION
## Summary

Implements the Goals module skeleton with full CRUD endpoints and ownership-based authorization.

## Changes

### New files under `backend/src/modules/goals/`
- **`goals.types.ts`** — TypeScript interfaces for GoalResponse, request types, and paginated list response
- **`goals.schema.ts`** — Zod validation schemas for create/update/list query inputs
- **`goals.service.ts`** — Business logic: createGoal, getGoalById, listGoals, updateGoal, cancelGoal (with ownership checks)
- **`goals.controller.ts`** — Express request/response handlers with Zod error handling
- **`goals.routes.ts`** — Router wiring: `GET /`, `GET /:id` (public), `POST /`, `PATCH /:id`, `DELETE /:id` (authenticated via `requireAuth`)
- **`goals.test.ts`** — 14 tests covering all endpoints including auth enforcement and ownership verification

### Modified files
- **`backend/src/app.ts`** — Mounted `goalsRouter` at `${API_BASE_PATH}/goals`

## Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | /goals | No | List goals (paginated, optional status filter) |
| GET | /goals/:id | No | Get a single goal |
| POST | /goals | Yes | Create a goal |
| PATCH | /goals/:id | Yes | Update own goal (ownership check) |
| DELETE | /goals/:id | Yes | Cancel own goal (ownership check) |

## Tests
- 14 tests pass covering success, auth enforcement, authorization (ownership), and validation error cases
- Typecheck and lint pass (0 errors)

Closes #1020