### PR TITLE
feat(jobs): BullMQ queue factory, scheduler, and standalone worker entrypoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,8 @@
     "dev": "tsx watch src/server.ts",
     "indexer": "tsx src/indexer/main.ts",
     "indexer:dev": "tsx watch src/indexer/main.ts",
+    "jobs": "tsx src/jobs/main.ts",
+    "jobs:dev": "tsx watch src/jobs/main.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "typecheck": "tsc --noEmit",

--- a/backend/src/jobs/analyticsDaily.queue.ts
+++ b/backend/src/jobs/analyticsDaily.queue.ts
@@ -1,19 +1,8 @@
-import { Queue } from 'bullmq';
-import { redis } from '../db/redis.js';
+import { getQueue } from './queueFactory.js';
 
 export const ANALYTICS_DAILY_QUEUE = 'analytics-daily';
 
-let queue: Queue | null = null;
-
-export function getAnalyticsDailyQueue(): Queue {
-  if (!queue) {
-    queue = new Queue(ANALYTICS_DAILY_QUEUE, {
-      connection: redis as any,
-      defaultJobOptions: {
-        removeOnComplete: { age: 3600 },
-        removeOnFail: { age: 86400 },
-      },
-    });
-  }
-  return queue;
+/** Lazily-initialised singleton Queue for daily analytics rollup jobs. */
+export function getAnalyticsDailyQueue() {
+  return getQueue(ANALYTICS_DAILY_QUEUE);
 }

--- a/backend/src/jobs/analyticsDaily.worker.ts
+++ b/backend/src/jobs/analyticsDaily.worker.ts
@@ -4,6 +4,7 @@ import { config } from '../config/index.js';
 import { logger } from '../common/utils/logger.js';
 import { computeDailyAnalytics } from '../modules/analytics/analytics.service.js';
 import { ANALYTICS_DAILY_QUEUE, getAnalyticsDailyQueue } from './analyticsDaily.queue.js';
+import { scheduleRepeatable } from './scheduler.js';
 
 export async function runDailyAnalyticsRollup(): Promise<{ date: string; totalTips: number; totalVolume: string }> {
   // Compute for yesterday in UTC so the job can run anytime after midnight
@@ -33,20 +34,9 @@ export function createAnalyticsDailyWorker(): Worker {
 }
 
 export async function scheduleAnalyticsDaily(): Promise<void> {
-  const queue = getAnalyticsDailyQueue();
-  const repeatableJobs = await queue.getRepeatableJobs();
-  const alreadyScheduled = repeatableJobs.some(
-    (j) => j.name === 'rollup' && j.pattern === config.analytics.dailyCron,
-  );
-
-  if (!alreadyScheduled) {
-    await queue.add(
-      'rollup',
-      {},
-      {
-        repeat: { pattern: config.analytics.dailyCron },
-      },
-    );
-    logger.info({ cron: config.analytics.dailyCron }, 'Daily analytics rollup scheduled');
-  }
+  await scheduleRepeatable({
+    queue: getAnalyticsDailyQueue(),
+    name: 'rollup',
+    pattern: config.analytics.dailyCron,
+  });
 }

--- a/backend/src/jobs/creditRecompute.queue.ts
+++ b/backend/src/jobs/creditRecompute.queue.ts
@@ -1,19 +1,8 @@
-import { Queue } from 'bullmq';
-import { redis } from '../db/redis.js';
+import { getQueue } from './queueFactory.js';
 
 export const CREDIT_RECOMPUTE_QUEUE = 'credit-recompute';
 
-let queue: Queue | null = null;
-
-export function getCreditRecomputeQueue(): Queue {
-  if (!queue) {
-    queue = new Queue(CREDIT_RECOMPUTE_QUEUE, {
-      connection: redis as any,
-      defaultJobOptions: {
-        removeOnComplete: { age: 3600 },
-        removeOnFail: { age: 86400 },
-      },
-    });
-  }
-  return queue;
+/** Lazily-initialised singleton Queue for credit-score recompute jobs. */
+export function getCreditRecomputeQueue() {
+  return getQueue(CREDIT_RECOMPUTE_QUEUE);
 }

--- a/backend/src/jobs/creditRecompute.worker.ts
+++ b/backend/src/jobs/creditRecompute.worker.ts
@@ -5,6 +5,7 @@ import { config } from '../config/index.js';
 import { logger } from '../common/utils/logger.js';
 import { recalculateCreditScore } from '../modules/credit/credit.service.js';
 import { CREDIT_RECOMPUTE_QUEUE, getCreditRecomputeQueue } from './creditRecompute.queue.js';
+import { scheduleRepeatable } from './scheduler.js';
 
 export async function recomputeAllScores(): Promise<{ processed: number; failed: number }> {
   const users = await prisma.user.findMany({
@@ -46,20 +47,9 @@ export function createCreditRecomputeWorker(): Worker {
 }
 
 export async function scheduleCreditRecompute(): Promise<void> {
-  const queue = getCreditRecomputeQueue();
-  const repeatableJobs = await queue.getRepeatableJobs();
-  const alreadyScheduled = repeatableJobs.some(
-    (j) => j.name === 'recompute' && j.pattern === config.credit.recomputeCron,
-  );
-
-  if (!alreadyScheduled) {
-    await queue.add(
-      'recompute',
-      {},
-      {
-        repeat: { pattern: config.credit.recomputeCron },
-      },
-    );
-    logger.info({ cron: config.credit.recomputeCron }, 'Credit recompute scheduled');
-  }
+  await scheduleRepeatable({
+    queue: getCreditRecomputeQueue(),
+    name: 'recompute',
+    pattern: config.credit.recomputeCron,
+  });
 }

--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -1,3 +1,6 @@
+export { getQueue } from './queueFactory.js';
+export { scheduleRepeatable } from './scheduler.js';
+
 export {
   CREDIT_RECOMPUTE_QUEUE,
   getCreditRecomputeQueue,
@@ -17,3 +20,5 @@ export {
   createAnalyticsDailyWorker,
   scheduleAnalyticsDaily,
 } from './analyticsDaily.worker.js';
+
+export { bootstrapJobs } from './main.js';

--- a/backend/src/jobs/main.test.ts
+++ b/backend/src/jobs/main.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockRegisterClosable, mockCloseAll, mockPrismaDisconnect, mockRedisQuit, mockScheduleRepeatable } = vi.hoisted(() => ({
+  mockRegisterClosable: vi.fn(),
+  mockCloseAll: vi.fn(),
+  mockPrismaDisconnect: vi.fn(),
+  mockRedisQuit: vi.fn(),
+  mockScheduleRepeatable: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../common/utils/lifecycle.js', () => ({
+  registerClosable: mockRegisterClosable,
+  closeAll: mockCloseAll,
+}));
+
+vi.mock('../db/prisma.js', () => ({
+  prisma: { $disconnect: mockPrismaDisconnect },
+}));
+
+vi.mock('../db/redis.js', () => ({
+  redis: { quit: mockRedisQuit },
+}));
+
+vi.mock('../config/index.js', () => ({
+  config: {
+    credit: { recomputeCron: '0 */6 * * *' },
+    analytics: { dailyCron: '5 0 * * *' },
+  },
+}));
+
+vi.mock('./scheduler.js', () => ({
+  scheduleRepeatable: mockScheduleRepeatable,
+}));
+
+vi.mock('../common/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const mockWorkerClose = vi.fn().mockResolvedValue(undefined);
+const mockWorkerOn = vi.fn();
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation(() => ({
+    name: 'mock-queue',
+    add: vi.fn(),
+    getRepeatableJobs: vi.fn().mockResolvedValue([]),
+  })),
+  Worker: vi.fn().mockImplementation(() => ({
+    close: mockWorkerClose,
+    on: mockWorkerOn,
+  })),
+}));
+
+describe('bootstrapJobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWorkerClose.mockResolvedValue(undefined);
+  });
+
+  it('registers Prisma and Redis as closable resources', async () => {
+    const { bootstrapJobs } = await import('./main.js');
+    await bootstrapJobs();
+
+    const closableNames = mockRegisterClosable.mock.calls.map((c: any[]) => c[0].name);
+    expect(closableNames).toContain('Prisma');
+    expect(closableNames).toContain('Redis');
+  });
+
+  it('registers credit and analytics workers as closable', async () => {
+    const { bootstrapJobs } = await import('./main.js');
+    await bootstrapJobs();
+
+    const closableNames = mockRegisterClosable.mock.calls.map((c: any[]) => c[0].name);
+    expect(closableNames).toContain('CreditRecomputeWorker');
+    expect(closableNames).toContain('AnalyticsDailyWorker');
+  });
+
+  it('schedules both credit recompute and analytics daily jobs', async () => {
+    const { bootstrapJobs } = await import('./main.js');
+    await bootstrapJobs();
+
+    expect(mockScheduleRepeatable).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/jobs/main.ts
+++ b/backend/src/jobs/main.ts
@@ -1,0 +1,61 @@
+import { pathToFileURL } from 'node:url';
+import { logger } from '../common/utils/logger.js';
+import { registerClosable, closeAll } from '../common/utils/lifecycle.js';
+import { prisma } from '../db/prisma.js';
+import { redis } from '../db/redis.js';
+import {
+  createCreditRecomputeWorker,
+  scheduleCreditRecompute,
+  createAnalyticsDailyWorker,
+  scheduleAnalyticsDaily,
+} from './index.js';
+
+/**
+ * Standalone jobs process bootstrap. Starts all BullMQ workers and registers
+ * graceful shutdown for Prisma, Redis, and every worker.
+ */
+export async function bootstrapJobs(): Promise<void> {
+  registerClosable({ name: 'Prisma', close: () => prisma.$disconnect() });
+  registerClosable({ name: 'Redis', close: async () => { await redis.quit(); } });
+
+  const creditWorker = createCreditRecomputeWorker();
+  registerClosable({
+    name: 'CreditRecomputeWorker',
+    close: async () => {
+      await creditWorker.close();
+    },
+  });
+  await scheduleCreditRecompute();
+
+  const analyticsWorker = createAnalyticsDailyWorker();
+  registerClosable({
+    name: 'AnalyticsDailyWorker',
+    close: async () => {
+      await analyticsWorker.close();
+    },
+  });
+  await scheduleAnalyticsDaily();
+
+  logger.info('Jobs process started');
+
+  const shutdown = async (signal: string) => {
+    logger.info(`${signal} received, shutting down jobs...`);
+    await closeAll();
+    logger.info('Jobs shutdown complete');
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+const isDirectRun =
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  bootstrapJobs().catch((err) => {
+    logger.error({ err }, 'Fatal jobs startup error');
+    process.exit(1);
+  });
+}

--- a/backend/src/jobs/queueFactory.test.ts
+++ b/backend/src/jobs/queueFactory.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockQueue = vi.fn();
+vi.mock('bullmq', () => ({
+  Queue: mockQueue,
+}));
+
+vi.mock('../db/redis.js', () => ({
+  redis: { url: 'redis://localhost:6379' },
+}));
+
+describe('getQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('creates a new queue on first call', async () => {
+    const { getQueue } = await import('./queueFactory.js');
+    mockQueue.mockReturnValue({ name: 'test-queue' });
+
+    const queue = getQueue('test-queue');
+
+    expect(mockQueue).toHaveBeenCalledWith('test-queue', {
+      connection: { url: 'redis://localhost:6379' },
+      defaultJobOptions: {
+        removeOnComplete: { age: 3600 },
+        removeOnFail: { age: 86400 },
+      },
+    });
+    expect(queue).toEqual({ name: 'test-queue' });
+  });
+
+  it('returns the same queue instance on subsequent calls', async () => {
+    const { getQueue } = await import('./queueFactory.js');
+    const instance = { name: 'cached-queue' };
+    mockQueue.mockReturnValue(instance);
+
+    const first = getQueue('cached-queue');
+    const second = getQueue('cached-queue');
+
+    expect(first).toBe(second);
+    expect(mockQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates separate instances for different names', async () => {
+    const { getQueue } = await import('./queueFactory.js');
+    mockQueue.mockReturnValueOnce({ name: 'queue-a' }).mockReturnValueOnce({ name: 'queue-b' });
+
+    const a = getQueue('queue-a');
+    const b = getQueue('queue-b');
+
+    expect(a).not.toBe(b);
+    expect(mockQueue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/jobs/queueFactory.ts
+++ b/backend/src/jobs/queueFactory.ts
@@ -1,0 +1,30 @@
+import { Queue } from 'bullmq';
+import { redis } from '../db/redis.js';
+
+const queues = new Map<string, Queue>();
+
+export interface QueueOptions {
+  removeOnComplete?: { age: number };
+  removeOnFail?: { age: number };
+}
+
+const DEFAULT_OPTIONS: Required<QueueOptions> = {
+  removeOnComplete: { age: 3600 },
+  removeOnFail: { age: 86400 },
+};
+
+/**
+ * Returns a lazily-initialized, singleton BullMQ Queue for the given name.
+ * All queues share the same Redis connection and default job options.
+ */
+export function getQueue(name: string, overrides?: QueueOptions): Queue {
+  let queue = queues.get(name);
+  if (!queue) {
+    queue = new Queue(name, {
+      connection: redis as any,
+      defaultJobOptions: { ...DEFAULT_OPTIONS, ...overrides },
+    });
+    queues.set(name, queue);
+  }
+  return queue;
+}

--- a/backend/src/jobs/scheduler.test.ts
+++ b/backend/src/jobs/scheduler.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { scheduleRepeatable } from './scheduler.js';
+
+describe('scheduleRepeatable', () => {
+  const mockAdd = vi.fn();
+  const mockGetRepeatableJobs = vi.fn();
+
+  const queue = {
+    name: 'test-queue',
+    add: mockAdd,
+    getRepeatableJobs: mockGetRepeatableJobs,
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adds a repeatable job when not already scheduled', async () => {
+    mockGetRepeatableJobs.mockResolvedValue([]);
+
+    await scheduleRepeatable({ queue, name: 'my-job', pattern: '*/5 * * * *' });
+
+    expect(mockAdd).toHaveBeenCalledWith('my-job', {}, { repeat: { pattern: '*/5 * * * *' } });
+  });
+
+  it('skips if same name and pattern already exists', async () => {
+    mockGetRepeatableJobs.mockResolvedValue([
+      { name: 'my-job', pattern: '*/5 * * * *' },
+    ]);
+
+    await scheduleRepeatable({ queue, name: 'my-job', pattern: '*/5 * * * *' });
+
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('adds if same name exists with a different pattern', async () => {
+    mockGetRepeatableJobs.mockResolvedValue([
+      { name: 'my-job', pattern: '0 * * * *' },
+    ]);
+
+    await scheduleRepeatable({ queue, name: 'my-job', pattern: '*/5 * * * *' });
+
+    expect(mockAdd).toHaveBeenCalledWith('my-job', {}, { repeat: { pattern: '*/5 * * * *' } });
+  });
+
+  it('adds if same pattern exists with a different name', async () => {
+    mockGetRepeatableJobs.mockResolvedValue([
+      { name: 'other-job', pattern: '*/5 * * * *' },
+    ]);
+
+    await scheduleRepeatable({ queue, name: 'my-job', pattern: '*/5 * * * *' });
+
+    expect(mockAdd).toHaveBeenCalledWith('my-job', {}, { repeat: { pattern: '*/5 * * * *' } });
+  });
+});

--- a/backend/src/jobs/scheduler.ts
+++ b/backend/src/jobs/scheduler.ts
@@ -1,0 +1,31 @@
+import type { Queue } from 'bullmq';
+import { logger } from '../common/utils/logger.js';
+
+export interface ScheduleOptions {
+  /** Queue instance to register the repeatable job on. */
+  queue: Queue;
+  /** Unique name for the repeatable job. */
+  name: string;
+  /** Cron expression controlling the schedule. */
+  pattern: string;
+}
+
+/**
+ * Registers a repeatable (cron) job on the given queue.
+ * Idempotent — skips if the same name+pattern is already registered.
+ */
+export async function scheduleRepeatable({
+  queue,
+  name,
+  pattern,
+}: ScheduleOptions): Promise<void> {
+  const repeatableJobs = await queue.getRepeatableJobs();
+  const alreadyScheduled = repeatableJobs.some(
+    (j) => j.name === name && j.pattern === pattern,
+  );
+
+  if (!alreadyScheduled) {
+    await queue.add(name, {}, { repeat: { pattern } });
+    logger.info({ queue: queue.name, name, pattern }, 'Repeatable job scheduled');
+  }
+}


### PR DESCRIPTION
Closes #986 , Closes #987, Closes #988, Closes #989

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional or behavioral changes)

---

## Summary

Add core BullMQ job infrastructure: a generic queue factory eliminating duplicate boilerplate, a repeatable job scheduler with idempotency, and a standalone worker process entrypoint. Refactor existing credit recompute and analytics daily jobs to use the shared helpers.

## Motivation / Context

The existing queue and worker modules had duplicated connection setup, default job options, and scheduling logic. This PR extracts that into reusable primitives (`queueFactory.ts`, `scheduler.ts`) and adds a standalone `jobs/main.ts` entrypoint following the established `indexer/main.ts` pattern — enabling jobs to run as a separate process for horizontal scaling.

**Changes by issue:**

- **#986** — `queueFactory.ts`: Generic `getQueue()` helper creating lazy singleton BullMQ queues sharing the Redis connection and standard job options (`removeOnComplete: 1h`, `removeOnFail: 24h`). Refactored `creditRecompute.queue.ts` and `analyticsDaily.queue.ts` to use it.
- **#987** — `main.ts`: Standalone worker entrypoint registering all workers, scheduling repeatable jobs, and handling graceful shutdown via `lifecycle.ts`. Added `npm run jobs` and `npm run jobs:dev` scripts.
- **#988** — `scheduler.ts`: Generic `scheduleRepeatable()` helper with built-in idempotency (skips if same name+pattern already registered). Refactored `scheduleCreditRecompute()` and `scheduleAnalyticsDaily()` to use it.
- **#989** — Credit recompute job was already wired into a queue; refactored to use the new queue factory and scheduler helpers.

## Testing

- All 15 jobs module tests pass (`vitest run src/jobs/`)
- New tests: `queueFactory.test.ts` (3 tests), `scheduler.test.ts` (4 tests), `main.test.ts` (3 tests)
- Pre-existing tests unchanged: `creditRecompute.worker.test.ts` (3 tests), `analyticsDaily.worker.test.ts` (2 tests)
- TypeScript typecheck clean (pre-existing errors in `credit.service.ts` only)
- ESLint clean (0 errors, only pre-existing `no-explicit-any` warnings)

## Files Changed

| File | Change |
|------|--------|
| `src/jobs/queueFactory.ts` | New — generic queue factory |
| `src/jobs/queueFactory.test.ts` | New — queue factory tests |
| `src/jobs/scheduler.ts` | New — repeatable job scheduler |
| `src/jobs/scheduler.test.ts` | New — scheduler tests |
| `src/jobs/main.ts` | New — standalone worker entrypoint |
| `src/jobs/main.test.ts` | New — entrypoint tests |
| `src/jobs/index.ts` | Updated — barrel exports |
| `src/jobs/creditRecompute.queue.ts` | Refactored to use queue factory |
| `src/jobs/analyticsDaily.queue.ts` | Refactored to use queue factory |
| `src/jobs/creditRecompute.worker.ts` | Refactored to use scheduler |
| `src/jobs/analyticsDaily.worker.ts` | Refactored to use scheduler |
| `package.json` | Added `jobs` and `jobs:dev` scripts |

## Tradeoffs

- The `as any` cast on the Redis connection for BullMQ is preserved from the existing codebase pattern (BullMQ's types are incompatible with ioredis's default export).
- The queue factory uses an in-memory `Map` for singleton caching — sufficient for single-process usage; horizontal scaling uses separate `jobs/main.ts` instances.

## Out of Scope

- No changes to `server.ts` — it continues to run workers embedded for the single-process mode.
- No new env vars required.