### PR TITLE
feat(search): cache creator search results and add module tests

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -65,6 +65,9 @@ CREDIT_SCORE_CAP_TIP_SUB=100
 # Cache TTL for credit scores in seconds
 CREDIT_SCORE_CACHE_TTL_SECONDS=300
 
+# Cache TTL for creator search results in seconds
+SEARCH_CACHE_TTL_SECONDS=60
+
 # Withdrawals
 WITHDRAWAL_MIN_AMOUNT_STROOPS=10000000
 # Withdrawal fee, in basis points (1/100th of a percent). 200 = 2%.

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -69,6 +69,8 @@ const envSchema = z.object({
   CREDIT_SCORE_CAP_TIP_SUB: z.coerce.number().int().min(0).optional(),
   /** Credit score cache TTL in seconds */
   CREDIT_SCORE_CACHE_TTL_SECONDS: z.coerce.number().int().positive().optional(),
+  /** Search results cache TTL in seconds */
+  SEARCH_CACHE_TTL_SECONDS: z.coerce.number().int().positive().optional(),
   /** Minimum withdrawal amount, in stroops (1 XLM = 10,000,000 stroops). */
   WITHDRAWAL_MIN_AMOUNT_STROOPS: z.coerce.number().int().positive().default(10_000_000),
   /** Withdrawal fee, in basis points (1/100th of a percent). 200 = 2%. */

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -1,15 +1,50 @@
 import { prisma } from '../../db/prisma.js';
+import { redis } from '../../db/redis.js';
+import { env } from '../../config/env.js';
+import { logger } from '../../common/utils/logger.js';
 import type { SearchCreatorsResponse } from './search.types.js';
+
+const CACHE_PREFIX = 'search:creators:';
+const CACHE_TTL_SECONDS = env.SEARCH_CACHE_TTL_SECONDS ?? 60;
+
+function cacheKey(query: string, limit: number, offset: number): string {
+  return `${CACHE_PREFIX}${query.trim().toLowerCase()}:${limit}:${offset}`;
+}
+
+async function readCache(key: string): Promise<SearchCreatorsResponse | null> {
+  try {
+    const cached = await redis.get(key);
+    return cached ? (JSON.parse(cached) as SearchCreatorsResponse) : null;
+  } catch (err) {
+    logger.warn({ err, key }, 'Search cache read failed');
+    return null;
+  }
+}
+
+async function writeCache(key: string, result: SearchCreatorsResponse): Promise<void> {
+  try {
+    await redis.set(key, JSON.stringify(result), 'EX', CACHE_TTL_SECONDS);
+  } catch (err) {
+    logger.warn({ err, key }, 'Search cache write failed');
+  }
+}
 
 /**
  * Searches creators by name or username using case-insensitive partial matching.
  * Returns paginated results ordered by relevance (username match first, then displayName).
+ * Results are cached in Redis, keyed by the normalized query and pagination params.
  */
 export async function searchCreators(
   query: string,
   limit: number,
   offset: number,
 ): Promise<SearchCreatorsResponse> {
+  const key = cacheKey(query, limit, offset);
+  const cached = await readCache(key);
+  if (cached) {
+    return cached;
+  }
+
   const where = {
     deletedAt: null,
     OR: [
@@ -39,7 +74,7 @@ export async function searchCreators(
     prisma.user.count({ where }),
   ]);
 
-  return {
+  const result: SearchCreatorsResponse = {
     data: rows,
     pagination: {
       limit,
@@ -48,4 +83,7 @@ export async function searchCreators(
       hasMore: offset + rows.length < total,
     },
   };
+
+  await writeCache(key, result);
+  return result;
 }

--- a/backend/src/modules/search/search.test.ts
+++ b/backend/src/modules/search/search.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from '../../app.js';
 import { searchCreators } from './search.service.js';
 
-const { mockFindMany, mockCount } = vi.hoisted(() => ({
+const { mockFindMany, mockCount, mockRedisGet, mockRedisSet } = vi.hoisted(() => ({
   mockFindMany: vi.fn(),
   mockCount: vi.fn(),
+  mockRedisGet: vi.fn(),
+  mockRedisSet: vi.fn(),
 }));
 
 vi.mock('../../db/prisma.js', () => ({
@@ -15,11 +17,21 @@ vi.mock('../../db/prisma.js', () => ({
   },
 }));
 
+vi.mock('../../db/redis.js', () => ({
+  redis: {
+    get: mockRedisGet,
+    set: mockRedisSet,
+    on: vi.fn(),
+  },
+}));
+
 describe('GET /api/v1/search/creators', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFindMany.mockResolvedValue([]);
     mockCount.mockResolvedValue(0);
+    mockRedisGet.mockResolvedValue(null);
+    mockRedisSet.mockResolvedValue('OK');
   });
 
   it('returns 400 when q is missing', async () => {
@@ -89,11 +101,58 @@ describe('GET /api/v1/search/creators', () => {
     const res = await request(app).get('/api/v1/search/creators?q=test&limit=100');
     expect(res.status).toBe(400);
   });
+
+  it('returns 400 for a negative offset', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=test&offset=-1');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a non-numeric limit', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=test&limit=abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('applies default limit and offset when omitted', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=test');
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination).toEqual({
+      limit: 20,
+      offset: 0,
+      total: 0,
+      hasMore: false,
+    });
+  });
+
+  it('matches creators by displayName as well as username', async () => {
+    mockFindMany.mockResolvedValue([
+      {
+        id: 'user-2',
+        username: 'bstar99',
+        displayName: 'Bob Star',
+        stellarAddress: 'GA2',
+        imageUrl: null,
+        bio: null,
+      },
+    ]);
+    mockCount.mockResolvedValue(1);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/search/creators?q=Star');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].displayName).toBe('Bob Star');
+  });
 });
 
 describe('searchCreators service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRedisGet.mockResolvedValue(null);
+    mockRedisSet.mockResolvedValue('OK');
   });
 
   it('queries with correct where clause', async () => {
@@ -115,5 +174,100 @@ describe('searchCreators service', () => {
         skip: 0,
       }),
     );
+  });
+});
+
+describe('searchCreators caching', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queries the database and caches the result on a cache miss', async () => {
+    mockRedisGet.mockResolvedValue(null);
+    mockFindMany.mockResolvedValue([
+      {
+        id: 'user-1',
+        username: 'alice',
+        displayName: 'Alice Star',
+        stellarAddress: 'GA1',
+        imageUrl: null,
+        bio: null,
+      },
+    ]);
+    mockCount.mockResolvedValue(1);
+
+    const result = await searchCreators('alice', 20, 0);
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      'search:creators:alice:20:0',
+      JSON.stringify(result),
+      'EX',
+      expect.any(Number),
+    );
+  });
+
+  it('returns the cached result without hitting the database on a cache hit', async () => {
+    const cached = {
+      data: [
+        {
+          id: 'user-1',
+          username: 'alice',
+          displayName: 'Alice Star',
+          stellarAddress: 'GA1',
+          imageUrl: null,
+          bio: null,
+        },
+      ],
+      pagination: { limit: 20, offset: 0, total: 1, hasMore: false },
+    };
+    mockRedisGet.mockResolvedValue(JSON.stringify(cached));
+
+    const result = await searchCreators('alice', 20, 0);
+
+    expect(result).toEqual(cached);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('normalizes the query casing and surrounding whitespace for the cache key', async () => {
+    mockRedisGet.mockResolvedValue(null);
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+
+    await searchCreators('  Alice  ', 20, 0);
+
+    expect(mockRedisGet).toHaveBeenCalledWith('search:creators:alice:20:0');
+  });
+
+  it('keys the cache separately per limit/offset combination', async () => {
+    mockRedisGet.mockResolvedValue(null);
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+
+    await searchCreators('alice', 5, 10);
+
+    expect(mockRedisGet).toHaveBeenCalledWith('search:creators:alice:5:10');
+  });
+
+  it('falls back to the database when the cache read fails', async () => {
+    mockRedisGet.mockRejectedValue(new Error('redis unavailable'));
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+
+    const result = await searchCreators('alice', 20, 0);
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(result.data).toEqual([]);
+  });
+
+  it('still returns a result when the cache write fails', async () => {
+    mockRedisGet.mockResolvedValue(null);
+    mockRedisSet.mockRejectedValue(new Error('redis unavailable'));
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+
+    const result = await searchCreators('alice', 20, 0);
+
+    expect(result.pagination.total).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Cache `searchCreators` results in Redis, keyed by normalized query + limit + offset, with a configurable TTL (`SEARCH_CACHE_TTL_SECONDS`, defaults to 60s).
- Gracefully fall back to the database if the cache read or write fails (logged as a warning, never throws).
- Add test coverage for cache hit/miss behavior, cache-key normalization (case/whitespace), per-pagination cache keys, and cache failure fallback.
- Add additional module test coverage: negative offset, non-numeric limit, default limit/offset, and matching by `displayName`.

## Tasks
- [x] Implement per module conventions.
- [x] Add tests.

## Acceptance criteria
- [x] Tests + typecheck + lint pass.

Closes #1018
Closes #1019