### PR TITLE
feat(backend): implement resilient webhook delivery queue with retries

### DIFF
--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -1,0 +1,1 @@
+export * from './webhookDelivery.js';

--- a/backend/src/jobs/webhookDelivery.ts
+++ b/backend/src/jobs/webhookDelivery.ts
@@ -1,0 +1,106 @@
+import { Queue, Worker, Job } from 'bullmq';
+import { redis } from '../db/redis.js';
+import { logger } from '../common/utils/logger.js';
+import crypto from 'node:crypto';
+
+export const WEBHOOK_DELIVERY_QUEUE = 'webhook-delivery';
+
+export interface WebhookDeliveryPayload {
+  url: string;
+  payload: Record<string, unknown>;
+  secret?: string; // Optional secret to sign the payload (HMAC)
+}
+
+/**
+ * Queue instance for dispatching webhook deliveries.
+ */
+export const webhookDeliveryQueue = new Queue<WebhookDeliveryPayload>(WEBHOOK_DELIVERY_QUEUE, {
+  connection: redis,
+  defaultJobOptions: {
+    attempts: 5,
+    backoff: {
+      type: 'exponential',
+      delay: 2000,
+    },
+    removeOnComplete: {
+      age: 3600, // keep completed jobs for 1 hour
+      count: 1000, // keep at most 1000 completed jobs
+    },
+    removeOnFail: {
+      age: 24 * 3600, // keep failed jobs for 24 hours
+    },
+  },
+});
+
+/**
+ * Helper to schedule a webhook delivery.
+ */
+export async function scheduleWebhookDelivery(
+  url: string,
+  payload: Record<string, unknown>,
+  secret?: string
+): Promise<void> {
+  await webhookDeliveryQueue.add('deliver', { url, payload, secret });
+}
+
+/**
+ * Worker to process webhook deliveries.
+ */
+export const webhookDeliveryWorker = new Worker<WebhookDeliveryPayload>(
+  WEBHOOK_DELIVERY_QUEUE,
+  async (job: Job<WebhookDeliveryPayload>) => {
+    const { url, payload, secret } = job.data;
+    
+    logger.info({ jobId: job.id, url }, 'Starting webhook delivery');
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'Stellar-Tipz-Webhook-Bot/1.0',
+    };
+
+    const body = JSON.stringify(payload);
+
+    // If a secret is provided, sign the payload with HMAC SHA256
+    if (secret) {
+      const hmac = crypto.createHmac('sha256', secret);
+      hmac.update(body);
+      headers['X-Signature'] = `sha256=${hmac.digest('hex')}`;
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000); // 10 second timeout
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      if (!response.ok) {
+        // Throwing an error automatically triggers BullMQ backoff retry
+        throw new Error(`HTTP Error: ${response.status} ${response.statusText}`);
+      }
+
+      logger.info({ jobId: job.id, url, status: response.status }, 'Webhook delivered successfully');
+    } catch (error: unknown) {
+      logger.warn({ jobId: job.id, url, error: error instanceof Error ? error.message : error }, 'Webhook delivery failed');
+      throw error;
+    }
+  },
+  {
+    connection: redis,
+    concurrency: 5, // Process up to 5 webhooks concurrently
+  }
+);
+
+webhookDeliveryWorker.on('failed', (job: Job<WebhookDeliveryPayload> | undefined, err: Error) => {
+  if (job) {
+    logger.error({ jobId: job.id, url: job.data.url, err: err.message }, 'Webhook job failed permanently or retrying');
+  } else {
+    logger.error({ err: err.message }, 'Webhook worker error');
+  }
+});

--- a/backend/tests/jobs/webhookDelivery.test.ts
+++ b/backend/tests/jobs/webhookDelivery.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest';
+import { 
+  webhookDeliveryQueue, 
+  webhookDeliveryWorker, 
+  scheduleWebhookDelivery 
+} from '../../src/jobs/webhookDelivery.js';
+import { redis } from '../../src/db/redis.js';
+
+// Mock fetch globally
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+describe('Webhook Delivery Job', () => {
+  beforeAll(async () => {
+    // Wait for worker to be ready
+    await webhookDeliveryWorker.waitUntilReady();
+  });
+
+  afterAll(async () => {
+    await webhookDeliveryQueue.close();
+    await webhookDeliveryWorker.close();
+    await redis.quit();
+  });
+
+  beforeEach(async () => {
+    fetchMock.mockReset();
+    // Clear the queue before each test
+    await webhookDeliveryQueue.drain();
+  });
+
+  it('successfully delivers a webhook and processes the job', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+    } as Response);
+
+    const url = 'https://example.com/webhook';
+    const payload = { event: 'test_event', data: { id: 123 } };
+
+    // Schedule the delivery
+    await scheduleWebhookDelivery(url, payload);
+
+    // Wait for the job to complete
+    const completedJob = await new Promise((resolve) => {
+      webhookDeliveryWorker.once('completed', (job) => {
+        resolve(job);
+      });
+    });
+
+    expect(completedJob).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'User-Agent': 'Stellar-Tipz-Webhook-Bot/1.0',
+        }),
+      })
+    );
+  });
+
+  it('includes an HMAC signature when a secret is provided', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+    } as Response);
+
+    const url = 'https://example.com/webhook-secure';
+    const payload = { event: 'secure_event' };
+    const secret = 'my-super-secret';
+
+    await scheduleWebhookDelivery(url, payload, secret);
+
+    await new Promise((resolve) => {
+      webhookDeliveryWorker.once('completed', (job) => {
+        resolve(job);
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Signature': expect.stringMatching(/^sha256=[0-9a-f]{64}$/),
+        }),
+      })
+    );
+  });
+
+  it('fails the job and triggers a retry when the webhook endpoint returns a non-2xx status', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as Response);
+
+    const url = 'https://example.com/webhook-fail';
+    const payload = { event: 'fail_event' };
+
+    await scheduleWebhookDelivery(url, payload);
+
+    // Wait for the job to fail
+    const failedJob = await new Promise((resolve) => {
+      webhookDeliveryWorker.once('failed', (job) => {
+        resolve(job);
+      });
+    });
+
+    expect(failedJob).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
closes #993

### Problem
The backend requires a resilient mechanism to reliably deliver webhooks to off-chain clients with support for retries and backoff when transient network failures or downtime occur.

### Solution
This PR implements a dedicated `BullMQ` job queue (`webhook-delivery`) backed by the shared Redis instance. It includes an autonomous worker that handles HTTP `POST` dispatching with automated backoff/retry policies and HMAC request signing.

### Key Changes:
- **Queue Initialization:** Created `src/jobs/webhookDelivery.ts` to manage the `webhook-delivery` queue, automatically retrying failed jobs up to 5 times with exponential backoff.
- **Worker Logic:** The worker performs native `fetch` requests with a 10-second `AbortController` timeout. Non-2xx responses correctly throw errors to natively leverage BullMQ's automatic backoff mechanics.
- **HMAC Security:** Supports appending an `X-Signature` header via HMAC SHA256 when a payload secret is provided.
- **Tests:** Added comprehensive Vitest unit tests in `tests/jobs/webhookDelivery.test.ts` to verify successful delivery, secure signing, and failure behaviors using global fetch mocking.

### Verification
- [x] Jobs are idempotent (only storing URL and JSON payloads).
- [x] Typecheck passes (`npm run typecheck`).
- [x] Lint passes (`npm run lint`).
- [x] Tests pass (`npm run test`).
