### PR TITLE
feat: issues #992, #1000, #1003, #1004 — subscription charge job, webhook docs, analytics

### DIFF
--- a/backend/docs/WEBHOOKS.md
+++ b/backend/docs/WEBHOOKS.md
@@ -1,0 +1,82 @@
+# Webhook Payloads & Signing
+
+## Overview
+
+Stellar-Tipz delivers event notifications to registered HTTP endpoints via signed webhooks. Every delivery includes an HMAC-SHA256 signature so consumers can verify payload authenticity.
+
+## Registering a Webhook
+
+```http
+POST /api/webhooks/subscriptions
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "url": "https://your-app.com/webhooks/tipz",
+  "events": ["tip.received", "tip.sent"]
+}
+```
+
+Response includes the signing `secret` — store it securely; it is only shown once.
+
+## Signature Verification
+
+Every delivery includes the `X-Signature` header:
+
+```
+X-Signature: sha256=<hex-encoded-hmac>
+```
+
+To verify:
+
+```javascript
+import crypto from "node:crypto";
+
+function verifySignature(secret, body, signature) {
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(body)
+    .digest("hex");
+  return `sha256=${expected}` === signature;
+}
+```
+
+Use constant-time comparison (`timingSafeEqual`) to avoid timing side-channels.
+
+## Payload Format
+
+```json
+{
+  "event": "tip.received",
+  "timestamp": "2026-07-28T12:00:00.000Z",
+  "data": {
+    "tipId": "tip_abc123",
+    "fromAddress": "GABC...",
+    "toAddress": "GDEF...",
+    "amountStroops": "10000000",
+    "memo": "Great content!"
+  }
+}
+```
+
+## Retry Policy
+
+Failed deliveries (non-2xx response or timeout) are retried with exponential backoff:
+
+| Attempt | Delay   |
+|---------|---------|
+| 1       | 2s      |
+| 2       | 4s      |
+| 3       | 8s      |
+| 4       | 16s     |
+| 5       | 32s     |
+
+After 5 failed attempts, the delivery is marked as `FAILED` and stored for inspection via `GET /api/webhooks/deliveries`.
+
+## Events
+
+| Event            | Description                          |
+|------------------|--------------------------------------|
+| `tip.received`   | A tip was received by a creator      |
+| `tip.sent`       | A tip was sent by a tipper           |
+| `subscription.charged` | A recurring subscription was charged |

--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -21,4 +21,14 @@ export {
   scheduleAnalyticsDaily,
 } from './analyticsDaily.worker.js';
 
+export {
+  SUBSCRIPTION_CHARGE_QUEUE,
+  getSubscriptionChargeQueue,
+} from './subscriptionCharge.queue.js';
+export {
+  processDueSubscriptions,
+  createSubscriptionChargeWorker,
+  scheduleSubscriptionCharge,
+} from './subscriptionCharge.worker.js';
+
 export { bootstrapJobs } from './main.js';

--- a/backend/src/jobs/main.ts
+++ b/backend/src/jobs/main.ts
@@ -8,6 +8,8 @@ import {
   scheduleCreditRecompute,
   createAnalyticsDailyWorker,
   scheduleAnalyticsDaily,
+  createSubscriptionChargeWorker,
+  scheduleSubscriptionCharge,
 } from './index.js';
 
 /**
@@ -35,6 +37,15 @@ export async function bootstrapJobs(): Promise<void> {
     },
   });
   await scheduleAnalyticsDaily();
+
+  const subscriptionWorker = createSubscriptionChargeWorker();
+  registerClosable({
+    name: 'SubscriptionChargeWorker',
+    close: async () => {
+      await subscriptionWorker.close();
+    },
+  });
+  await scheduleSubscriptionCharge();
 
   logger.info('Jobs process started');
 

--- a/backend/src/jobs/subscriptionCharge.queue.ts
+++ b/backend/src/jobs/subscriptionCharge.queue.ts
@@ -1,0 +1,8 @@
+import { getQueue } from './queueFactory.js';
+
+export const SUBSCRIPTION_CHARGE_QUEUE = 'subscription-charge';
+
+/** Lazily-initialised singleton Queue for subscription charge jobs. */
+export function getSubscriptionChargeQueue() {
+  return getQueue(SUBSCRIPTION_CHARGE_QUEUE);
+}

--- a/backend/src/jobs/subscriptionCharge.worker.test.ts
+++ b/backend/src/jobs/subscriptionCharge.worker.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock prisma and redis before importing the worker
+vi.mock('../db/prisma.js', () => ({
+  prisma: {
+    subscription: {
+      findMany: vi.fn(),
+    },
+    tip: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../db/redis.js', () => ({
+  redis: {},
+}));
+
+vi.mock('../common/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { processDueSubscriptions } from './subscriptionCharge.worker.js';
+import { prisma } from '../db/prisma.js';
+
+describe('processDueSubscriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns { processed: 0, failed: 0 } when no subscriptions are due', async () => {
+    vi.mocked(prisma.subscription.findMany).mockResolvedValue([]);
+
+    const result = await processDueSubscriptions();
+
+    expect(result).toEqual({ processed: 0, failed: 0 });
+    expect(prisma.subscription.findMany).toHaveBeenCalledWith({
+      where: {
+        status: 'ACTIVE',
+        nextChargeAt: { lte: expect.any(Date) },
+        deletedAt: null,
+      },
+    });
+  });
+
+  it('charges a due subscription and advances nextChargeAt', async () => {
+    const sub = {
+      id: 'sub_01',
+      tipperId: 'user_tipper',
+      creatorId: 'user_creator',
+      amountStroops: BigInt(1_000_000),
+      interval: 'WEEKLY',
+      nextChargeAt: new Date('2026-07-20'),
+    };
+
+    vi.mocked(prisma.subscription.findMany).mockResolvedValue([sub]);
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => {
+      const tx = {
+        tip: { create: vi.fn() },
+        subscription: { update: vi.fn() },
+      };
+      await fn(tx);
+      return undefined;
+    });
+
+    const result = await processDueSubscriptions();
+
+    expect(result).toEqual({ processed: 1, failed: 0 });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('increments failed count when a subscription charge throws', async () => {
+    const sub = {
+      id: 'sub_fail',
+      tipperId: 'user_tipper',
+      creatorId: 'user_creator',
+      amountStroops: BigInt(500_000),
+      interval: 'DAILY',
+      nextChargeAt: new Date('2026-07-20'),
+    };
+
+    vi.mocked(prisma.subscription.findMany).mockResolvedValue([sub]);
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('db error'));
+
+    const result = await processDueSubscriptions();
+
+    expect(result).toEqual({ processed: 0, failed: 1 });
+  });
+
+  it('processes multiple subscriptions independently', async () => {
+    const subs = [
+      { id: 'sub_a', tipperId: 't1', creatorId: 'c1', amountStroops: BigInt(100), interval: 'DAILY', nextChargeAt: new Date() },
+      { id: 'sub_b', tipperId: 't2', creatorId: 'c2', amountStroops: BigInt(200), interval: 'WEEKLY', nextChargeAt: new Date() },
+    ];
+
+    vi.mocked(prisma.subscription.findMany).mockResolvedValue(subs);
+    vi.mocked(prisma.$transaction).mockResolvedValue(undefined);
+
+    const result = await processDueSubscriptions();
+
+    expect(result).toEqual({ processed: 2, failed: 0 });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/jobs/subscriptionCharge.worker.ts
+++ b/backend/src/jobs/subscriptionCharge.worker.ts
@@ -1,0 +1,109 @@
+import { Worker } from 'bullmq';
+import { redis } from '../db/redis.js';
+import { prisma } from '../db/prisma.js';
+import { logger } from '../common/utils/logger.js';
+import { SUBSCRIPTION_CHARGE_QUEUE, getSubscriptionChargeQueue } from './subscriptionCharge.queue.js';
+import { scheduleRepeatable } from './scheduler.js';
+
+/**
+ * Process due subscriptions: find all ACTIVE subscriptions whose
+ * `nextChargeAt` <= now, create a Tip for each, and advance the
+ * nextChargeAt timestamp by the subscription interval.
+ *
+ * Idempotent — safe to run multiple times for the same window.
+ */
+export async function processDueSubscriptions(): Promise<{ processed: number; failed: number }> {
+  const now = new Date();
+
+  const due = await prisma.subscription.findMany({
+    where: {
+      status: 'ACTIVE',
+      nextChargeAt: { lte: now },
+      deletedAt: null,
+    },
+  });
+
+  logger.info({ count: due.length }, 'Found due subscriptions');
+
+  let processed = 0;
+  let failed = 0;
+
+  for (const sub of due) {
+    try {
+      await prisma.$transaction(async (tx) => {
+        // Create a Tip for this subscription charge
+        await tx.tip.create({
+          data: {
+            fromAddress: sub.tipperId,
+            toAddress: sub.creatorId,
+            amountStroops: sub.amountStroops,
+            status: 'CONFIRMED',
+            memo: `Subscription charge: ${sub.id}`,
+          },
+        });
+
+        // Advance nextChargeAt based on interval
+        const next = computeNextChargeAt(sub.nextChargeAt, sub.interval);
+        await tx.subscription.update({
+          where: { id: sub.id },
+          data: { nextChargeAt: next },
+        });
+      });
+
+      processed += 1;
+      logger.info({ subscriptionId: sub.id }, 'Subscription charged');
+    } catch (err) {
+      failed += 1;
+      logger.error(
+        { err, subscriptionId: sub.id },
+        'Failed to charge subscription',
+      );
+    }
+  }
+
+  logger.info({ processed, failed }, 'Subscription charge run complete');
+  return { processed, failed };
+}
+
+function computeNextChargeAt(current: Date, interval: string): Date {
+  const next = new Date(current);
+  switch (interval) {
+    case 'DAILY':
+      next.setDate(next.getDate() + 1);
+      break;
+    case 'WEEKLY':
+      next.setDate(next.getDate() + 7);
+      break;
+    case 'MONTHLY':
+      next.setMonth(next.getMonth() + 1);
+      break;
+    default:
+      next.setDate(next.getDate() + 1);
+  }
+  return next;
+}
+
+export function createSubscriptionChargeWorker(): Worker {
+  const worker = new Worker(
+    SUBSCRIPTION_CHARGE_QUEUE,
+    async (_job) => {
+      const result = await processDueSubscriptions();
+      logger.info(result, 'Subscription charge job complete');
+    },
+    { connection: redis as any },
+  );
+
+  worker.on('failed', (job, err) => {
+    logger.error({ err, jobId: job?.id }, 'Subscription charge job failed');
+  });
+
+  return worker;
+}
+
+export async function scheduleSubscriptionCharge(): Promise<void> {
+  await scheduleRepeatable({
+    queue: getSubscriptionChargeQueue(),
+    name: 'charge',
+    pattern: '*/5 * * * *', // Every 5 minutes
+  });
+}


### PR DESCRIPTION
Closes #992
Closes #1000
Closes #1003
Closes #1004

## Summary

- **#992**: Implemented subscription charging job — BullMQ queue/worker (`subscriptionCharge.queue.ts`, `subscriptionCharge.worker.ts`) that finds ACTIVE subscriptions due for charging, creates Tips, and advances `nextChargeAt`. Scheduled every 5 minutes. 4 tests pass.
- **#1000**: Webhook delivery retry policy already implemented in `src/jobs/webhookDelivery.ts` — 5 attempts with exponential backoff (2s → 32s). No changes needed.
- **#1003**: Added `docs/WEBHOOKS.md` — documents payload format, HMAC-SHA256 signature verification, retry policy, and supported events.
- **#1004**: Analytics module skeleton already exists in `src/modules/analytics/` — service, controller, routes, types, schema, and tests all present. No changes needed.

## Files changed

- `backend/src/jobs/subscriptionCharge.queue.ts` — new BullMQ queue
- `backend/src/jobs/subscriptionCharge.worker.ts` — subscription charge worker
- `backend/src/jobs/subscriptionCharge.worker.test.ts` — 4 unit tests
- `backend/src/jobs/index.ts` — exports new subscription charge module
- `backend/src/jobs/main.ts` — registers subscription charge worker in bootstrap
- `backend/docs/WEBHOOKS.md` — webhook documentation

## Testing

```
✓ src/jobs/subscriptionCharge.worker.test.ts (4 tests)
```