### PR TITLE
Subscriptions module: skeleton, create/cancel endpoints, list, charge processing job (#1026, #1027, #1028, #1029)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -73,6 +73,14 @@ WITHDRAWAL_MIN_AMOUNT_STROOPS=10000000
 # Withdrawal fee, in basis points (1/100th of a percent). 200 = 2%.
 WITHDRAWAL_FEE_BPS=200
 
+# Subscriptions — recurring tip charge processing
+# Secret key for the platform's keeper account, used to sign and submit
+# execute_due_subscription calls server-side. Leave blank in dev; the job
+# logs a clear per-subscription error if a charge is due and this is unset.
+SUBSCRIPTION_KEEPER_SECRET_KEY=
+# Cron expression for the subscription-charge processing job (BullMQ repeatable job).
+SUBSCRIPTION_CHARGE_CRON=0 * * * *
+
 # X (Twitter) API — credit score signals
 X_API_BEARER_TOKEN=
 X_API_BASE_URL=https://api.twitter.com/2

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -22,6 +22,7 @@ import { webhooksRouter } from './modules/webhooks/webhooks.routes.js';
 import { analyticsRouter } from './modules/analytics/analytics.routes.js';
 import { goalsRouter } from './modules/goals/goals.routes.js';
 import { registerGoalsDocs } from './modules/goals/goals.openapi.js';
+import { subscriptionsRouter } from './modules/subscriptions/subscriptions.routes.js';
 
 /** Builds and configures the Express application without starting a listener. */
 export function createApp(): Express {
@@ -71,6 +72,7 @@ export function createApp(): Express {
   app.use(`${env.API_BASE_PATH}/webhooks`, webhooksRouter);
   app.use(`${env.API_BASE_PATH}/analytics`, analyticsRouter);
   app.use(`${env.API_BASE_PATH}/goals`, goalsRouter);
+  app.use(`${env.API_BASE_PATH}/subscriptions`, subscriptionsRouter);
 
   // Register OpenAPI path docs for feature modules.
   registerGoalsDocs();

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -76,6 +76,17 @@ const envSchema = z.object({
   /** Withdrawal fee, in basis points (1/100th of a percent). 200 = 2%. */
   WITHDRAWAL_FEE_BPS: z.coerce.number().int().min(0).max(10_000).default(200),
 
+  /**
+   * Secret key for the platform's subscription-charge keeper account. Used
+   * only by the subscription-charge job to sign `execute_due_subscription`
+   * calls server-side (that contract function doesn't require the
+   * subscriber's own signature). Optional so the app/tests can run without
+   * it; the job itself throws a clear error per-subscription if it's unset.
+   */
+  SUBSCRIPTION_KEEPER_SECRET_KEY: z.string().optional(),
+  /** Cron expression for the subscription-charge processing job. */
+  SUBSCRIPTION_CHARGE_CRON: z.string().default('0 * * * *'),
+
   X_API_BEARER_TOKEN: z.string().optional(),
   X_API_BASE_URL: z.string().default('https://api.twitter.com/2'),
 

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -71,6 +71,11 @@ export const config = {
     feeBps: env.WITHDRAWAL_FEE_BPS,
   },
 
+  subscriptions: {
+    keeperSecretKey: env.SUBSCRIPTION_KEEPER_SECRET_KEY,
+    chargeCron: env.SUBSCRIPTION_CHARGE_CRON,
+  },
+
   logging: {
     level: env.LOG_LEVEL,
     sentryDsn: env.SENTRY_DSN,

--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -21,4 +21,14 @@ export {
   scheduleAnalyticsDaily,
 } from './analyticsDaily.worker.js';
 
+export {
+  SUBSCRIPTION_CHARGE_QUEUE,
+  getSubscriptionChargeQueue,
+} from './subscriptionCharge.queue.js';
+export {
+  processDueSubscriptions,
+  createSubscriptionChargeWorker,
+  scheduleSubscriptionCharge,
+} from './subscriptionCharge.worker.js';
+
 export { bootstrapJobs } from './main.js';

--- a/backend/src/jobs/main.test.ts
+++ b/backend/src/jobs/main.test.ts
@@ -25,6 +25,7 @@ vi.mock('../config/index.js', () => ({
   config: {
     credit: { recomputeCron: '0 */6 * * *' },
     analytics: { dailyCron: '5 0 * * *' },
+    subscriptions: { chargeCron: '0 * * * *' },
   },
 }));
 
@@ -70,19 +71,20 @@ describe('bootstrapJobs', () => {
     expect(closableNames).toContain('Redis');
   });
 
-  it('registers credit and analytics workers as closable', async () => {
+  it('registers credit, analytics, and subscription-charge workers as closable', async () => {
     const { bootstrapJobs } = await import('./main.js');
     await bootstrapJobs();
 
     const closableNames = mockRegisterClosable.mock.calls.map((c: any[]) => c[0].name);
     expect(closableNames).toContain('CreditRecomputeWorker');
     expect(closableNames).toContain('AnalyticsDailyWorker');
+    expect(closableNames).toContain('SubscriptionChargeWorker');
   });
 
-  it('schedules both credit recompute and analytics daily jobs', async () => {
+  it('schedules credit recompute, analytics daily, and subscription-charge jobs', async () => {
     const { bootstrapJobs } = await import('./main.js');
     await bootstrapJobs();
 
-    expect(mockScheduleRepeatable).toHaveBeenCalledTimes(2);
+    expect(mockScheduleRepeatable).toHaveBeenCalledTimes(3);
   });
 });

--- a/backend/src/jobs/main.ts
+++ b/backend/src/jobs/main.ts
@@ -8,6 +8,8 @@ import {
   scheduleCreditRecompute,
   createAnalyticsDailyWorker,
   scheduleAnalyticsDaily,
+  createSubscriptionChargeWorker,
+  scheduleSubscriptionCharge,
 } from './index.js';
 
 /**
@@ -35,6 +37,15 @@ export async function bootstrapJobs(): Promise<void> {
     },
   });
   await scheduleAnalyticsDaily();
+
+  const subscriptionChargeWorker = createSubscriptionChargeWorker();
+  registerClosable({
+    name: 'SubscriptionChargeWorker',
+    close: async () => {
+      await subscriptionChargeWorker.close();
+    },
+  });
+  await scheduleSubscriptionCharge();
 
   logger.info('Jobs process started');
 

--- a/backend/src/jobs/subscriptionCharge.queue.ts
+++ b/backend/src/jobs/subscriptionCharge.queue.ts
@@ -1,0 +1,8 @@
+import { getQueue } from './queueFactory.js';
+
+export const SUBSCRIPTION_CHARGE_QUEUE = 'subscription-charge';
+
+/** Lazily-initialised singleton Queue for subscription-charge processing jobs. */
+export function getSubscriptionChargeQueue() {
+  return getQueue(SUBSCRIPTION_CHARGE_QUEUE);
+}

--- a/backend/src/jobs/subscriptionCharge.worker.test.ts
+++ b/backend/src/jobs/subscriptionCharge.worker.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { processDueSubscriptions } from './subscriptionCharge.worker.js';
+
+const { mockFindMany, mockUpdate, mockChargeOnChain } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockChargeOnChain: vi.fn(),
+}));
+
+vi.mock('../db/prisma.js', () => ({
+  prisma: {
+    subscription: {
+      findMany: mockFindMany,
+      update: mockUpdate,
+    },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock('../modules/subscriptions/subscriptions.service.js', () => ({
+  chargeSubscriptionOnChain: mockChargeOnChain,
+  INTERVAL_DAYS: { DAILY: 1, WEEKLY: 7, MONTHLY: 30 },
+}));
+
+const tipper = { stellarAddress: 'GTIPPER...' };
+const creator = { stellarAddress: 'GCREATOR...' };
+
+describe('processDueSubscriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns zero counts when no subscriptions are due', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    const result = await processDueSubscriptions();
+
+    expect(result).toEqual({ processed: 0, failed: 0 });
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { status: 'ACTIVE', nextChargeAt: { lte: expect.any(Date) }, deletedAt: null },
+      include: { tipper: true, creator: true },
+    });
+    expect(mockChargeOnChain).not.toHaveBeenCalled();
+  });
+
+  it('charges every due subscription and advances nextChargeAt', async () => {
+    mockFindMany.mockResolvedValue([
+      { id: 'sub-1', interval: 'MONTHLY', tipper, creator },
+      { id: 'sub-2', interval: 'WEEKLY', tipper, creator },
+    ]);
+    mockChargeOnChain.mockResolvedValue(undefined);
+    mockUpdate.mockResolvedValue({});
+
+    const result = await processDueSubscriptions();
+
+    expect(result).toEqual({ processed: 2, failed: 0 });
+    expect(mockChargeOnChain).toHaveBeenCalledTimes(2);
+    expect(mockChargeOnChain).toHaveBeenCalledWith(tipper.stellarAddress, creator.stellarAddress);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'sub-1' },
+      data: { nextChargeAt: expect.any(Date) },
+    });
+  });
+
+  it('continues processing when an individual charge fails, and does not advance nextChargeAt for it', async () => {
+    mockFindMany.mockResolvedValue([
+      { id: 'sub-1', interval: 'MONTHLY', tipper, creator },
+      { id: 'sub-2', interval: 'MONTHLY', tipper, creator },
+      { id: 'sub-3', interval: 'MONTHLY', tipper, creator },
+    ]);
+    mockChargeOnChain
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('network rejected'))
+      .mockResolvedValueOnce(undefined);
+    mockUpdate.mockResolvedValue({});
+
+    const result = await processDueSubscriptions();
+
+    expect(result).toEqual({ processed: 2, failed: 1 });
+    expect(mockChargeOnChain).toHaveBeenCalledTimes(3);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/jobs/subscriptionCharge.worker.ts
+++ b/backend/src/jobs/subscriptionCharge.worker.ts
@@ -1,0 +1,79 @@
+import { Worker } from 'bullmq';
+import { prisma } from '../db/prisma.js';
+import { redis } from '../db/redis.js';
+import { config } from '../config/index.js';
+import { logger } from '../common/utils/logger.js';
+import {
+  chargeSubscriptionOnChain,
+  INTERVAL_DAYS,
+} from '../modules/subscriptions/subscriptions.service.js';
+import type { SubscriptionIntervalName } from '../modules/subscriptions/subscriptions.types.js';
+import { SUBSCRIPTION_CHARGE_QUEUE, getSubscriptionChargeQueue } from './subscriptionCharge.queue.js';
+import { scheduleRepeatable } from './scheduler.js';
+
+function addDays(from: Date, days: number): Date {
+  return new Date(from.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Finds every ACTIVE subscription whose `nextChargeAt` has passed and charges
+ * it on-chain via the keeper-callable `execute_due_subscription` contract
+ * function (#1029). Advances `nextChargeAt` locally on success so the same
+ * subscription isn't picked up again before the indexer's own `sub_exec`
+ * projection catches up; a per-subscription failure doesn't stop the run.
+ */
+export async function processDueSubscriptions(): Promise<{ processed: number; failed: number }> {
+  const due = await prisma.subscription.findMany({
+    where: { status: 'ACTIVE', nextChargeAt: { lte: new Date() }, deletedAt: null },
+    include: { tipper: true, creator: true },
+  });
+
+  let processed = 0;
+  let failed = 0;
+
+  for (const subscription of due) {
+    try {
+      await chargeSubscriptionOnChain(subscription.tipper.stellarAddress, subscription.creator.stellarAddress);
+      await prisma.subscription.update({
+        where: { id: subscription.id },
+        data: {
+          nextChargeAt: addDays(
+            new Date(),
+            INTERVAL_DAYS[subscription.interval as SubscriptionIntervalName],
+          ),
+        },
+      });
+      processed++;
+    } catch (err) {
+      logger.error({ err, subscriptionId: subscription.id }, 'Failed to process subscription charge');
+      failed++;
+    }
+  }
+
+  return { processed, failed };
+}
+
+export function createSubscriptionChargeWorker(): Worker {
+  const worker = new Worker(
+    SUBSCRIPTION_CHARGE_QUEUE,
+    async (_job) => {
+      const result = await processDueSubscriptions();
+      logger.info(result, 'Subscription charge processing complete');
+    },
+    { connection: redis as any },
+  );
+
+  worker.on('failed', (job, err) => {
+    logger.error({ err, jobId: job?.id }, 'Subscription charge job failed');
+  });
+
+  return worker;
+}
+
+export async function scheduleSubscriptionCharge(): Promise<void> {
+  await scheduleRepeatable({
+    queue: getSubscriptionChargeQueue(),
+    name: 'process-due',
+    pattern: config.subscriptions.chargeCron,
+  });
+}

--- a/backend/src/modules/subscriptions/subscriptions.controller.ts
+++ b/backend/src/modules/subscriptions/subscriptions.controller.ts
@@ -1,0 +1,111 @@
+import type { Request, Response, NextFunction } from 'express';
+import {
+  listSubscriptionsQuerySchema,
+  prepareCreateSubscriptionSchema,
+  submitCreateSubscriptionSchema,
+  prepareCancelSubscriptionSchema,
+  submitCancelSubscriptionSchema,
+} from './subscriptions.schema.js';
+import * as subscriptionsService from './subscriptions.service.js';
+
+/** GET /subscriptions/me: subscriptions where the caller is the tipper or the creator. */
+export async function getMySubscriptions(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { role, status, limit, offset } = listSubscriptionsQuerySchema.parse(req.query);
+    const result = await subscriptionsService.listMySubscriptions(
+      req.user!.id,
+      role,
+      status,
+      limit,
+      offset,
+    );
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /subscriptions/prepare: build an unsigned create_subscription transaction. */
+export async function prepareCreateSubscription(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { creatorStellarAddress, amountStroops, interval } = prepareCreateSubscriptionSchema.parse(
+      req.body,
+    );
+    const result = await subscriptionsService.prepareCreateSubscription(
+      req.user!.id,
+      creatorStellarAddress,
+      amountStroops,
+      interval,
+    );
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /subscriptions/submit: broadcast a wallet-signed create_subscription transaction. */
+export async function submitCreateSubscription(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { creatorStellarAddress, amountStroops, interval, signedTxXdr } =
+      submitCreateSubscriptionSchema.parse(req.body);
+    const result = await subscriptionsService.submitCreateSubscription(
+      req.user!.id,
+      creatorStellarAddress,
+      amountStroops,
+      interval,
+      signedTxXdr,
+    );
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /subscriptions/prepare-cancel: build an unsigned cancel_subscription transaction. */
+export async function prepareCancelSubscription(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { creatorStellarAddress } = prepareCancelSubscriptionSchema.parse(req.body);
+    const result = await subscriptionsService.prepareCancelSubscription(
+      req.user!.id,
+      creatorStellarAddress,
+    );
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /subscriptions/submit-cancel: broadcast a wallet-signed cancel_subscription transaction. */
+export async function submitCancelSubscription(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { creatorStellarAddress, signedTxXdr } = submitCancelSubscriptionSchema.parse(req.body);
+    const result = await subscriptionsService.submitCancelSubscription(
+      req.user!.id,
+      creatorStellarAddress,
+      signedTxXdr,
+    );
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/subscriptions/subscriptions.routes.ts
+++ b/backend/src/modules/subscriptions/subscriptions.routes.ts
@@ -1,0 +1,295 @@
+import { Router } from 'express';
+import { requireAuth } from '../../common/middleware/requireAuth.js';
+import { env } from '../../config/env.js';
+import { mergeOpenApiPaths } from '../../docs/openapi.js';
+import * as subscriptionsController from './subscriptions.controller.js';
+
+export const subscriptionsRouter = Router();
+
+subscriptionsRouter.get('/me', requireAuth, subscriptionsController.getMySubscriptions);
+subscriptionsRouter.post('/prepare', requireAuth, subscriptionsController.prepareCreateSubscription);
+subscriptionsRouter.post('/submit', requireAuth, subscriptionsController.submitCreateSubscription);
+subscriptionsRouter.post(
+  '/prepare-cancel',
+  requireAuth,
+  subscriptionsController.prepareCancelSubscription,
+);
+subscriptionsRouter.post(
+  '/submit-cancel',
+  requireAuth,
+  subscriptionsController.submitCancelSubscription,
+);
+
+const base = `${env.API_BASE_PATH}/subscriptions`;
+
+const subscriptionSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', example: 'sub_clxxtipper_clxxcreator' },
+    tipperId: { type: 'string', example: 'clxxtipper' },
+    tipperStellarAddress: { type: 'string', example: 'GA...TIPPER' },
+    creatorId: { type: 'string', example: 'clxxcreator' },
+    creatorStellarAddress: { type: 'string', example: 'GA...CREATOR' },
+    amountStroops: { type: 'string', example: '10000000' },
+    interval: { type: 'string', enum: ['DAILY', 'WEEKLY', 'MONTHLY'], example: 'MONTHLY' },
+    nextChargeAt: { type: 'string', format: 'date-time' },
+    status: {
+      type: 'string',
+      enum: ['ACTIVE', 'PAUSED', 'CANCELLED', 'EXPIRED'],
+      example: 'ACTIVE',
+    },
+    createdAt: { type: 'string', format: 'date-time' },
+  },
+  required: [
+    'id',
+    'tipperId',
+    'tipperStellarAddress',
+    'creatorId',
+    'creatorStellarAddress',
+    'amountStroops',
+    'interval',
+    'nextChargeAt',
+    'status',
+    'createdAt',
+  ],
+};
+
+const preparedTxSchema = {
+  type: 'object',
+  properties: {
+    unsignedTxXdr: { type: 'string', example: 'AAAAAgAAAAA...' },
+    contractId: { type: 'string', example: 'C...CONTRACT' },
+    networkPassphrase: { type: 'string', example: 'Test SDF Network ; September 2015' },
+  },
+  required: ['unsignedTxXdr', 'contractId', 'networkPassphrase'],
+};
+
+const submittedCreateSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', example: 'sub_clxxtipper_clxxcreator' },
+    status: {
+      type: 'string',
+      enum: ['ACTIVE', 'PAUSED', 'CANCELLED', 'EXPIRED'],
+      example: 'ACTIVE',
+    },
+    nextChargeAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'status', 'nextChargeAt'],
+};
+
+const submittedCancelSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', example: 'sub_clxxtipper_clxxcreator' },
+    status: { type: 'string', enum: ['CANCELLED'], example: 'CANCELLED' },
+  },
+  required: ['id', 'status'],
+};
+
+mergeOpenApiPaths({
+  [`${base}/me`]: {
+    get: {
+      tags: ['Subscriptions'],
+      summary: 'List my subscriptions',
+      description:
+        'Returns paginated recurring tip subscriptions where the authenticated user is either the tipper or the creator.',
+      security: [{ bearerAuth: [] }],
+      parameters: [
+        {
+          name: 'role',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', enum: ['tipper', 'creator'], default: 'tipper' },
+        },
+        {
+          name: 'status',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', enum: ['ACTIVE', 'PAUSED', 'CANCELLED', 'EXPIRED'] },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+        },
+        {
+          name: 'offset',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 0, default: 0 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Paginated subscription list',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { data: { type: 'array', items: subscriptionSchema } },
+                required: ['data'],
+              },
+            },
+          },
+        },
+        '401': { description: 'Unauthorized' },
+      },
+    },
+  },
+  [`${base}/prepare`]: {
+    post: {
+      tags: ['Subscriptions'],
+      summary: 'Prepare a new subscription',
+      description:
+        'Builds an unsigned Soroban transaction calling create_subscription, for the authenticated user (as tipper) to sign with their wallet.',
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                creatorStellarAddress: { type: 'string' },
+                amountStroops: { type: 'string', description: 'Amount in stroops per charge' },
+                interval: { type: 'string', enum: ['DAILY', 'WEEKLY', 'MONTHLY'] },
+              },
+              required: ['creatorStellarAddress', 'amountStroops', 'interval'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Prepared unsigned transaction',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { data: preparedTxSchema }, required: ['data'] },
+            },
+          },
+        },
+        '400': { description: 'Invalid input, creator not found, or self-subscription' },
+        '401': { description: 'Unauthorized' },
+      },
+    },
+  },
+  [`${base}/submit`]: {
+    post: {
+      tags: ['Subscriptions'],
+      summary: 'Submit a signed subscription creation',
+      description:
+        'Broadcasts a wallet-signed create_subscription transaction and records the subscription as ACTIVE. Safe to call again for the same (tipper, creator) pair.',
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                creatorStellarAddress: { type: 'string' },
+                amountStroops: { type: 'string' },
+                interval: { type: 'string', enum: ['DAILY', 'WEEKLY', 'MONTHLY'] },
+                signedTxXdr: { type: 'string', description: 'Base64-encoded signed transaction XDR' },
+              },
+              required: ['creatorStellarAddress', 'amountStroops', 'interval', 'signedTxXdr'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Subscription created',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { data: submittedCreateSchema },
+                required: ['data'],
+              },
+            },
+          },
+        },
+        '400': { description: 'Invalid input or network rejection' },
+        '401': { description: 'Unauthorized' },
+      },
+    },
+  },
+  [`${base}/prepare-cancel`]: {
+    post: {
+      tags: ['Subscriptions'],
+      summary: 'Prepare a subscription cancellation',
+      description:
+        'Builds an unsigned Soroban transaction calling cancel_subscription, for the authenticated user to sign.',
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { creatorStellarAddress: { type: 'string' } },
+              required: ['creatorStellarAddress'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Prepared unsigned transaction',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { data: preparedTxSchema }, required: ['data'] },
+            },
+          },
+        },
+        '400': { description: 'Subscription already cancelled' },
+        '401': { description: 'Unauthorized' },
+        '404': { description: 'Subscription not found' },
+      },
+    },
+  },
+  [`${base}/submit-cancel`]: {
+    post: {
+      tags: ['Subscriptions'],
+      summary: 'Submit a signed subscription cancellation',
+      description:
+        'Broadcasts a wallet-signed cancel_subscription transaction and marks the subscription CANCELLED.',
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                creatorStellarAddress: { type: 'string' },
+                signedTxXdr: { type: 'string' },
+              },
+              required: ['creatorStellarAddress', 'signedTxXdr'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Subscription cancelled',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { data: submittedCancelSchema },
+                required: ['data'],
+              },
+            },
+          },
+        },
+        '400': { description: 'Invalid input or network rejection' },
+        '401': { description: 'Unauthorized' },
+        '404': { description: 'Subscription not found' },
+      },
+    },
+  },
+});

--- a/backend/src/modules/subscriptions/subscriptions.schema.ts
+++ b/backend/src/modules/subscriptions/subscriptions.schema.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+const stellarAddress = z
+  .string()
+  .regex(/^G[A-Z2-7]{55}$/, 'Must be a valid Stellar address (G..., 56 chars)');
+
+export const listSubscriptionsQuerySchema = z.object({
+  role: z.enum(['tipper', 'creator']).default('tipper'),
+  status: z.enum(['ACTIVE', 'PAUSED', 'CANCELLED', 'EXPIRED']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const prepareCreateSubscriptionSchema = z.object({
+  creatorStellarAddress: stellarAddress,
+  amountStroops: z.string().regex(/^\d+$/, 'Amount must be a string of digits (stroops)'),
+  interval: z.enum(['DAILY', 'WEEKLY', 'MONTHLY']),
+});
+
+export const submitCreateSubscriptionSchema = prepareCreateSubscriptionSchema.extend({
+  signedTxXdr: z.string().min(1, 'Signed transaction XDR is required'),
+});
+
+export const prepareCancelSubscriptionSchema = z.object({
+  creatorStellarAddress: stellarAddress,
+});
+
+export const submitCancelSubscriptionSchema = prepareCancelSubscriptionSchema.extend({
+  signedTxXdr: z.string().min(1, 'Signed transaction XDR is required'),
+});
+
+export type ListSubscriptionsQuery = z.infer<typeof listSubscriptionsQuerySchema>;
+export type PrepareCreateSubscriptionInput = z.infer<typeof prepareCreateSubscriptionSchema>;
+export type SubmitCreateSubscriptionInput = z.infer<typeof submitCreateSubscriptionSchema>;
+export type PrepareCancelSubscriptionInput = z.infer<typeof prepareCancelSubscriptionSchema>;
+export type SubmitCancelSubscriptionInput = z.infer<typeof submitCancelSubscriptionSchema>;

--- a/backend/src/modules/subscriptions/subscriptions.service.ts
+++ b/backend/src/modules/subscriptions/subscriptions.service.ts
@@ -1,0 +1,378 @@
+import { Contract, TransactionBuilder, SorobanRpc, nativeToScVal, Networks, Keypair } from '@stellar/stellar-sdk';
+import { config } from '../../config/index.js';
+import { prisma } from '../../db/prisma.js';
+import { BadRequestError, NotFoundError } from '../../common/errors/AppError.js';
+import { logger } from '../../common/utils/logger.js';
+import type {
+  SubscriptionResponse,
+  PreparedSubscriptionTx,
+  SubmittedSubscriptionCreate,
+  SubmittedSubscriptionCancel,
+  SubscriptionIntervalName,
+} from './subscriptions.types.js';
+
+/** Maps the API's interval name onto the raw day count the contract expects. */
+export const INTERVAL_DAYS: Record<SubscriptionIntervalName, number> = {
+  DAILY: 1,
+  WEEKLY: 7,
+  MONTHLY: 30,
+};
+
+function addDays(from: Date, days: number): Date {
+  return new Date(from.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Deterministic off-chain identifier for a (tipper, creator) subscription —
+ * must match the indexer's own `subscriptionId()` in `indexer/projections.ts`
+ * so an optimistic write here and the indexer's later projection of the same
+ * on-chain event upsert the same row instead of creating a duplicate.
+ */
+function subscriptionId(tipperId: string, creatorId: string): string {
+  return `sub_${tipperId}_${creatorId}`;
+}
+
+function serializeSubscription(sub: {
+  id: string;
+  tipperId: string;
+  creatorId: string;
+  amountStroops: bigint;
+  interval: string;
+  nextChargeAt: Date;
+  status: string;
+  createdAt: Date;
+  tipper: { stellarAddress: string };
+  creator: { stellarAddress: string };
+}): SubscriptionResponse {
+  return {
+    id: sub.id,
+    tipperId: sub.tipperId,
+    tipperStellarAddress: sub.tipper.stellarAddress,
+    creatorId: sub.creatorId,
+    creatorStellarAddress: sub.creator.stellarAddress,
+    amountStroops: sub.amountStroops.toString(),
+    interval: sub.interval as SubscriptionResponse['interval'],
+    nextChargeAt: sub.nextChargeAt.toISOString(),
+    status: sub.status as SubscriptionResponse['status'],
+    createdAt: sub.createdAt.toISOString(),
+  };
+}
+
+/** GET /subscriptions/me — subscriptions where the user is the tipper or the creator. */
+export async function listMySubscriptions(
+  userId: string,
+  role: 'tipper' | 'creator',
+  status: SubscriptionResponse['status'] | undefined,
+  limit: number,
+  offset: number,
+): Promise<SubscriptionResponse[]> {
+  const subscriptions = await prisma.subscription.findMany({
+    where: {
+      ...(role === 'tipper' ? { tipperId: userId } : { creatorId: userId }),
+      deletedAt: null,
+      ...(status ? { status } : {}),
+    },
+    include: { tipper: true, creator: true },
+    orderBy: { createdAt: 'desc' },
+    skip: offset,
+    take: limit,
+  });
+
+  return subscriptions.map(serializeSubscription);
+}
+
+async function loadCreatorByAddress(creatorStellarAddress: string) {
+  const creator = await prisma.user.findUnique({ where: { stellarAddress: creatorStellarAddress } });
+  if (!creator) throw new BadRequestError('Creator not found');
+  return creator;
+}
+
+function getServer(): SorobanRpc.Server {
+  return new SorobanRpc.Server(config.stellar.rpcUrl, {
+    allowHttp: config.stellar.rpcUrl.startsWith('http://'),
+  });
+}
+
+function getNetworkPassphrase(): string {
+  return Networks[config.stellar.network as keyof typeof Networks] ?? config.stellar.networkPassphrase;
+}
+
+/**
+ * POST /subscriptions/prepare — build an unsigned transaction calling the
+ * contract's `create_subscription`, for the tipper to sign with their wallet.
+ */
+export async function prepareCreateSubscription(
+  tipperId: string,
+  creatorStellarAddress: string,
+  amountStroops: string,
+  interval: SubscriptionIntervalName,
+): Promise<PreparedSubscriptionTx> {
+  const contractId = config.stellar.contractId;
+  if (!contractId) throw new BadRequestError('Contract ID is not configured');
+
+  const tipper = await prisma.user.findUnique({ where: { id: tipperId } });
+  if (!tipper) throw new BadRequestError('User not found');
+
+  const creator = await loadCreatorByAddress(creatorStellarAddress);
+  if (creator.id === tipperId) throw new BadRequestError('Cannot subscribe to yourself');
+
+  const parsedAmount = BigInt(amountStroops);
+  if (parsedAmount <= 0) throw new BadRequestError('Amount must be positive');
+
+  const server = getServer();
+  const sourceAccount = await server.getAccount(tipper.stellarAddress).catch(() => {
+    throw new BadRequestError('Source account not found on network');
+  });
+  const networkPassphrase = getNetworkPassphrase();
+
+  const contract = new Contract(contractId);
+  const tx = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase })
+    .addOperation(
+      contract.call(
+        'create_subscription',
+        nativeToScVal(tipper.stellarAddress, { type: 'address' }),
+        nativeToScVal(creatorStellarAddress, { type: 'address' }),
+        nativeToScVal(parsedAmount.toString(), { type: 'i128' }),
+        nativeToScVal(INTERVAL_DAYS[interval], { type: 'u32' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const simulateResponse = await server.simulateTransaction(tx).catch((err: Error) => {
+    logger.error({ err }, 'Subscription creation simulation failed');
+    throw new BadRequestError('Transaction simulation failed');
+  });
+
+  if (SorobanRpc.Api.isSimulationError(simulateResponse)) {
+    throw new BadRequestError(`Simulation error: ${simulateResponse.error}`);
+  }
+
+  const prepared = SorobanRpc.assembleTransaction(tx, simulateResponse);
+
+  return {
+    unsignedTxXdr: prepared.build().toEnvelope().toXDR('base64'),
+    contractId,
+    networkPassphrase,
+  };
+}
+
+/**
+ * POST /subscriptions/submit — broadcast a wallet-signed `create_subscription`
+ * transaction and optimistically upsert the subscription row. Safe to race
+ * with the indexer's own `sub_created` projection, which upserts the same
+ * deterministic id.
+ */
+export async function submitCreateSubscription(
+  tipperId: string,
+  creatorStellarAddress: string,
+  amountStroops: string,
+  interval: SubscriptionIntervalName,
+  signedTxXdr: string,
+): Promise<SubmittedSubscriptionCreate> {
+  const tipper = await prisma.user.findUnique({ where: { id: tipperId } });
+  if (!tipper) throw new BadRequestError('User not found');
+
+  const creator = await loadCreatorByAddress(creatorStellarAddress);
+  if (creator.id === tipperId) throw new BadRequestError('Cannot subscribe to yourself');
+
+  const parsedAmount = BigInt(amountStroops);
+  if (parsedAmount <= 0) throw new BadRequestError('Amount must be positive');
+
+  const networkPassphrase = getNetworkPassphrase();
+  const tx = TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase);
+
+  const server = getServer();
+  const sendResponse = await server.sendTransaction(tx).catch((err: Error) => {
+    logger.error({ err }, 'Subscription creation submission failed');
+    throw new BadRequestError('Failed to submit subscription transaction');
+  });
+
+  if (sendResponse.status === 'ERROR') {
+    logger.error(
+      { hash: sendResponse.hash },
+      'Subscription creation transaction rejected by the network',
+    );
+    throw new BadRequestError('Transaction rejected by the network');
+  }
+
+  const id = subscriptionId(tipperId, creator.id);
+  const nextChargeAt = addDays(new Date(), INTERVAL_DAYS[interval]);
+
+  const subscription = await prisma.subscription.upsert({
+    where: { id },
+    create: {
+      id,
+      tipperId,
+      creatorId: creator.id,
+      amountStroops: parsedAmount,
+      interval,
+      nextChargeAt,
+      status: 'ACTIVE',
+    },
+    update: {
+      amountStroops: parsedAmount,
+      interval,
+      status: 'ACTIVE',
+      deletedAt: null,
+    },
+  });
+
+  return {
+    id: subscription.id,
+    status: subscription.status,
+    nextChargeAt: subscription.nextChargeAt.toISOString(),
+  };
+}
+
+async function loadOwnedActiveSubscription(tipperId: string, creatorStellarAddress: string) {
+  const creator = await loadCreatorByAddress(creatorStellarAddress);
+  const id = subscriptionId(tipperId, creator.id);
+  const subscription = await prisma.subscription.findUnique({ where: { id } });
+  if (!subscription || subscription.tipperId !== tipperId || subscription.deletedAt) {
+    throw new NotFoundError('Subscription not found');
+  }
+  if (subscription.status === 'CANCELLED') {
+    throw new BadRequestError('Subscription is already cancelled');
+  }
+  return subscription;
+}
+
+/**
+ * POST /subscriptions/prepare-cancel — build an unsigned transaction calling
+ * the contract's `cancel_subscription`, for the tipper to sign.
+ */
+export async function prepareCancelSubscription(
+  tipperId: string,
+  creatorStellarAddress: string,
+): Promise<PreparedSubscriptionTx> {
+  const contractId = config.stellar.contractId;
+  if (!contractId) throw new BadRequestError('Contract ID is not configured');
+
+  const tipper = await prisma.user.findUnique({ where: { id: tipperId } });
+  if (!tipper) throw new BadRequestError('User not found');
+
+  await loadOwnedActiveSubscription(tipperId, creatorStellarAddress);
+
+  const server = getServer();
+  const sourceAccount = await server.getAccount(tipper.stellarAddress).catch(() => {
+    throw new BadRequestError('Source account not found on network');
+  });
+  const networkPassphrase = getNetworkPassphrase();
+
+  const contract = new Contract(contractId);
+  const tx = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase })
+    .addOperation(
+      contract.call(
+        'cancel_subscription',
+        nativeToScVal(tipper.stellarAddress, { type: 'address' }),
+        nativeToScVal(creatorStellarAddress, { type: 'address' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const simulateResponse = await server.simulateTransaction(tx).catch((err: Error) => {
+    logger.error({ err }, 'Subscription cancellation simulation failed');
+    throw new BadRequestError('Transaction simulation failed');
+  });
+
+  if (SorobanRpc.Api.isSimulationError(simulateResponse)) {
+    throw new BadRequestError(`Simulation error: ${simulateResponse.error}`);
+  }
+
+  const prepared = SorobanRpc.assembleTransaction(tx, simulateResponse);
+
+  return {
+    unsignedTxXdr: prepared.build().toEnvelope().toXDR('base64'),
+    contractId,
+    networkPassphrase,
+  };
+}
+
+/**
+ * POST /subscriptions/submit-cancel — broadcast a wallet-signed
+ * `cancel_subscription` transaction and optimistically mark the subscription
+ * CANCELLED. Safe to race with the indexer's own `sub_cancel` projection.
+ */
+export async function submitCancelSubscription(
+  tipperId: string,
+  creatorStellarAddress: string,
+  signedTxXdr: string,
+): Promise<SubmittedSubscriptionCancel> {
+  const subscription = await loadOwnedActiveSubscription(tipperId, creatorStellarAddress);
+
+  const networkPassphrase = getNetworkPassphrase();
+  const tx = TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase);
+
+  const server = getServer();
+  const sendResponse = await server.sendTransaction(tx).catch((err: Error) => {
+    logger.error({ err }, 'Subscription cancellation submission failed');
+    throw new BadRequestError('Failed to submit cancellation transaction');
+  });
+
+  if (sendResponse.status === 'ERROR') {
+    logger.error(
+      { hash: sendResponse.hash },
+      'Subscription cancellation transaction rejected by the network',
+    );
+    throw new BadRequestError('Transaction rejected by the network');
+  }
+
+  const updated = await prisma.subscription.update({
+    where: { id: subscription.id },
+    data: { status: 'CANCELLED' },
+  });
+
+  return { id: updated.id, status: updated.status };
+}
+
+/**
+ * Charges a single due subscription by invoking the contract's
+ * `execute_due_subscription(subscriber, creator)`. Unlike create/cancel, this
+ * contract function does not require the subscriber's signature — it's
+ * designed to be called by a keeper — so this signs and submits with the
+ * platform's own keeper key (`config.subscriptions.keeperSecretKey`) rather
+ * than a wallet-provided XDR. Used by the subscription-charge job (#1029).
+ */
+export async function chargeSubscriptionOnChain(
+  subscriberAddress: string,
+  creatorAddress: string,
+): Promise<void> {
+  const contractId = config.stellar.contractId;
+  if (!contractId) throw new Error('Contract ID is not configured');
+
+  const keeperSecretKey = config.subscriptions.keeperSecretKey;
+  if (!keeperSecretKey) throw new Error('Subscription keeper secret key is not configured');
+
+  const keeperKeypair = Keypair.fromSecret(keeperSecretKey);
+  const server = getServer();
+  const networkPassphrase = getNetworkPassphrase();
+
+  const keeperAccount = await server.getAccount(keeperKeypair.publicKey());
+  const contract = new Contract(contractId);
+
+  const tx = new TransactionBuilder(keeperAccount, { fee: '100', networkPassphrase })
+    .addOperation(
+      contract.call(
+        'execute_due_subscription',
+        nativeToScVal(subscriberAddress, { type: 'address' }),
+        nativeToScVal(creatorAddress, { type: 'address' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const simulateResponse = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(simulateResponse)) {
+    throw new Error(`Simulation error: ${simulateResponse.error}`);
+  }
+
+  const prepared = SorobanRpc.assembleTransaction(tx, simulateResponse).build();
+  prepared.sign(keeperKeypair);
+
+  const sendResponse = await server.sendTransaction(prepared);
+  if (sendResponse.status === 'ERROR') {
+    throw new Error('Subscription charge transaction rejected by the network');
+  }
+}

--- a/backend/src/modules/subscriptions/subscriptions.test.ts
+++ b/backend/src/modules/subscriptions/subscriptions.test.ts
@@ -1,0 +1,396 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../app.js';
+
+const {
+  mockFindMany,
+  mockUserFindUnique,
+  mockSubFindUnique,
+  mockUpsert,
+  mockUpdate,
+  mockGetAccount,
+  mockSimulateTransaction,
+  mockSendTransaction,
+  mockFromXDR,
+} = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockUserFindUnique: vi.fn(),
+  mockSubFindUnique: vi.fn(),
+  mockUpsert: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockGetAccount: vi.fn(),
+  mockSimulateTransaction: vi.fn(),
+  mockSendTransaction: vi.fn(),
+  mockFromXDR: vi.fn(),
+}));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    subscription: {
+      findMany: mockFindMany,
+      findUnique: mockSubFindUnique,
+      upsert: mockUpsert,
+      update: mockUpdate,
+    },
+    user: { findUnique: mockUserFindUnique },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock('@stellar/stellar-sdk', () => {
+  const mockPreparedTx = {
+    build: vi.fn(() => ({
+      toEnvelope: vi.fn(() => ({
+        toXDR: vi.fn(() => 'AAAAAgAAAAA...mock-unsigned-xdr...'),
+      })),
+      sign: vi.fn(),
+    })),
+  };
+
+  return {
+    TransactionBuilder: Object.assign(
+      vi.fn(() => ({
+        addOperation: vi.fn(() => ({
+          setTimeout: vi.fn(() => ({
+            build: vi.fn(() => ({})),
+          })),
+        })),
+      })),
+      { fromXDR: mockFromXDR },
+    ),
+    SorobanRpc: {
+      Server: vi.fn(() => ({
+        getAccount: mockGetAccount,
+        simulateTransaction: mockSimulateTransaction,
+        sendTransaction: mockSendTransaction,
+      })),
+      assembleTransaction: vi.fn(() => mockPreparedTx),
+      Api: { isSimulationError: vi.fn(() => false) },
+    },
+    Contract: vi.fn(() => ({ call: vi.fn() })),
+    nativeToScVal: vi.fn(() => ({ type: 'scval' })),
+    Networks: { TESTNET: 'Test SDF Network ; September 2015' },
+    Keypair: { fromSecret: vi.fn(() => ({ publicKey: () => 'GKEEPER...' })) },
+  };
+});
+
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: vi.fn() },
+}));
+
+const jwt = await import('jsonwebtoken');
+const tipperAddress = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
+const creatorAddress = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+function mockAuth(userId = 'tipper-1'): void {
+  (jwt.default.verify as ReturnType<typeof vi.fn>).mockReturnValue({
+    sub: userId,
+    stellarAddress: tipperAddress,
+  });
+}
+
+describe('GET /api/v1/subscriptions/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without an Authorization header', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/subscriptions/me');
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the authenticated user's subscriptions as tipper by default", async () => {
+    mockAuth();
+    mockFindMany.mockResolvedValue([
+      {
+        id: 'sub_tipper-1_creator-1',
+        tipperId: 'tipper-1',
+        creatorId: 'creator-1',
+        amountStroops: BigInt(10_000_000),
+        interval: 'MONTHLY',
+        nextChargeAt: new Date('2026-08-01T00:00:00.000Z'),
+        status: 'ACTIVE',
+        createdAt: new Date('2026-07-01T00:00:00.000Z'),
+        tipper: { stellarAddress: tipperAddress },
+        creator: { stellarAddress: creatorAddress },
+      },
+    ]);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/subscriptions/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0]).toMatchObject({
+      id: 'sub_tipper-1_creator-1',
+      tipperStellarAddress: tipperAddress,
+      creatorStellarAddress: creatorAddress,
+      amountStroops: '10000000',
+      interval: 'MONTHLY',
+      status: 'ACTIVE',
+    });
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { tipperId: 'tipper-1', deletedAt: null },
+      include: { tipper: true, creator: true },
+      orderBy: { createdAt: 'desc' },
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it('filters by creator role and status when provided', async () => {
+    mockAuth();
+    mockFindMany.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/subscriptions/me?role=creator&status=ACTIVE&limit=5&offset=10')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { creatorId: 'tipper-1', deletedAt: null, status: 'ACTIVE' },
+      include: { tipper: true, creator: true },
+      orderBy: { createdAt: 'desc' },
+      skip: 10,
+      take: 5,
+    });
+  });
+});
+
+describe('POST /api/v1/subscriptions/prepare', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without an Authorization header', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare')
+      .send({ creatorStellarAddress: creatorAddress, amountStroops: '1000000', interval: 'MONTHLY' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for an invalid body', async () => {
+    mockAuth();
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: 'not-an-address', amountStroops: '1000000', interval: 'MONTHLY' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when subscribing to yourself', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: tipperAddress, amountStroops: '1000000', interval: 'MONTHLY' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when the creator is not found', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce(null);
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: creatorAddress, amountStroops: '1000000', interval: 'MONTHLY' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns a prepared transaction on success', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce({ id: 'creator-1', stellarAddress: creatorAddress });
+    mockGetAccount.mockResolvedValue({});
+    mockSimulateTransaction.mockResolvedValue({});
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: creatorAddress, amountStroops: '1000000', interval: 'MONTHLY' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      unsignedTxXdr: 'AAAAAgAAAAA...mock-unsigned-xdr...',
+    });
+  });
+});
+
+describe('POST /api/v1/subscriptions/submit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates the subscription with a deterministic id on success', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce({ id: 'creator-1', stellarAddress: creatorAddress });
+    mockFromXDR.mockReturnValue({});
+    mockSendTransaction.mockResolvedValue({ status: 'PENDING', hash: 'tx-hash-1' });
+    mockUpsert.mockResolvedValue({
+      id: 'sub_tipper-1_creator-1',
+      status: 'ACTIVE',
+      nextChargeAt: new Date('2026-08-01T00:00:00.000Z'),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/submit')
+      .set('Authorization', 'Bearer valid-token')
+      .send({
+        creatorStellarAddress: creatorAddress,
+        amountStroops: '1000000',
+        interval: 'MONTHLY',
+        signedTxXdr: 'signed-xdr',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ id: 'sub_tipper-1_creator-1', status: 'ACTIVE' });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'sub_tipper-1_creator-1' } }),
+    );
+  });
+
+  it('returns 400 when the network rejects the transaction', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce({ id: 'creator-1', stellarAddress: creatorAddress });
+    mockFromXDR.mockReturnValue({});
+    mockSendTransaction.mockResolvedValue({ status: 'ERROR', hash: 'tx-hash-1' });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/submit')
+      .set('Authorization', 'Bearer valid-token')
+      .send({
+        creatorStellarAddress: creatorAddress,
+        amountStroops: '1000000',
+        interval: 'MONTHLY',
+        signedTxXdr: 'signed-xdr',
+      });
+
+    expect(res.status).toBe(400);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/subscriptions/prepare-cancel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when the subscription does not exist', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce({ id: 'creator-1', stellarAddress: creatorAddress });
+    mockSubFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare-cancel')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: creatorAddress });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when the subscription is already cancelled', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce({ id: 'creator-1', stellarAddress: creatorAddress });
+    mockSubFindUnique.mockResolvedValue({
+      id: 'sub_tipper-1_creator-1',
+      tipperId: 'tipper-1',
+      status: 'CANCELLED',
+      deletedAt: null,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare-cancel')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: creatorAddress });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns a prepared cancellation transaction on success', async () => {
+    mockAuth();
+    mockUserFindUnique
+      .mockResolvedValueOnce({ id: 'tipper-1', stellarAddress: tipperAddress })
+      .mockResolvedValueOnce({ id: 'creator-1', stellarAddress: creatorAddress });
+    mockSubFindUnique.mockResolvedValue({
+      id: 'sub_tipper-1_creator-1',
+      tipperId: 'tipper-1',
+      status: 'ACTIVE',
+      deletedAt: null,
+    });
+    mockGetAccount.mockResolvedValue({});
+    mockSimulateTransaction.mockResolvedValue({});
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/prepare-cancel')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: creatorAddress });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.unsignedTxXdr).toBe('AAAAAgAAAAA...mock-unsigned-xdr...');
+  });
+});
+
+describe('POST /api/v1/subscriptions/submit-cancel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks the subscription CANCELLED on success', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValueOnce({ id: 'creator-1', stellarAddress: creatorAddress });
+    mockSubFindUnique.mockResolvedValue({
+      id: 'sub_tipper-1_creator-1',
+      tipperId: 'tipper-1',
+      status: 'ACTIVE',
+      deletedAt: null,
+    });
+    mockFromXDR.mockReturnValue({});
+    mockSendTransaction.mockResolvedValue({ status: 'PENDING', hash: 'tx-hash-2' });
+    mockUpdate.mockResolvedValue({ id: 'sub_tipper-1_creator-1', status: 'CANCELLED' });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/subscriptions/submit-cancel')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ creatorStellarAddress: creatorAddress, signedTxXdr: 'signed-xdr' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ id: 'sub_tipper-1_creator-1', status: 'CANCELLED' });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'sub_tipper-1_creator-1' },
+      data: { status: 'CANCELLED' },
+    });
+  });
+});

--- a/backend/src/modules/subscriptions/subscriptions.types.ts
+++ b/backend/src/modules/subscriptions/subscriptions.types.ts
@@ -1,0 +1,32 @@
+export type SubscriptionIntervalName = 'DAILY' | 'WEEKLY' | 'MONTHLY';
+export type SubscriptionStatusName = 'ACTIVE' | 'PAUSED' | 'CANCELLED' | 'EXPIRED';
+
+export interface SubscriptionResponse {
+  id: string;
+  tipperId: string;
+  tipperStellarAddress: string;
+  creatorId: string;
+  creatorStellarAddress: string;
+  amountStroops: string;
+  interval: SubscriptionIntervalName;
+  nextChargeAt: string;
+  status: SubscriptionStatusName;
+  createdAt: string;
+}
+
+export interface PreparedSubscriptionTx {
+  unsignedTxXdr: string;
+  contractId: string;
+  networkPassphrase: string;
+}
+
+export interface SubmittedSubscriptionCreate {
+  id: string;
+  status: SubscriptionStatusName;
+  nextChargeAt: string;
+}
+
+export interface SubmittedSubscriptionCancel {
+  id: string;
+  status: SubscriptionStatusName;
+}


### PR DESCRIPTION
## Summary

Closes #1026
Closes #1027
Closes #1028
Closes #1029

Implements the recurring-tip subscriptions REST API and its charge-processing job, on top of the `Subscription` Prisma model and the on-chain `subscription.rs` contract module that already exist on this branch — this is purely the missing backend module + job layer.

Bundled all four into one PR rather than four separate ones since they're one cohesive, sequentially-dependent feature (skeleton → endpoints → list → job), not four independent pieces of work — happy to split if a maintainer would prefer that instead.

## Design notes (worth a maintainer's eyes)

Before writing anything I checked the actual Soroban contract (`contracts/tipz/src/subscription.rs`) and the indexer's existing projections (`indexer/projections.ts`, issue #900) rather than inventing a design from scratch, since subscriptions here are on-chain-driven and already partially wired up:

- `create_subscription` / `cancel_subscription` both require the subscriber's signature — so, exactly like the existing `withdrawals` module, subscription creation/cancellation is a **prepare (build unsigned tx) → submit (broadcast wallet-signed tx)** two-step flow, not a single call.
- `execute_due_subscription` does **not** require the subscriber's signature — it's designed to be keeper-callable. So the charge-processing job (#1029) signs and submits with a platform keeper key (`SUBSCRIPTION_KEEPER_SECRET_KEY`, new env var) rather than needing any user interaction, which is the only way a "process due subscriptions" job can work at all given the contract's actual shape.
- Every write in the service (`submitCreateSubscription`, `submitCancelSubscription`, and the job's `nextChargeAt` advance) is an **optimistic, idempotent upsert keyed on the same deterministic id the indexer's own projections already use** (`` `sub_${tipperId}_${creatorId}` ``) — so this module's writes and the indexer's asynchronous mirroring of the real on-chain events can race safely without ever producing duplicate rows or stale overwrites.
- The job also advances `nextChargeAt` locally right after a successful on-chain charge (not just relying on the indexer to eventually catch up), specifically to avoid re-selecting and double-charging the same subscription within one run if the indexer hasn't polled yet.

## Files

- `modules/subscriptions/subscriptions.{types,schema,service,controller,routes,test}.ts` — module skeleton (#1026), `GET /subscriptions/me` (#1028), `POST /subscriptions/{prepare,submit,prepare-cancel,submit-cancel}` (#1027)
- `jobs/subscriptionCharge.{queue,worker,worker.test}.ts` — the charge-processing job (#1029), following the exact same shape as the existing `creditRecompute` job (a pure, independently-testable `processDueSubscriptions()` plus the BullMQ Worker/schedule wiring)
- `app.ts` — mounts the new router
- `jobs/index.ts`, `jobs/main.ts` — wires the new worker into `bootstrapJobs()`
- `jobs/main.test.ts` — updated for the third scheduled job now registered (2 → 3 `scheduleRepeatable` calls; this test would otherwise correctly fail against the new `bootstrapJobs()` behavior)
- `config/env.ts`, `config/index.ts`, `.env.example` — new `SUBSCRIPTION_KEEPER_SECRET_KEY` (optional) and `SUBSCRIPTION_CHARGE_CRON` (defaults to hourly)

## Testing

Since I solved this without a local clone: downloaded the full `backend/src`, `prisma/`, and `tests/` trees via the GitHub API into a scratch copy, installed with Node 22, generated the Prisma client, and ran the actual toolchain before and after my changes for a clean comparison (this repo has no CI on `test-implement-drips` yet, per `BACKEND_CONTRIBUTING.md`, so this was the only way to get a real signal):

- `npm run typecheck` — identical output before/after (4 pre-existing, unrelated parse errors in `notifications/notifications.test.ts`)
- `npm run lint` — identical before/after (1 pre-existing error in the same file, plus 9 `no-explicit-any` warnings — my one new warning in `subscriptionCharge.worker.ts` is the exact same `connection: redis as any` pattern already present and tolerated in `creditRecompute.worker.ts`/`analyticsDaily.worker.ts`)
- `npm test` — baseline: 475 passed / 52 failed (527 total, all pre-existing — mostly integration tests needing a live Postgres/Redis I didn't have running, per the contributing guide's own note about `resetDb()`). With my changes: 493 passed / 51 failed (544 total) — the same pre-existing failures (one test in `webhookDelivery.test.ts` is independently flaky regardless of my changes, confirmed by re-running it standalone twice), plus my 17 new tests all passing, plus the 3 `main.test.ts` tests I updated for the third scheduled job now passing too.