### PR TITLE
feat: refunds module + request-refund endpoint, streaks GET /me

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1846,6 +1846,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2209,6 +2210,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3282,6 +3284,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3547,6 +3550,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3856,6 +3860,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5183,6 +5188,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5310,6 +5316,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -5874,6 +5881,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
       "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.21.0"
@@ -6430,6 +6438,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6508,6 +6517,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7021,6 +7031,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -23,6 +23,7 @@ import { analyticsRouter } from './modules/analytics/analytics.routes.js';
 import { goalsRouter } from './modules/goals/goals.routes.js';
 import { registerGoalsDocs } from './modules/goals/goals.openapi.js';
 import { subscriptionsRouter } from './modules/subscriptions/subscriptions.routes.js';
+import { refundsRouter } from './modules/refunds/refunds.routes.js';
 
 /** Builds and configures the Express application without starting a listener. */
 export function createApp(): Express {
@@ -73,6 +74,7 @@ export function createApp(): Express {
   app.use(`${env.API_BASE_PATH}/analytics`, analyticsRouter);
   app.use(`${env.API_BASE_PATH}/goals`, goalsRouter);
   app.use(`${env.API_BASE_PATH}/subscriptions`, subscriptionsRouter);
+  app.use(`${env.API_BASE_PATH}/refunds`, refundsRouter);
 
   // Register OpenAPI path docs for feature modules.
   registerGoalsDocs();

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,6 +24,7 @@ import { goalsRouter } from './modules/goals/goals.routes.js';
 import { registerGoalsDocs } from './modules/goals/goals.openapi.js';
 import { subscriptionsRouter } from './modules/subscriptions/subscriptions.routes.js';
 import { refundsRouter } from './modules/refunds/refunds.routes.js';
+import { streaksRouter } from './modules/streaks/streaks.routes.js';
 
 /** Builds and configures the Express application without starting a listener. */
 export function createApp(): Express {
@@ -75,6 +76,7 @@ export function createApp(): Express {
   app.use(`${env.API_BASE_PATH}/goals`, goalsRouter);
   app.use(`${env.API_BASE_PATH}/subscriptions`, subscriptionsRouter);
   app.use(`${env.API_BASE_PATH}/refunds`, refundsRouter);
+  app.use(`${env.API_BASE_PATH}/streaks`, streaksRouter);
 
   // Register OpenAPI path docs for feature modules.
   registerGoalsDocs();

--- a/backend/src/modules/refunds/refunds.controller.ts
+++ b/backend/src/modules/refunds/refunds.controller.ts
@@ -1,0 +1,33 @@
+import type { Request, Response, NextFunction } from 'express';
+import { refundHistoryQuerySchema, requestRefundSchema } from './refunds.schema.js';
+import * as refundsService from './refunds.service.js';
+
+/** POST /refunds/request: request a refund for a tip sent by the authenticated user. */
+export async function requestRefund(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { tipTxHash, reason } = requestRefundSchema.parse(req.body);
+    const result = await refundsService.requestRefund(req.user!.id, tipTxHash, reason);
+    res.status(201).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** GET /refunds/me: refund history for the authenticated user. */
+export async function getMyRefunds(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { limit, offset } = refundHistoryQuerySchema.parse(req.query);
+    const result = await refundsService.getMyRefunds(req.user!.id, limit, offset);
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/refunds/refunds.routes.ts
+++ b/backend/src/modules/refunds/refunds.routes.ts
@@ -1,0 +1,111 @@
+import { Router } from 'express';
+import { requireAuth } from '../../common/middleware/requireAuth.js';
+import { env } from '../../config/env.js';
+import { mergeOpenApiPaths } from '../../docs/openapi.js';
+import * as refundsController from './refunds.controller.js';
+
+export const refundsRouter = Router();
+
+refundsRouter.get('/me', requireAuth, refundsController.getMyRefunds);
+refundsRouter.post('/request', requireAuth, refundsController.requestRefund);
+
+const base = `${env.API_BASE_PATH}/refunds`;
+
+const refundSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', example: 'clxx1234567890abcdef' },
+    tipId: { type: 'string', example: 'clxx0987654321fedcba' },
+    amount: { type: 'string', example: '1000000' },
+    reason: { type: 'string', example: 'Sent to the wrong creator' },
+    status: { type: 'string', example: 'pending' },
+    txHash: { type: 'string', nullable: true, example: null },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'tipId', 'amount', 'reason', 'status', 'txHash', 'createdAt', 'updatedAt'],
+};
+
+mergeOpenApiPaths({
+  [`${base}/me`]: {
+    get: {
+      tags: ['Refunds'],
+      summary: 'Get refund history',
+      description: 'Returns paginated refund history for tips sent by the authenticated user.',
+      security: [{ bearerAuth: [] }],
+      parameters: [
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+        },
+        {
+          name: 'offset',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 0, default: 0 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Paginated refund history',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { type: 'array', items: refundSchema },
+                },
+                required: ['data'],
+              },
+            },
+          },
+        },
+        '401': { description: 'Unauthorized' },
+      },
+    },
+  },
+  [`${base}/request`]: {
+    post: {
+      tags: ['Refunds'],
+      summary: 'Request a refund',
+      description: 'Requests a refund for a confirmed tip sent by the authenticated user.',
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                tipTxHash: { type: 'string', description: 'Transaction hash of the tip to refund' },
+                reason: { type: 'string', description: 'Reason for the refund request' },
+              },
+              required: ['tipTxHash', 'reason'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Refund requested',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { data: refundSchema },
+                required: ['data'],
+              },
+            },
+          },
+        },
+        '400': { description: 'Invalid input or tip not eligible for refund' },
+        '401': { description: 'Unauthorized' },
+        '403': { description: 'Tip does not belong to the authenticated user' },
+        '404': { description: 'Tip not found' },
+        '409': { description: 'Refund already requested for this tip' },
+      },
+    },
+  },
+});

--- a/backend/src/modules/refunds/refunds.schema.ts
+++ b/backend/src/modules/refunds/refunds.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const requestRefundSchema = z.object({
+  tipTxHash: z.string().min(1, 'Tip transaction hash is required'),
+  reason: z.string().min(1, 'Reason is required').max(500, 'Reason must be 500 characters or fewer'),
+});
+
+export const refundHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type RequestRefundInput = z.infer<typeof requestRefundSchema>;
+export type RefundHistoryQuery = z.infer<typeof refundHistoryQuerySchema>;

--- a/backend/src/modules/refunds/refunds.service.ts
+++ b/backend/src/modules/refunds/refunds.service.ts
@@ -1,0 +1,94 @@
+import { prisma } from '../../db/prisma.js';
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from '../../common/errors/AppError.js';
+import type { RefundResponse } from './refunds.types.js';
+
+interface RefundRecord {
+  id: string;
+  tipId: string;
+  amount: bigint;
+  reason: string;
+  status: string;
+  txHash: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function serializeRefund(refund: RefundRecord): RefundResponse {
+  return {
+    id: refund.id,
+    tipId: refund.tipId,
+    amount: refund.amount.toString(),
+    reason: refund.reason,
+    status: refund.status,
+    txHash: refund.txHash,
+    createdAt: refund.createdAt.toISOString(),
+    updatedAt: refund.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * POST /refunds/request — request a refund for a confirmed tip sent by the
+ * authenticated user. One refund request is allowed per tip.
+ */
+export async function requestRefund(
+  userId: string,
+  tipTxHash: string,
+  reason: string,
+): Promise<RefundResponse> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new BadRequestError('User not found');
+
+  const tip = await prisma.tip.findUnique({ where: { txHash: tipTxHash } });
+  if (!tip) throw new NotFoundError('Tip not found');
+
+  if (tip.fromAddress !== user.stellarAddress) {
+    throw new ForbiddenError('You can only request a refund for tips you sent');
+  }
+
+  if (tip.status !== 'CONFIRMED') {
+    throw new BadRequestError('Only confirmed tips can be refunded');
+  }
+
+  const existing = await prisma.refund.findUnique({ where: { tipId: tip.id } });
+  if (existing) {
+    throw new ConflictError('A refund has already been requested for this tip');
+  }
+
+  const refund = await prisma.refund.create({
+    data: {
+      tipId: tip.id,
+      amount: tip.amountStroops,
+      reason,
+      status: 'pending',
+    },
+  });
+
+  return serializeRefund(refund);
+}
+
+/**
+ * GET /refunds/me — paginated refund history for tips sent by the
+ * authenticated user, most recent first.
+ */
+export async function getMyRefunds(
+  userId: string,
+  limit: number,
+  offset: number,
+): Promise<RefundResponse[]> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new BadRequestError('User not found');
+
+  const refunds = await prisma.refund.findMany({
+    where: { tip: { fromAddress: user.stellarAddress } },
+    orderBy: { createdAt: 'desc' },
+    skip: offset,
+    take: limit,
+  });
+
+  return refunds.map(serializeRefund);
+}

--- a/backend/src/modules/refunds/refunds.test.ts
+++ b/backend/src/modules/refunds/refunds.test.ts
@@ -1,0 +1,246 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../app.js';
+
+const { mockUserFindUnique, mockTipFindUnique, mockRefundFindUnique, mockRefundFindMany, mockRefundCreate } =
+  vi.hoisted(() => ({
+    mockUserFindUnique: vi.fn(),
+    mockTipFindUnique: vi.fn(),
+    mockRefundFindUnique: vi.fn(),
+    mockRefundFindMany: vi.fn(),
+    mockRefundCreate: vi.fn(),
+  }));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    user: { findUnique: mockUserFindUnique },
+    tip: { findUnique: mockTipFindUnique },
+    refund: {
+      findUnique: mockRefundFindUnique,
+      findMany: mockRefundFindMany,
+      create: mockRefundCreate,
+    },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: vi.fn() },
+}));
+
+const jwt = await import('jsonwebtoken');
+const address = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
+
+function mockAuth(userId = 'user-1'): void {
+  (jwt.default.verify as ReturnType<typeof vi.fn>).mockReturnValue({
+    sub: userId,
+    stellarAddress: address,
+  });
+}
+
+describe('POST /api/v1/refunds/request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without an Authorization header', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/refunds/request')
+      .send({ tipTxHash: 'tip-hash', reason: 'wrong creator' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for an empty body', async () => {
+    mockAuth();
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/refunds/request')
+      .set('Authorization', 'Bearer valid-token')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 when the tip does not exist', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockTipFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/refunds/request')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ tipTxHash: 'tip-hash', reason: 'wrong creator' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when the tip was not sent by the authenticated user", async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockTipFindUnique.mockResolvedValue({
+      id: 'tip-1',
+      fromAddress: 'GDIFFERENTADDRESS',
+      status: 'CONFIRMED',
+      amountStroops: BigInt(1_000_000),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/refunds/request')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ tipTxHash: 'tip-hash', reason: 'wrong creator' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when the tip is not confirmed', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockTipFindUnique.mockResolvedValue({
+      id: 'tip-1',
+      fromAddress: address,
+      status: 'PENDING',
+      amountStroops: BigInt(1_000_000),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/refunds/request')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ tipTxHash: 'tip-hash', reason: 'wrong creator' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 when a refund has already been requested for the tip', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockTipFindUnique.mockResolvedValue({
+      id: 'tip-1',
+      fromAddress: address,
+      status: 'CONFIRMED',
+      amountStroops: BigInt(1_000_000),
+    });
+    mockRefundFindUnique.mockResolvedValue({ id: 'refund-1', tipId: 'tip-1' });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/refunds/request')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ tipTxHash: 'tip-hash', reason: 'wrong creator' });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('creates a pending refund for a confirmed tip sent by the authenticated user', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockTipFindUnique.mockResolvedValue({
+      id: 'tip-1',
+      fromAddress: address,
+      status: 'CONFIRMED',
+      amountStroops: BigInt(1_000_000),
+    });
+    mockRefundFindUnique.mockResolvedValue(null);
+    mockRefundCreate.mockResolvedValue({
+      id: 'refund-1',
+      tipId: 'tip-1',
+      amount: BigInt(1_000_000),
+      reason: 'wrong creator',
+      status: 'pending',
+      txHash: null,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/v1/refunds/request')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ tipTxHash: 'tip-hash', reason: 'wrong creator' });
+
+    expect(res.status).toBe(201);
+    expect(mockRefundCreate).toHaveBeenCalledWith({
+      data: {
+        tipId: 'tip-1',
+        amount: BigInt(1_000_000),
+        reason: 'wrong creator',
+        status: 'pending',
+      },
+    });
+    expect(res.body.data).toMatchObject({
+      id: 'refund-1',
+      tipId: 'tip-1',
+      amount: '1000000',
+      reason: 'wrong creator',
+      status: 'pending',
+      txHash: null,
+    });
+  });
+});
+
+describe('GET /api/v1/refunds/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without an Authorization header', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/refunds/me');
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the authenticated user's refund history", async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockRefundFindMany.mockResolvedValue([
+      {
+        id: 'refund-1',
+        tipId: 'tip-1',
+        amount: BigInt(1_000_000),
+        reason: 'wrong creator',
+        status: 'pending',
+        txHash: null,
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/refunds/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0]).toMatchObject({
+      id: 'refund-1',
+      tipId: 'tip-1',
+      amount: '1000000',
+      status: 'pending',
+    });
+    expect(mockRefundFindMany).toHaveBeenCalledWith({
+      where: { tip: { fromAddress: address } },
+      orderBy: { createdAt: 'desc' },
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it('returns an empty array when the user has no refunds', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockRefundFindMany.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/refunds/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+});

--- a/backend/src/modules/refunds/refunds.types.ts
+++ b/backend/src/modules/refunds/refunds.types.ts
@@ -1,0 +1,11 @@
+/** Serialized refund record returned by the refunds API. */
+export interface RefundResponse {
+  id: string;
+  tipId: string;
+  amount: string;
+  reason: string;
+  status: string;
+  txHash: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/backend/src/modules/streaks/streaks.controller.ts
+++ b/backend/src/modules/streaks/streaks.controller.ts
@@ -1,0 +1,16 @@
+import type { Request, Response, NextFunction } from 'express';
+import * as streaksService from './streaks.service.js';
+
+/** GET /streaks/me: the authenticated user's current tipping streak. */
+export async function getMyStreak(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const result = await streaksService.getMyStreak(req.user!.id);
+    res.status(200).json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/streaks/streaks.routes.ts
+++ b/backend/src/modules/streaks/streaks.routes.ts
@@ -1,0 +1,47 @@
+import { Router } from 'express';
+import { requireAuth } from '../../common/middleware/requireAuth.js';
+import { env } from '../../config/env.js';
+import { mergeOpenApiPaths } from '../../docs/openapi.js';
+import * as streaksController from './streaks.controller.js';
+
+export const streaksRouter = Router();
+
+streaksRouter.get('/me', requireAuth, streaksController.getMyStreak);
+
+const base = `${env.API_BASE_PATH}/streaks`;
+
+mergeOpenApiPaths({
+  [`${base}/me`]: {
+    get: {
+      tags: ['Streaks'],
+      summary: 'Get current tipping streak',
+      description: 'Returns the authenticated user\'s current and longest tipping streak.',
+      security: [{ bearerAuth: [] }],
+      responses: {
+        '200': {
+          description: 'Streak details',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      currentStreak: { type: 'integer', example: 3 },
+                      longestStreak: { type: 'integer', example: 7 },
+                      lastTipDate: { type: 'string', format: 'date-time', nullable: true, example: null },
+                    },
+                    required: ['currentStreak', 'longestStreak', 'lastTipDate'],
+                  },
+                },
+                required: ['data'],
+              },
+            },
+          },
+        },
+        '401': { description: 'Unauthorized' },
+      },
+    },
+  },
+});

--- a/backend/src/modules/streaks/streaks.service.ts
+++ b/backend/src/modules/streaks/streaks.service.ts
@@ -1,0 +1,21 @@
+import { prisma } from '../../db/prisma.js';
+import { BadRequestError } from '../../common/errors/AppError.js';
+import type { StreakResponse } from './streaks.types.js';
+
+/**
+ * GET /streaks/me — the authenticated user's current tipping streak. Users
+ * who have not yet tipped have no Streak row; this returns a zeroed streak
+ * for them instead of a 404.
+ */
+export async function getMyStreak(userId: string): Promise<StreakResponse> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new BadRequestError('User not found');
+
+  const streak = await prisma.streak.findUnique({ where: { userId } });
+
+  return {
+    currentStreak: streak?.currentStreak ?? 0,
+    longestStreak: streak?.longestStreak ?? 0,
+    lastTipDate: streak?.lastTipDate ? streak.lastTipDate.toISOString() : null,
+  };
+}

--- a/backend/src/modules/streaks/streaks.test.ts
+++ b/backend/src/modules/streaks/streaks.test.ts
@@ -1,0 +1,84 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../app.js';
+
+const { mockUserFindUnique, mockStreakFindUnique } = vi.hoisted(() => ({
+  mockUserFindUnique: vi.fn(),
+  mockStreakFindUnique: vi.fn(),
+}));
+
+vi.mock('../../db/prisma.js', () => ({
+  prisma: {
+    user: { findUnique: mockUserFindUnique },
+    streak: { findUnique: mockStreakFindUnique },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: vi.fn() },
+}));
+
+const jwt = await import('jsonwebtoken');
+const address = 'GF5YV3FQRHRMA7IQWCZKGRRJ5P7CEPIVBQLM4X2FEHS2IU57KF3U4CLN';
+
+function mockAuth(userId = 'user-1'): void {
+  (jwt.default.verify as ReturnType<typeof vi.fn>).mockReturnValue({
+    sub: userId,
+    stellarAddress: address,
+  });
+}
+
+describe('GET /api/v1/streaks/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without an Authorization header', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/streaks/me');
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the authenticated user's streak", async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockStreakFindUnique.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 3,
+      longestStreak: 7,
+      lastTipDate: new Date('2024-01-01T00:00:00.000Z'),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/streaks/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      currentStreak: 3,
+      longestStreak: 7,
+      lastTipDate: '2024-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('returns a zeroed streak when the user has never tipped', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue({ id: 'user-1', stellarAddress: address });
+    mockStreakFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/streaks/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      currentStreak: 0,
+      longestStreak: 0,
+      lastTipDate: null,
+    });
+  });
+});

--- a/backend/src/modules/streaks/streaks.types.ts
+++ b/backend/src/modules/streaks/streaks.types.ts
@@ -1,0 +1,6 @@
+/** Serialized tipping streak returned by the streaks API. */
+export interface StreakResponse {
+  currentStreak: number;
+  longestStreak: number;
+  lastTipDate: string | null;
+}


### PR DESCRIPTION
## Summary

- **#1036** — Adds the `backend/src/modules/refunds/` module skeleton (routes/controller/service/schema/types/tests), wired into `app.ts`, following the same layout as `withdrawals`.
- **#1037** — Implements `POST /refunds/request` on top of the skeleton: an authenticated user can request a refund for a `CONFIRMED` tip they sent (`fromAddress` must match their `stellarAddress`). Rejects tips that aren't confirmed (400), tips not owned by the caller (403), unknown tips (404), and duplicate requests for the same tip (409). Also adds `GET /refunds/me` for paginated refund history. Uses the existing `Refund` Prisma model.
- **#1034** — Implements `GET /streaks/me`, returning the authenticated user's `currentStreak`, `longestStreak`, and `lastTipDate` from the existing `Streak` Prisma model, defaulting to a zeroed streak for users who haven't tipped yet.

All three endpoints are protected by the existing `requireAuth` JWT middleware, validate input with Zod, and throw `AppError` subclasses (`NotFoundError`/`ForbiddenError`/`ConflictError`/`BadRequestError`) for error cases.

## Test plan

- [x] `npm run typecheck` — passes for all new/changed files (pre-existing failure in `notifications.test.ts` on `test-implement-drips` is unrelated and out of scope; verified it exists without this branch's changes too)
- [x] `npm run lint` — passes for all new/changed files (same pre-existing `notifications.test.ts` parsing error, unrelated)
- [x] `npm run test` — 13 new tests added across `refunds.test.ts` and `streaks.test.ts`, all passing with mocked Prisma. Full local suite has pre-existing failures on this branch that require a live Postgres/Redis (integration tests, e.g. `x.test.ts`, `retry.test.ts`) — same failures exist without this branch's changes, unrelated to this PR, and out of scope per contributing guide.

Closes #1037
Closes #1036
Closes #1034