### PR TITLE
feat(analytics): implement GET /creators/:username/analytics (issue #1006)

### DIFF
--- a/backend/src/modules/analytics/analytics.controller.ts
+++ b/backend/src/modules/analytics/analytics.controller.ts
@@ -1,9 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { BadRequestError } from '../../common/errors/AppError.js';
-import { analyticsDailyQuerySchema, volumeQuerySchema, topTippersQuerySchema } from './analytics.schema.js';
+import { analyticsDailyQuerySchema, volumeQuerySchema, topTippersQuerySchema, creatorUsernameParamSchema, creatorAnalyticsQuerySchema } from './analytics.schema.js';
 import * as analyticsService from './analytics.service.js';
-import { getTipVolume, getTopTippers } from './analytics.service.js';
+import { getTipVolume, getTopTippers, getCreatorAnalytics } from './analytics.service.js';
 
 /** GET /analytics/daily — paginated daily analytics with optional date range. */
 export async function getDailyAnalytics(
@@ -71,6 +71,26 @@ export async function getTopTippersController(
   } catch (error) {
     if (error instanceof z.ZodError) {
       next(new BadRequestError('Invalid query parameters', error.issues));
+    } else {
+      next(error);
+    }
+  }
+}
+
+/** GET /analytics/creators/:username — creator-specific analytics (issue #1006). */
+export async function getCreatorAnalyticsController(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { username } = creatorUsernameParamSchema.parse(req.params);
+    const query = creatorAnalyticsQuerySchema.parse(req.query);
+    const result = await getCreatorAnalytics(username, query.startDate, query.endDate, query.granularity);
+    res.status(200).json({ data: result });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new BadRequestError('Invalid parameters', error.issues));
     } else {
       next(error);
     }

--- a/backend/src/modules/analytics/analytics.routes.ts
+++ b/backend/src/modules/analytics/analytics.routes.ts
@@ -9,6 +9,7 @@ analyticsRouter.get('/daily', analyticsController.getDailyAnalytics);
 analyticsRouter.get('/summary', analyticsController.getAnalyticsSummary);
 analyticsRouter.get('/volume', analyticsController.getTipVolumeController);
 analyticsRouter.get('/top-tippers', analyticsController.getTopTippersController);
+analyticsRouter.get('/creators/:username', analyticsController.getCreatorAnalyticsController);
 
 const base = `${env.API_BASE_PATH}/analytics`;
 
@@ -135,6 +136,105 @@ mergeOpenApiPaths({
           },
         },
         '400': { description: 'Validation error' },
+      },
+    },
+  },
+  [`${base}/creators/{username}`]: {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get creator analytics',
+      description: 'Returns analytics for a specific creator including summary stats, time-series data, and top tippers.',
+      parameters: [
+        {
+          name: 'username',
+          in: 'path',
+          required: true,
+          schema: { type: 'string', description: 'Creator username' },
+        },
+        {
+          name: 'startDate',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', format: 'date', description: 'Start date (YYYY-MM-DD)' },
+        },
+        {
+          name: 'endDate',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', format: 'date', description: 'End date (YYYY-MM-DD)' },
+        },
+        {
+          name: 'granularity',
+          in: 'query',
+          required: false,
+          schema: { type: 'string', enum: ['day', 'week', 'month'], default: 'day' },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Creator analytics',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      summary: {
+                        type: 'object',
+                        properties: {
+                          totalTipsReceived: { type: 'integer' },
+                          totalVolumeReceived: { type: 'string' },
+                          uniqueTippers: { type: 'integer' },
+                          averageTipSize: { type: 'string' },
+                          firstTipDate: { type: 'string', nullable: true },
+                          lastTipDate: { type: 'string', nullable: true },
+                        },
+                      },
+                      timeSeries: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            date: { type: 'string' },
+                            totalTips: { type: 'integer' },
+                            totalVolume: { type: 'string' },
+                            uniqueTippers: { type: 'integer' },
+                          },
+                        },
+                      },
+                      topTippers: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            userId: { type: 'string' },
+                            stellarAddress: { type: 'string' },
+                            username: { type: 'string', nullable: true },
+                            displayName: { type: 'string', nullable: true },
+                            totalTipsStroops: { type: 'string' },
+                            tipCount: { type: 'integer' },
+                          },
+                        },
+                      },
+                      granularity: { type: 'string' },
+                      period: {
+                        type: 'object',
+                        properties: {
+                          start: { type: 'string', nullable: true },
+                          end: { type: 'string', nullable: true },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': { description: 'Validation error' },
+        '404': { description: 'Creator not found' },
       },
     },
   },

--- a/backend/src/modules/analytics/analytics.schema.ts
+++ b/backend/src/modules/analytics/analytics.schema.ts
@@ -26,3 +26,19 @@ export const topTippersQuerySchema = z.object({
 });
 
 export type TopTippersQuery = z.infer<typeof topTippersQuerySchema>;
+
+/** Path parameters for GET /analytics/creators/:username. */
+export const creatorUsernameParamSchema = z.object({
+  username: z.string().min(1, 'Username is required').max(50),
+});
+
+export type CreatorUsernameParam = z.infer<typeof creatorUsernameParamSchema>;
+
+/** Query parameters for GET /analytics/creators/:username. */
+export const creatorAnalyticsQuerySchema = z.object({
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be YYYY-MM-DD format').optional(),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be YYYY-MM-DD format').optional(),
+  granularity: z.enum(['day', 'week', 'month']).default('day'),
+});
+
+export type CreatorAnalyticsQuery = z.infer<typeof creatorAnalyticsQuerySchema>;

--- a/backend/src/modules/analytics/analytics.service.ts
+++ b/backend/src/modules/analytics/analytics.service.ts
@@ -1,7 +1,9 @@
 import { prisma } from '../../db/prisma.js';
 import { logger } from '../../common/utils/logger.js';
+import { NotFoundError } from '../../common/errors/AppError.js';
 import type { AnalyticsDailyEntry, AnalyticsDailyResponse, AnalyticsSummary } from './analytics.types.js';
 import type { TipVolumeResponse, TopTipperEntry, TopTippersResponse } from './analytics.types.js';
+import type { CreatorAnalyticsResponse, CreatorAnalyticsSummary, CreatorAnalyticsEntry, CreatorTopTipperEntry } from './analytics.types.js';
 
 /**
  * Returns paginated daily analytics rows, optionally filtered by date range.
@@ -283,5 +285,145 @@ export async function computeDailyAnalytics(date: string): Promise<AnalyticsDail
     totalVolume: upserted.totalVolume.toString(),
     newUsers: upserted.newUsers,
     activeUsers: upserted.activeUsers,
+  };
+}
+
+/**
+ * Returns analytics for a specific creator identified by username.
+ * Includes summary stats, time-series data, and top tippers.
+ */
+export async function getCreatorAnalytics(
+  username: string,
+  startDate: string | undefined,
+  endDate: string | undefined,
+  granularity: string,
+): Promise<CreatorAnalyticsResponse> {
+  logger.info({ username, startDate, endDate, granularity }, 'Fetching creator analytics');
+
+  const user = await prisma.user.findUnique({
+    where: { username },
+    select: { id: true, stellarAddress: true, username: true, displayName: true },
+  });
+
+  if (!user) {
+    throw new NotFoundError('Creator not found');
+  }
+
+  const now = new Date();
+  const start = startDate ? new Date(startDate) : new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const end = endDate ? new Date(endDate) : now;
+
+  const tips = await prisma.tip.findMany({
+    where: {
+      toAddress: user.stellarAddress,
+      createdAt: { gte: start, lte: end },
+      status: 'CONFIRMED',
+    },
+    select: { amountStroops: true, createdAt: true, fromAddress: true },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  const totalTipsReceived = tips.length;
+  const totalVolumeReceived = tips.reduce((sum, tip) => sum + tip.amountStroops, BigInt(0));
+  const uniqueTippers = new Set(tips.map((tip) => tip.fromAddress)).size;
+  const averageTipSize = totalTipsReceived > 0
+    ? (totalVolumeReceived / BigInt(totalTipsReceived)).toString()
+    : '0';
+
+  const firstTipDate = tips.length > 0 ? tips[0].createdAt.toISOString().slice(0, 10) : null;
+  const lastTipDate = tips.length > 0 ? tips[tips.length - 1].createdAt.toISOString().slice(0, 10) : null;
+
+  const summary: CreatorAnalyticsSummary = {
+    totalTipsReceived,
+    totalVolumeReceived: totalVolumeReceived.toString(),
+    uniqueTippers,
+    averageTipSize,
+    firstTipDate,
+    lastTipDate,
+  };
+
+  const buckets = new Map<string, { totalStroops: bigint; count: number; tippers: Set<string> }>();
+
+  for (const tip of tips) {
+    let key: string;
+    const d = new Date(tip.createdAt);
+
+    switch (granularity) {
+      case 'week': {
+        const startOfWeek = new Date(d);
+        startOfWeek.setDate(d.getDate() - d.getDay());
+        key = startOfWeek.toISOString().slice(0, 10);
+        break;
+      }
+      case 'month':
+        key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+        break;
+      default:
+        key = d.toISOString().slice(0, 10);
+        break;
+    }
+
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.totalStroops += tip.amountStroops;
+      existing.count += 1;
+      existing.tippers.add(tip.fromAddress);
+    } else {
+      buckets.set(key, {
+        totalStroops: tip.amountStroops,
+        count: 1,
+        tippers: new Set([tip.fromAddress]),
+      });
+    }
+  }
+
+  const timeSeries: CreatorAnalyticsEntry[] = Array.from(buckets.entries()).map(([date, data]) => ({
+    date,
+    totalTips: data.count,
+    totalVolume: data.totalStroops.toString(),
+    uniqueTippers: data.tippers.size,
+  }));
+
+  const tipperMap = new Map<string, { totalStroops: bigint; count: number }>();
+  for (const tip of tips) {
+    const existing = tipperMap.get(tip.fromAddress);
+    if (existing) {
+      existing.totalStroops += tip.amountStroops;
+      existing.count += 1;
+    } else {
+      tipperMap.set(tip.fromAddress, { totalStroops: tip.amountStroops, count: 1 });
+    }
+  }
+
+  const sortedTippers = Array.from(tipperMap.entries())
+    .sort((a, b) => (b[1].totalStroops > a[1].totalStroops ? 1 : -1))
+    .slice(0, 10);
+
+  const topTippers: CreatorTopTipperEntry[] = await Promise.all(
+    sortedTippers.map(async ([address, data]) => {
+      const tipper = await prisma.user.findUnique({
+        where: { stellarAddress: address },
+        select: { id: true, stellarAddress: true, username: true, displayName: true },
+      });
+      return {
+        userId: tipper?.id ?? '',
+        stellarAddress: address,
+        username: tipper?.username ?? null,
+        displayName: tipper?.displayName ?? null,
+        totalTipsStroops: data.totalStroops.toString(),
+        tipCount: data.count,
+      };
+    }),
+  );
+
+  return {
+    summary,
+    timeSeries,
+    topTippers,
+    granularity,
+    period: {
+      start: startDate ?? null,
+      end: endDate ?? null,
+    },
   };
 }

--- a/backend/src/modules/analytics/analytics.test.ts
+++ b/backend/src/modules/analytics/analytics.test.ts
@@ -252,3 +252,119 @@ describe('computeDailyAnalytics', () => {
     });
   });
 });
+
+describe('GET /api/v1/analytics/creators/:username', () => {
+  beforeEach(resetMocks);
+
+  const mockUser = {
+    id: 'user-1',
+    stellarAddress: 'GCREATOR123',
+    username: 'testcreator',
+    displayName: 'Test Creator',
+  };
+
+  const mockTips = [
+    { amountStroops: BigInt(100000000), createdAt: new Date('2026-07-20T10:00:00Z'), fromAddress: 'GTIPPER1' },
+    { amountStroops: BigInt(200000000), createdAt: new Date('2026-07-21T11:00:00Z'), fromAddress: 'GTIPPER2' },
+    { amountStroops: BigInt(150000000), createdAt: new Date('2026-07-21T12:00:00Z'), fromAddress: 'GTIPPER1' },
+    { amountStroops: BigInt(50000000), createdAt: new Date('2026-07-22T09:00:00Z'), fromAddress: 'GTIPPER3' },
+  ];
+
+  it('returns 404 for non-existent creator', async () => {
+    vi.spyOn(await import('../../db/prisma.js'), 'prisma').mockReturnValue({
+      user: { findUnique: vi.fn().mockResolvedValue(null) },
+      tip: { findMany: vi.fn() },
+      $disconnect: vi.fn(),
+    } as any);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/creators/nonexistent');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for missing username', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/creators/');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns creator analytics with default parameters', async () => {
+    const { prisma } = await import('../../db/prisma.js');
+    vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockUser as any);
+    vi.spyOn(prisma.tip, 'findMany').mockResolvedValue(mockTips as any);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/creators/testcreator');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeDefined();
+    expect(res.body.data.summary).toBeDefined();
+    expect(res.body.data.summary.totalTipsReceived).toBe(4);
+    expect(res.body.data.summary.totalVolumeReceived).toBe('500000000');
+    expect(res.body.data.summary.uniqueTippers).toBe(3);
+    expect(res.body.data.granularity).toBe('day');
+  });
+
+  it('returns creator analytics with custom date range', async () => {
+    const { prisma } = await import('../../db/prisma.js');
+    vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockUser as any);
+    vi.spyOn(prisma.tip, 'findMany').mockResolvedValue(mockTips as any);
+
+    const app = createApp();
+    const res = await request(app).get(
+      '/api/v1/analytics/creators/testcreator?startDate=2026-07-20&endDate=2026-07-21',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.period.start).toBe('2026-07-20');
+    expect(res.body.data.period.end).toBe('2026-07-21');
+  });
+
+  it('returns creator analytics with week granularity', async () => {
+    const { prisma } = await import('../../db/prisma.js');
+    vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockUser as any);
+    vi.spyOn(prisma.tip, 'findMany').mockResolvedValue(mockTips as any);
+
+    const app = createApp();
+    const res = await request(app).get(
+      '/api/v1/analytics/creators/testcreator?granularity=week',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.granularity).toBe('week');
+    expect(res.body.data.timeSeries).toBeDefined();
+  });
+
+  it('returns empty analytics for creator with no tips', async () => {
+    const { prisma } = await import('../../db/prisma.js');
+    vi.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockUser as any);
+    vi.spyOn(prisma.tip, 'findMany').mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app).get('/api/v1/analytics/creators/testcreator');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.summary.totalTipsReceived).toBe(0);
+    expect(res.body.data.summary.totalVolumeReceived).toBe('0');
+    expect(res.body.data.summary.uniqueTippers).toBe(0);
+    expect(res.body.data.timeSeries).toEqual([]);
+    expect(res.body.data.topTippers).toEqual([]);
+  });
+
+  it('returns 400 for invalid date format', async () => {
+    const app = createApp();
+    const res = await request(app).get(
+      '/api/v1/analytics/creators/testcreator?startDate=invalid-date',
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid granularity', async () => {
+    const app = createApp();
+    const res = await request(app).get(
+      '/api/v1/analytics/creators/testcreator?granularity=invalid',
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/modules/analytics/analytics.types.ts
+++ b/backend/src/modules/analytics/analytics.types.ts
@@ -62,3 +62,43 @@ export interface TopTippersResponse {
   page: number;
   limit: number;
 }
+
+/** A single creator analytics time-series entry. */
+export interface CreatorAnalyticsEntry {
+  date: string;
+  totalTips: number;
+  totalVolume: string;
+  uniqueTippers: number;
+}
+
+/** Creator analytics summary. */
+export interface CreatorAnalyticsSummary {
+  totalTipsReceived: number;
+  totalVolumeReceived: string;
+  uniqueTippers: number;
+  averageTipSize: string;
+  firstTipDate: string | null;
+  lastTipDate: string | null;
+}
+
+/** Top tipper to a specific creator. */
+export interface CreatorTopTipperEntry {
+  userId: string;
+  stellarAddress: string;
+  username: string | null;
+  displayName: string | null;
+  totalTipsStroops: string;
+  tipCount: number;
+}
+
+/** Creator analytics response. */
+export interface CreatorAnalyticsResponse {
+  summary: CreatorAnalyticsSummary;
+  timeSeries: CreatorAnalyticsEntry[];
+  topTippers: CreatorTopTipperEntry[];
+  granularity: string;
+  period: {
+    start: string | null;
+    end: string | null;
+  };
+}


### PR DESCRIPTION
## Description:
Implements the per-creator analytics endpoint as specified in issue #1006.
Endpoint: GET /api/v1/analytics/creators/:username
## Query parameters:
- startDate (optional) — YYYY-MM-DD format
- endDate (optional) — YYYY-MM-DD format
- granularity (optional) — day | week | month (default: day)
## Response includes:
- summary — totalTipsReceived, totalVolumeReceived, uniqueTippers, averageTipSize, firstTipDate, lastTipDate
- timeSeries — bucketed tip data by chosen granularity
- topTippers — top 10 tippers ranked by total stroops sent
- period — the date range applied
## Files changed:
- analytics.schema.ts — Added creatorUsernameParamSchema + creatorAnalyticsQuerySchema
- analytics.types.ts — Added CreatorAnalyticsResponse, CreatorAnalyticsSummary, CreatorAnalyticsEntry, CreatorTopTipperEntry
- analytics.service.ts — Added getCreatorAnalytics() with user lookup, tip aggregation, time-series bucketing, and top-tipper ranking
- analytics.controller.ts — Added getCreatorAnalyticsController with Zod validation
- analytics.routes.ts — Registered route + OpenAPI documentation
- analytics.test.ts — 7 test cases covering happy path, empty state, date ranges, granularity, validation, and 404
## Fixes 
closes #1006 