### PR TITLE
feat(jobs): wire leaderboard snapshotting into a scheduled queue (#991)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,6 +42,10 @@ CREDIT_RECOMPUTE_CRON=0 */6 * * *
 # Runs at 00:05 UTC daily by default
 ANALYTICS_DAILY_CRON=5 0 * * *
 
+# Leaderboard snapshot schedule (cron expression for BullMQ repeatable job)
+# Runs at 00:15 UTC daily by default
+LEADERBOARD_SNAPSHOT_CRON=15 0 * * *
+
 # Credit score weights and configuration (optional — defaults provided)
 # Weights as percentages (must sum to <= 100)
 CREDIT_SCORE_WEIGHT_BASE=40

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -51,6 +51,8 @@ const envSchema = z.object({
   CREDIT_RECOMPUTE_CRON: z.string().default('0 */6 * * *'),
   /** Cron expression for the daily analytics rollup job. Runs at 00:05 UTC daily by default. */
   ANALYTICS_DAILY_CRON: z.string().default('5 0 * * *'),
+  /** Cron expression for the leaderboard snapshot job. Runs at 00:15 UTC daily by default. */
+  LEADERBOARD_SNAPSHOT_CRON: z.string().default('15 0 * * *'),
   /** Credit score weights (must sum to <= 100) */
   CREDIT_SCORE_WEIGHT_BASE: z.coerce.number().int().min(0).max(100).optional(),
   CREDIT_SCORE_WEIGHT_TIP: z.coerce.number().int().min(0).max(100).optional(),

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -66,6 +66,10 @@ export const config = {
     dailyCron: env.ANALYTICS_DAILY_CRON,
   },
 
+  leaderboard: {
+    snapshotCron: env.LEADERBOARD_SNAPSHOT_CRON,
+  },
+
   withdrawals: {
     minAmountStroops: env.WITHDRAWAL_MIN_AMOUNT_STROOPS,
     feeBps: env.WITHDRAWAL_FEE_BPS,

--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -31,4 +31,14 @@ export {
   scheduleSubscriptionCharge,
 } from './subscriptionCharge.worker.js';
 
+export {
+  LEADERBOARD_SNAPSHOT_QUEUE,
+  getLeaderboardSnapshotQueue,
+} from './leaderboardSnapshot.queue.js';
+export {
+  runLeaderboardSnapshot,
+  createLeaderboardSnapshotWorker,
+  scheduleLeaderboardSnapshot,
+} from './leaderboardSnapshot.worker.js';
+
 export { bootstrapJobs } from './main.js';

--- a/backend/src/jobs/leaderboardSnapshot.queue.ts
+++ b/backend/src/jobs/leaderboardSnapshot.queue.ts
@@ -1,0 +1,8 @@
+import { getQueue } from './queueFactory.js';
+
+export const LEADERBOARD_SNAPSHOT_QUEUE = 'leaderboard-snapshot';
+
+/** Lazily-initialised singleton Queue for leaderboard snapshot jobs. */
+export function getLeaderboardSnapshotQueue() {
+  return getQueue(LEADERBOARD_SNAPSHOT_QUEUE);
+}

--- a/backend/src/jobs/leaderboardSnapshot.worker.test.ts
+++ b/backend/src/jobs/leaderboardSnapshot.worker.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../modules/leaderboard/leaderboard.service.js', () => ({
+  createLeaderboardSnapshot: vi.fn(),
+}));
+
+vi.mock('../db/redis.js', () => ({
+  redis: {},
+}));
+
+vi.mock('../common/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { runLeaderboardSnapshot } from './leaderboardSnapshot.worker.js';
+import { createLeaderboardSnapshot } from '../modules/leaderboard/leaderboard.service.js';
+
+describe('runLeaderboardSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rebuilds the snapshot for every period', async () => {
+    vi.mocked(createLeaderboardSnapshot).mockImplementation(async (period) => ({
+      period,
+      entriesCreated: 3,
+    }));
+
+    const result = await runLeaderboardSnapshot();
+
+    expect(result).toEqual({ processed: 3, failed: 0 });
+    expect(createLeaderboardSnapshot).toHaveBeenCalledTimes(3);
+    expect(createLeaderboardSnapshot).toHaveBeenCalledWith('WEEKLY');
+    expect(createLeaderboardSnapshot).toHaveBeenCalledWith('MONTHLY');
+    expect(createLeaderboardSnapshot).toHaveBeenCalledWith('ALL_TIME');
+  });
+
+  it('is idempotent — running twice in a row produces the same result', async () => {
+    vi.mocked(createLeaderboardSnapshot).mockImplementation(async (period) => ({
+      period,
+      entriesCreated: 5,
+    }));
+
+    const first = await runLeaderboardSnapshot();
+    const second = await runLeaderboardSnapshot();
+
+    expect(first).toEqual(second);
+    expect(createLeaderboardSnapshot).toHaveBeenCalledTimes(6);
+  });
+
+  it('counts a period as failed without throwing, and still snapshots the rest', async () => {
+    vi.mocked(createLeaderboardSnapshot).mockImplementation(async (period) => {
+      if (period === 'MONTHLY') throw new Error('db error');
+      return { period, entriesCreated: 1 };
+    });
+
+    const result = await runLeaderboardSnapshot();
+
+    expect(result).toEqual({ processed: 2, failed: 1 });
+    expect(createLeaderboardSnapshot).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns processed: 0, failed: 3 when every period fails', async () => {
+    vi.mocked(createLeaderboardSnapshot).mockRejectedValue(new Error('db unavailable'));
+
+    const result = await runLeaderboardSnapshot();
+
+    expect(result).toEqual({ processed: 0, failed: 3 });
+  });
+});

--- a/backend/src/jobs/leaderboardSnapshot.worker.ts
+++ b/backend/src/jobs/leaderboardSnapshot.worker.ts
@@ -1,0 +1,64 @@
+import { Worker } from 'bullmq';
+import { redis } from '../db/redis.js';
+import { config } from '../config/index.js';
+import { logger } from '../common/utils/logger.js';
+import { createLeaderboardSnapshot } from '../modules/leaderboard/leaderboard.service.js';
+import type { SnapshotPeriod } from '../modules/leaderboard/leaderboard.schema.js';
+import {
+  LEADERBOARD_SNAPSHOT_QUEUE,
+  getLeaderboardSnapshotQueue,
+} from './leaderboardSnapshot.queue.js';
+import { scheduleRepeatable } from './scheduler.js';
+
+const SNAPSHOT_PERIODS: SnapshotPeriod[] = ['WEEKLY', 'MONTHLY', 'ALL_TIME'];
+
+/**
+ * Rebuilds the leaderboard snapshot for every period. Idempotent — each
+ * period's snapshot is fully replaced (delete + recreate in a single
+ * transaction) by `createLeaderboardSnapshot`, so re-running for the same
+ * window always converges to the same stored ranking. One period failing
+ * never blocks the others.
+ */
+export async function runLeaderboardSnapshot(): Promise<{ processed: number; failed: number }> {
+  let processed = 0;
+  let failed = 0;
+
+  for (const period of SNAPSHOT_PERIODS) {
+    try {
+      const result = await createLeaderboardSnapshot(period);
+      processed += 1;
+      logger.info(result, 'Leaderboard snapshot period complete');
+    } catch (err) {
+      failed += 1;
+      logger.error({ err, period }, 'Failed to snapshot leaderboard period');
+    }
+  }
+
+  logger.info({ processed, failed }, 'Leaderboard snapshot run complete');
+  return { processed, failed };
+}
+
+export function createLeaderboardSnapshotWorker(): Worker {
+  const worker = new Worker(
+    LEADERBOARD_SNAPSHOT_QUEUE,
+    async (_job) => {
+      const result = await runLeaderboardSnapshot();
+      logger.info(result, 'Leaderboard snapshot job complete');
+    },
+    { connection: redis as any },
+  );
+
+  worker.on('failed', (job, err) => {
+    logger.error({ err, jobId: job?.id }, 'Leaderboard snapshot job failed');
+  });
+
+  return worker;
+}
+
+export async function scheduleLeaderboardSnapshot(): Promise<void> {
+  await scheduleRepeatable({
+    queue: getLeaderboardSnapshotQueue(),
+    name: 'snapshot',
+    pattern: config.leaderboard.snapshotCron,
+  });
+}

--- a/backend/src/jobs/main.test.ts
+++ b/backend/src/jobs/main.test.ts
@@ -26,6 +26,7 @@ vi.mock('../config/index.js', () => ({
     credit: { recomputeCron: '0 */6 * * *' },
     analytics: { dailyCron: '5 0 * * *' },
     subscriptions: { chargeCron: '0 * * * *' },
+    leaderboard: { snapshotCron: '15 0 * * *' },
   },
 }));
 
@@ -71,7 +72,7 @@ describe('bootstrapJobs', () => {
     expect(closableNames).toContain('Redis');
   });
 
-  it('registers credit, analytics, and subscription-charge workers as closable', async () => {
+  it('registers credit, analytics, subscription-charge, and leaderboard-snapshot workers as closable', async () => {
     const { bootstrapJobs } = await import('./main.js');
     await bootstrapJobs();
 
@@ -79,12 +80,13 @@ describe('bootstrapJobs', () => {
     expect(closableNames).toContain('CreditRecomputeWorker');
     expect(closableNames).toContain('AnalyticsDailyWorker');
     expect(closableNames).toContain('SubscriptionChargeWorker');
+    expect(closableNames).toContain('LeaderboardSnapshotWorker');
   });
 
-  it('schedules credit recompute, analytics daily, and subscription-charge jobs', async () => {
+  it('schedules credit recompute, analytics daily, subscription-charge, and leaderboard-snapshot jobs', async () => {
     const { bootstrapJobs } = await import('./main.js');
     await bootstrapJobs();
 
-    expect(mockScheduleRepeatable).toHaveBeenCalledTimes(3);
+    expect(mockScheduleRepeatable).toHaveBeenCalledTimes(4);
   });
 });

--- a/backend/src/jobs/main.ts
+++ b/backend/src/jobs/main.ts
@@ -10,6 +10,8 @@ import {
   scheduleAnalyticsDaily,
   createSubscriptionChargeWorker,
   scheduleSubscriptionCharge,
+  createLeaderboardSnapshotWorker,
+  scheduleLeaderboardSnapshot,
 } from './index.js';
 
 /**
@@ -46,6 +48,15 @@ export async function bootstrapJobs(): Promise<void> {
     },
   });
   await scheduleSubscriptionCharge();
+
+  const leaderboardSnapshotWorker = createLeaderboardSnapshotWorker();
+  registerClosable({
+    name: 'LeaderboardSnapshotWorker',
+    close: async () => {
+      await leaderboardSnapshotWorker.close();
+    },
+  });
+  await scheduleLeaderboardSnapshot();
 
   logger.info('Jobs process started');
 


### PR DESCRIPTION
## Problem

`createLeaderboardSnapshot(period, now)` already exists in `modules/leaderboard/leaderboard.service.ts` — it rebuilds `LeaderboardSnapshot` rows for a period (`WEEKLY` / `MONTHLY` / `ALL_TIME`) and is already idempotent (delete + recreate inside one transaction). Nothing scheduled it though: no queue, no worker, no cron entry, so snapshots were never actually produced.

## Solution

Wires it into the existing BullMQ job pattern used by `analyticsDaily` / `creditRecompute` / `subscriptionCharge`:

- `src/jobs/leaderboardSnapshot.queue.ts` — singleton queue via `getQueue()`.
- `src/jobs/leaderboardSnapshot.worker.ts`:
  - `runLeaderboardSnapshot()` calls `createLeaderboardSnapshot` for all three periods, isolating failures per period (`{ processed, failed }`, same shape as `processDueSubscriptions`) so one bad period never blocks the others.
  - `createLeaderboardSnapshotWorker()` / `scheduleLeaderboardSnapshot()` register the BullMQ worker and a repeatable cron job.
- New `LEADERBOARD_SNAPSHOT_CRON` env var (default `15 0 * * *`, daily) added to `env.ts`, `.env.example`, and `config/index.ts`.
- Wired into `jobs/index.ts` (exports) and `jobs/main.ts` (bootstrap + graceful shutdown), matching the other three jobs exactly.
- Updated `main.test.ts`'s config mock and assertions for the 4th scheduled job / closable worker.

**Idempotency**: satisfied at the data layer — `createLeaderboardSnapshot` fully replaces a period's rows (delete + `createMany`) inside a single transaction, so re-running the job for the same period always converges to the same stored ranking regardless of how many times it fires.

## Testing

- `npx eslint` on all touched files — clean (only the same `no-explicit-any` warning every other worker already has for `redis as any`).
- `npm run typecheck` — no new errors (this branch already has 4 pre-existing errors from an unrelated parsing issue in `notifications.test.ts`, untouched here).
- `npx vitest run src/jobs` — 23/23 pass (19 existing + 4 new), including a dedicated idempotency test (running the job twice in a row produces identical output).
- `npm run test` (full suite) — 508 passed vs. 504 on the unmodified branch (+4 mine), same pre-existing DB-dependent failures, no regressions.

Closes #991