### PR TITLE
test(streaks): add unit and endpoint tests for streaks module

### DIFF
--- a/backend/src/modules/streaks/streaks.test.ts
+++ b/backend/src/modules/streaks/streaks.test.ts
@@ -1,16 +1,24 @@
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from '../../app.js';
+import { updateStreakOnTip } from './streaks.service.js';
 
-const { mockUserFindUnique, mockStreakFindUnique } = vi.hoisted(() => ({
-  mockUserFindUnique: vi.fn(),
-  mockStreakFindUnique: vi.fn(),
-}));
+const { mockUserFindUnique, mockStreakFindUnique, mockStreakCreate, mockStreakUpdate } =
+  vi.hoisted(() => ({
+    mockUserFindUnique: vi.fn(),
+    mockStreakFindUnique: vi.fn(),
+    mockStreakCreate: vi.fn(),
+    mockStreakUpdate: vi.fn(),
+  }));
 
 vi.mock('../../db/prisma.js', () => ({
   prisma: {
     user: { findUnique: mockUserFindUnique },
-    streak: { findUnique: mockStreakFindUnique },
+    streak: {
+      findUnique: mockStreakFindUnique,
+      create: mockStreakCreate,
+      update: mockStreakUpdate,
+    },
     $disconnect: vi.fn(),
   },
 }));
@@ -27,6 +35,17 @@ function mockAuth(userId = 'user-1'): void {
     sub: userId,
     stellarAddress: address,
   });
+}
+
+function getTestDates() {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const yesterday = new Date(today);
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  const twoDaysAgo = new Date(today);
+  twoDaysAgo.setUTCDate(twoDaysAgo.getUTCDate() - 2);
+
+  return { today, yesterday, twoDaysAgo };
 }
 
 describe('GET /api/v1/streaks/me', () => {
@@ -79,6 +98,176 @@ describe('GET /api/v1/streaks/me', () => {
       currentStreak: 0,
       longestStreak: 0,
       lastTipDate: null,
+    });
+  });
+
+  it('returns 400 when user does not exist in database', async () => {
+    mockAuth();
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/v1/streaks/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toBe('User not found');
+  });
+});
+
+describe('updateStreakOnTip service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a new streak record on first tip ever', async () => {
+    mockStreakFindUnique.mockResolvedValue(null);
+    mockStreakCreate.mockResolvedValue({
+      id: 'streak-new',
+      userId: 'user-1',
+      currentStreak: 1,
+      longestStreak: 1,
+      lastTipDate: new Date(),
+    });
+
+    const result = await updateStreakOnTip('user-1');
+
+    expect(mockStreakFindUnique).toHaveBeenCalledWith({ where: { userId: 'user-1' } });
+    expect(mockStreakCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        currentStreak: 1,
+        longestStreak: 1,
+        lastTipDate: expect.any(Date),
+      },
+    });
+    expect(result).toEqual({
+      currentStreak: 1,
+      longestStreak: 1,
+      streakUpdated: true,
+    });
+  });
+
+  it('returns streakUpdated: false when user has already tipped today', async () => {
+    const { today } = getTestDates();
+    mockStreakFindUnique.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 5,
+      longestStreak: 8,
+      lastTipDate: today,
+    });
+
+    const result = await updateStreakOnTip('user-1');
+
+    expect(mockStreakFindUnique).toHaveBeenCalledWith({ where: { userId: 'user-1' } });
+    expect(mockStreakUpdate).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      currentStreak: 5,
+      longestStreak: 8,
+      streakUpdated: false,
+    });
+  });
+
+  it('increments current streak and updates longest streak when user tipped yesterday (new peak)', async () => {
+    const { yesterday } = getTestDates();
+    mockStreakFindUnique.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 4,
+      longestStreak: 4,
+      lastTipDate: yesterday,
+    });
+    mockStreakUpdate.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 5,
+      longestStreak: 5,
+      lastTipDate: new Date(),
+    });
+
+    const result = await updateStreakOnTip('user-1');
+
+    expect(mockStreakUpdate).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      data: {
+        currentStreak: 5,
+        longestStreak: 5,
+        lastTipDate: expect.any(Date),
+      },
+    });
+    expect(result).toEqual({
+      currentStreak: 5,
+      longestStreak: 5,
+      streakUpdated: true,
+    });
+  });
+
+  it('increments current streak but retains longest streak when current <= longest', async () => {
+    const { yesterday } = getTestDates();
+    mockStreakFindUnique.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 3,
+      longestStreak: 10,
+      lastTipDate: yesterday,
+    });
+    mockStreakUpdate.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 4,
+      longestStreak: 10,
+      lastTipDate: new Date(),
+    });
+
+    const result = await updateStreakOnTip('user-1');
+
+    expect(mockStreakUpdate).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      data: {
+        currentStreak: 4,
+        longestStreak: 10,
+        lastTipDate: expect.any(Date),
+      },
+    });
+    expect(result).toEqual({
+      currentStreak: 4,
+      longestStreak: 10,
+      streakUpdated: true,
+    });
+  });
+
+  it('resets current streak to 1 when streak is broken (>1 day since last tip)', async () => {
+    const { twoDaysAgo } = getTestDates();
+    mockStreakFindUnique.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 7,
+      longestStreak: 12,
+      lastTipDate: twoDaysAgo,
+    });
+    mockStreakUpdate.mockResolvedValue({
+      id: 'streak-1',
+      userId: 'user-1',
+      currentStreak: 1,
+      longestStreak: 12,
+      lastTipDate: new Date(),
+    });
+
+    const result = await updateStreakOnTip('user-1');
+
+    expect(mockStreakUpdate).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      data: {
+        currentStreak: 1,
+        longestStreak: 12,
+        lastTipDate: expect.any(Date),
+      },
+    });
+    expect(result).toEqual({
+      currentStreak: 1,
+      longestStreak: 12,
+      streakUpdated: true,
     });
   });
 });


### PR DESCRIPTION
Closes #1035

## Description
Implements unit and integration test coverage for the Streaks module (`backend/src/modules/streaks/`).

### Key Changes
- **`GET /api/v1/streaks/me` Endpoint Tests**:
  - Verified `401 Unauthorized` response when requesting without authentication.
  - Verified `400 Bad Request` error response when authenticated user is not found in the database.
  - Verified `200 OK` response with active streak data when user exists and has a streak record.
  - Verified `200 OK` response with zeroed streak data (`currentStreak: 0`, `longestStreak: 0`, `lastTipDate: null`) for users without prior tips.
- **`updateStreakOnTip` Service Unit Tests**:
  - Verified creation of a new streak record on a user's first tip (`currentStreak: 1`, `longestStreak: 1`, `streakUpdated: true`).
  - Verified same-day tip returns `streakUpdated: false` without database updates.
  - Verified consecutive-day tip increments `currentStreak` and updates `longestStreak` when a new peak is reached.
  - Verified consecutive-day tip retains existing `longestStreak` when `currentStreak <= longestStreak`.
  - Verified broken streak (tip after missing >1 day) resets `currentStreak` to 1 while preserving historical `longestStreak`.

## Verification
- Ran `npx vitest run src/modules/streaks/streaks.test.ts` (9/9 tests passing).
- Ran `npx eslint "src/modules/streaks/**/*.ts"` (0 errors, 0 warnings).
